### PR TITLE
Go command variables in Makefiles

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,3 +1,10 @@
+GO=go
+GOLANGCI_LINT=golangci-lint
+GO_TEST=$(GO) test
+GO_BUILD=$(GO) build
+GO_CLEAN=$(GO) clean
+GO_MOD=$(GO) mod
+
 SOURCES=$(shell find . -type f -name "*.go" -print)
 BUILD_SHA:=$(shell git rev-parse --short HEAD 2>/dev/null || echo "0000000" )
 BUILD_VERSION:=$(shell cat ../VERSION 2>/dev/null || echo "0.0.0")
@@ -9,45 +16,45 @@ MY_BIN=scheme
 build: $(DIST_DIR)/$(MY_BIN)
 
 $(DIST_DIR)/$(MY_BIN): $(SOURCES)
-	go build -o $(DIST_DIR)/$(MY_BIN) -ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" ./cmd
+	$(GO_BUILD) -o $(DIST_DIR)/$(MY_BIN) -ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" ./cmd
 
 .PHONY: buildtest
 buildtest:
-	go test -v -c -o $(DIST_DIR)/$(MY_BIN) ./...
+	$(GO_TEST) -v -c -o $(DIST_DIR)/$(MY_BIN) ./...
 
 .PHONY: test
 test:
-	go test -v ./...
+	$(GO_TEST) -v ./...
 
 .PHONY: cover
 cover:
-	go test -cover -v ./...
+	$(GO_TEST) -cover -v ./...
 
 .PHONY: lint
 lint:
-	golangci-lint -v run
+	$(GOLANGCI_LINT) -v run
 
 .PHONY: fix
 fix:
-	golangci-lint -v run --fix
+	$(GOLANGCI_LINT) -v run --fix
 
 .PHONY: format
 format:
-	golangci-lint -v fmt
+	$(GOLANGCI_LINT) -v fmt
 
 .PHONY: tidy
 tidy:
-	go mod tidy -e -x
+	$(GO_MOD) tidy -e -x
 
 .PHONY: buildclean
 buildclean:
-	go clean -cache
+	$(GO_CLEAN) -cache
 
 .PHONY: testclean
 testclean:
-	go clean -testcache -fuzzcache
+	$(GO_CLEAN) -testcache -fuzzcache
 
 .PHONY: modclean
 modclean:
-	go clean -modcache 
+	$(GO_CLEAN) -modcache 
 


### PR DESCRIPTION
The following stanza has been added to the top of the `go/Makefile` for build tool flexibility.

```Makefile
GO=go
GOLANGCI_LINT=golangci-lint
GO_TEST=$(GO) test
GO_BUILD=$(GO) build
GO_CLEAN=$(GO) clean
GO_MOD=$(GO) mod
```

fixes #1 