### PR TITLE
fix: fixed number parsing for R7RS test compatibility.

### DIFF
--- a/go/extensions/math/prim_math.go
+++ b/go/extensions/math/prim_math.go
@@ -258,29 +258,22 @@ func PrimExpt(_ context.Context, mc *machine.MachineContext) error {
 
 		if baseInt, ok := baseNum.(*values.Integer); ok {
 			if e >= 0 {
-				result := int64(1)
-				b := baseInt.Value
-				for e > 0 {
-					if e%2 == 1 {
-						result *= b
-					}
-					b *= b
-					e /= 2
+				// Use big.Int to avoid overflow, then simplify if possible
+				baseBig := big.NewInt(baseInt.Value)
+				result := new(big.Int).Exp(baseBig, big.NewInt(e), nil)
+				// Try to fit in int64, otherwise return BigInteger
+				if result.IsInt64() {
+					mc.SetValue(values.NewInteger(result.Int64()))
+				} else {
+					mc.SetValue(values.NewBigInteger(result))
 				}
-				mc.SetValue(values.NewInteger(result))
 				return nil
 			}
-			result := int64(1)
-			b := baseInt.Value
+			// Negative exponent: compute 1 / base^|e|
 			absE := -e
-			for absE > 0 {
-				if absE%2 == 1 {
-					result *= b
-				}
-				b *= b
-				absE /= 2
-			}
-			mc.SetValue(values.NewRational(1, result))
+			baseBig := big.NewInt(baseInt.Value)
+			denom := new(big.Int).Exp(baseBig, big.NewInt(absE), nil)
+			mc.SetValue(values.NewRationalFromBigInt(big.NewInt(1), denom))
 			return nil
 		}
 

--- a/go/parser/big_number_test.go
+++ b/go/parser/big_number_test.go
@@ -173,3 +173,71 @@ func TestReadSyntaxBigIntegerInVector(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(bigInt.BigInt().Int64(), qt.Equals, int64(100))
 }
+
+// TestIntegerOverflowPromotion tests that integer literals too large for int64
+// are automatically promoted to BigInteger.
+func TestIntegerOverflowPromotion(t *testing.T) {
+	tcs := []struct {
+		input  string
+		expect string
+	}{
+		// Unsigned overflow
+		{"31622776601683793319", "31622776601683793319"},
+		{"9223372036854775808", "9223372036854775808"}, // int64 max + 1
+		{"99999999999999999999", "99999999999999999999"},
+		// Signed positive overflow
+		{"+9223372036854775808", "9223372036854775808"},
+		// Signed negative overflow
+		{"-9223372036854775809", "-9223372036854775809"}, // int64 min - 1
+		{"-99999999999999999999", "-99999999999999999999"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			c := qt.New(t)
+			env := environment.NewTopLevelEnvironmentFrame()
+			p := NewParser(env, true, strings.NewReader(tc.input))
+
+			syn, err := p.ReadSyntax(context.TODO())
+			c.Assert(err, qt.IsNil)
+
+			obj := syn.Unwrap()
+			bigInt, ok := obj.(*values.BigInteger)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("expected BigInteger, got %T", obj))
+
+			expected := new(big.Int)
+			expected.SetString(tc.expect, 10)
+			c.Assert(bigInt.BigInt().Cmp(expected), qt.Equals, 0)
+		})
+	}
+}
+
+// TestIntegerNoOverflow tests that integers within int64 range remain Integer.
+func TestIntegerNoOverflow(t *testing.T) {
+	tcs := []struct {
+		input  string
+		expect int64
+	}{
+		{"9223372036854775807", 9223372036854775807},   // int64 max
+		{"-9223372036854775808", -9223372036854775808}, // int64 min
+		{"0", 0},
+		{"12345", 12345},
+		{"-12345", -12345},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			c := qt.New(t)
+			env := environment.NewTopLevelEnvironmentFrame()
+			p := NewParser(env, true, strings.NewReader(tc.input))
+
+			syn, err := p.ReadSyntax(context.TODO())
+			c.Assert(err, qt.IsNil)
+
+			obj := syn.Unwrap()
+			intVal, ok := obj.(*values.Integer)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("expected Integer, got %T", obj))
+			c.Assert(intVal.Value, qt.Equals, tc.expect)
+		})
+	}
+}

--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math"
 	"math/big"
@@ -358,6 +359,17 @@ func (p *Parser) readQuoteForm(keyword string) (syntax.SyntaxValue, tokenizer.To
 func (p *Parser) parseIntegerWithBase(base int) (syntax.SyntaxValue, tokenizer.Token, error) {
 	a, err := strconv.ParseInt(p.cur.String(), base, 64)
 	if err != nil {
+		// If overflow, promote to BigInteger
+		var numErr *strconv.NumError
+		isNumErr := errors.As(err, &numErr)
+		if isNumErr && errors.Is(numErr.Err, strconv.ErrRange) {
+			bigInt := new(big.Int)
+			_, ok := bigInt.SetString(p.cur.String(), base)
+			if ok {
+				q := p.wrapSyntax(values.NewBigInteger(bigInt), p.cur)
+				return q, p.cur, nil
+			}
+		}
 		return nil, p.cur, err
 	}
 	q := p.wrapSyntax(values.NewInteger(a), p.cur)
@@ -623,6 +635,18 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		var a int64
 		a, p.err = strconv.ParseInt(p.cur.String(), 10, 64)
 		if p.err != nil {
+			// If overflow, promote to BigInteger
+			var numErr *strconv.NumError
+			isNumErr := errors.As(p.err, &numErr)
+			if isNumErr && errors.Is(numErr.Err, strconv.ErrRange) {
+				bigInt := new(big.Int)
+				_, ok := bigInt.SetString(p.cur.String(), 10)
+				if ok {
+					q = p.wrapSyntax(values.NewBigInteger(bigInt), p.cur)
+					p.err = nil
+					return q, p.cur, nil
+				}
+			}
 			return nil, p.cur, p.err
 		}
 		q1 := values.NewInteger(a)
@@ -642,6 +666,18 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		var a int64
 		a, p.err = strconv.ParseInt(p.cur.String(), 10, 64)
 		if p.err != nil {
+			// If overflow, promote to BigInteger
+			var numErr *strconv.NumError
+			isNumErr := errors.As(p.err, &numErr)
+			if isNumErr && errors.Is(numErr.Err, strconv.ErrRange) {
+				bigInt := new(big.Int)
+				_, ok := bigInt.SetString(p.cur.String(), 10)
+				if ok {
+					q = p.wrapSyntax(values.NewBigInteger(bigInt), p.cur)
+					p.err = nil
+					return q, p.cur, nil
+				}
+			}
 			return nil, p.cur, p.err
 		}
 		q1 := values.NewInteger(a)
@@ -681,28 +717,14 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		if p.err != nil {
 			return nil, p.cur, p.err
 		}
-		var a int64
-		a, p.err = strconv.ParseInt(p.cur.String(), 2, 64)
-		if p.err != nil {
-			return nil, p.cur, p.err
-		}
-		q1 := values.NewInteger(a)
-		q = p.wrapSyntax(q1, p.cur)
-		return q, p.cur, nil
+		return p.parseIntegerWithBase(2)
 	case tokenizer.TokenizerStateMarkerBase8:
 		// #o prefix - next token is base 8 integer
 		p.cur, p.err = p.toks.Next()
 		if p.err != nil {
 			return nil, p.cur, p.err
 		}
-		var a int64
-		a, p.err = strconv.ParseInt(p.cur.String(), 8, 64)
-		if p.err != nil {
-			return nil, p.cur, p.err
-		}
-		q1 := values.NewInteger(a)
-		q = p.wrapSyntax(q1, p.cur)
-		return q, p.cur, nil
+		return p.parseIntegerWithBase(8)
 	case tokenizer.TokenizerStateMarkerBase10:
 		// #d prefix - next token is base 10 integer
 		p.cur, p.err = p.toks.Next()


### PR DESCRIPTION
  1. extensions/math/prim_math.go - Fixed expt integer overflow
    - Uses big.Int.Exp() instead of manual loop to avoid overflow
    - Returns Integer if result fits in int64, otherwise BigInteger
    - Negative exponents also use big.Int for the denominator
  2. parser/parser.go - Fixed large integer literal parsing
    - Added overflow detection using errors.As and strconv.ErrRange
    - On overflow, parses with big.Int.SetString() and returns BigInteger
    - Applied to: unsigned integers, signed integers, and parseIntegerWithBase helper
    - Refactored MarkerBase2 and MarkerBase8 to use parseIntegerWithBase (DRY)
  3. parser/big_number_test.go - Added regression tests
    - TestIntegerOverflowPromotion - verifies overflow promotion works
    - TestIntegerNoOverflow - verifies int64-range integers stay as Integer