### PR TITLE
fix: scientific notation parsing for bare integers

### DIFF
--- a/go/parser/big_number_test.go
+++ b/go/parser/big_number_test.go
@@ -16,12 +16,15 @@ package parser
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"strings"
 	"testing"
 
 	"wile/environment"
 	"wile/values"
+
+	"github.com/google/go-cmp/cmp"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -238,6 +241,112 @@ func TestIntegerNoOverflow(t *testing.T) {
 			intVal, ok := obj.(*values.Integer)
 			c.Assert(ok, qt.IsTrue, qt.Commentf("expected Integer, got %T", obj))
 			c.Assert(intVal.Value, qt.Equals, tc.expect)
+		})
+	}
+}
+
+// TestScientificNotationToInteger tests that scientific notation with positive exponents
+// or negative exponents with sufficient trailing zeros yields integers.
+func TestScientificNotationToInteger(t *testing.T) {
+	tcs := []struct {
+		input  string
+		expect int64
+	}{
+		// Positive exponents - always integer
+		{"1e10", 10000000000},
+		{"2e5", 200000},
+		{"+3e2", 300},
+		{"-4e3", -4000},
+		{"1e0", 1},
+		// Negative exponents with sufficient trailing zeros
+		{"100000e-4", 10},      // 5 trailing zeros >= 4
+		{"100000e-5", 1},       // 5 trailing zeros >= 5
+		{"1000e-3", 1},         // 3 trailing zeros >= 3
+		{"-2000e-2", -20},      // 3 trailing zeros >= 2
+		{"+50000e-4", 5},       // 4 trailing zeros >= 4
+		{"10e-1", 1},           // 1 trailing zero >= 1
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			c := qt.New(t)
+			env := environment.NewTopLevelEnvironmentFrame()
+			p := NewParser(env, true, strings.NewReader(tc.input))
+
+			syn, err := p.ReadSyntax(context.TODO())
+			c.Assert(err, qt.IsNil)
+
+			obj := syn.Unwrap()
+			intVal, ok := obj.(*values.Integer)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("expected Integer, got %T: %v", obj, obj))
+			c.Assert(intVal.Value, qt.Equals, tc.expect)
+		})
+	}
+}
+
+// TestScientificNotationToFloat tests that scientific notation with negative exponents
+// and insufficient trailing zeros yields floats.
+func TestScientificNotationToFloat(t *testing.T) {
+	tcs := []struct {
+		input  string
+		expect float64
+	}{
+		// Negative exponents without sufficient trailing zeros
+		{"1e-10", 1e-10},
+		{"10e-4", 0.001},       // 1 trailing zero < 4
+		{"123e-5", 0.00123},    // 0 trailing zeros < 5
+		{"+5e-2", 0.05},        // 0 trailing zeros < 2
+		{"-7e-3", -0.007},      // 0 trailing zeros < 3
+		{"100e-4", 0.01},       // 2 trailing zeros < 4
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			c := qt.New(t)
+			env := environment.NewTopLevelEnvironmentFrame()
+			p := NewParser(env, true, strings.NewReader(tc.input))
+
+			syn, err := p.ReadSyntax(context.TODO())
+			c.Assert(err, qt.IsNil)
+
+			obj := syn.Unwrap()
+			floatVal, ok := obj.(*values.Float)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("expected Float, got %T: %v", obj, obj))
+			c.Assert(floatVal.Value, qt.CmpEquals(cmp.Comparer(func(a, b float64) bool {
+				return math.Abs(a-b) < 1e-15
+			})), tc.expect)
+		})
+	}
+}
+
+// TestScientificNotationToBigInteger tests that large scientific notation results
+// are promoted to BigInteger.
+func TestScientificNotationToBigInteger(t *testing.T) {
+	tcs := []struct {
+		input  string
+		expect string
+	}{
+		{"1e20", "100000000000000000000"},
+		{"1e19", "10000000000000000000"}, // Just over int64 max (~9.2e18)
+		{"-5e19", "-50000000000000000000"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.input, func(t *testing.T) {
+			c := qt.New(t)
+			env := environment.NewTopLevelEnvironmentFrame()
+			p := NewParser(env, true, strings.NewReader(tc.input))
+
+			syn, err := p.ReadSyntax(context.TODO())
+			c.Assert(err, qt.IsNil)
+
+			obj := syn.Unwrap()
+			bigInt, ok := obj.(*values.BigInteger)
+			c.Assert(ok, qt.IsTrue, qt.Commentf("expected BigInteger, got %T: %v", obj, obj))
+
+			expected := new(big.Int)
+			expected.SetString(tc.expect, 10)
+			c.Assert(bigInt.BigInt().Cmp(expected), qt.Equals, 0)
 		})
 	}
 }

--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -389,6 +389,97 @@ func (p *Parser) parseBigIntegerWithBase(base int) (syntax.SyntaxValue, tokenize
 	return q, p.cur, nil
 }
 
+// parseScientificNotation parses a number in scientific notation (e.g., "1e10", "+2e-5").
+// Returns an integer if the result is a whole number, otherwise a float.
+// For positive exponents: always integer (may promote to BigInteger).
+// For negative exponents: integer if mantissa has enough trailing zeros, otherwise float.
+func (p *Parser) parseScientificNotation() (syntax.SyntaxValue, tokenizer.Token, error) {
+	s := p.cur.String()
+
+	// Find the exponent marker (e or E)
+	expIdx := strings.IndexAny(s, "eEsSfFdDlL")
+	if expIdx == -1 {
+		return nil, p.cur, NewParserErrorf(p.cur, "invalid scientific notation: %s", s)
+	}
+
+	mantissaStr := s[:expIdx]
+	expStr := s[expIdx+1:]
+
+	// Parse exponent
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return nil, p.cur, NewParserErrorf(p.cur, "invalid exponent in scientific notation: %s", s)
+	}
+
+	// Parse mantissa as big.Int (strip sign for trailing zero counting)
+	mantissaStrNoSign := strings.TrimLeft(mantissaStr, "+-")
+	mantissa := new(big.Int)
+	_, ok := mantissa.SetString(mantissaStrNoSign, 10)
+	if !ok {
+		return nil, p.cur, NewParserErrorf(p.cur, "invalid mantissa in scientific notation: %s", s)
+	}
+
+	// Check sign
+	negative := strings.HasPrefix(mantissaStr, "-")
+
+	if exp >= 0 {
+		// Positive exponent: result is mantissa * 10^exp (always integer)
+		multiplier := new(big.Int).Exp(big.NewInt(10), big.NewInt(exp), nil)
+		result := new(big.Int).Mul(mantissa, multiplier)
+		if negative {
+			result.Neg(result)
+		}
+		// Try to fit in int64
+		if result.IsInt64() {
+			q := p.wrapSyntax(values.NewInteger(result.Int64()), p.cur)
+			return q, p.cur, nil
+		}
+		q := p.wrapSyntax(values.NewBigInteger(result), p.cur)
+		return q, p.cur, nil
+	}
+
+	// Negative exponent: check if mantissa has enough trailing zeros
+	trailingZeros := countTrailingZeros(mantissaStrNoSign)
+	absExp := -exp
+
+	if int64(trailingZeros) >= absExp {
+		// Result is integer: mantissa / 10^|exp|
+		divisor := new(big.Int).Exp(big.NewInt(10), big.NewInt(absExp), nil)
+		result := new(big.Int).Div(mantissa, divisor)
+		if negative {
+			result.Neg(result)
+		}
+		// Try to fit in int64
+		if result.IsInt64() {
+			q := p.wrapSyntax(values.NewInteger(result.Int64()), p.cur)
+			return q, p.cur, nil
+		}
+		q := p.wrapSyntax(values.NewBigInteger(result), p.cur)
+		return q, p.cur, nil
+	}
+
+	// Result is float
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, p.cur, NewParserErrorf(p.cur, "invalid scientific notation: %s", s)
+	}
+	q := p.wrapSyntax(values.NewFloat(f), p.cur)
+	return q, p.cur, nil
+}
+
+// countTrailingZeros counts the number of trailing zeros in a numeric string.
+func countTrailingZeros(s string) int {
+	count := 0
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == '0' {
+			count++
+		} else {
+			break
+		}
+	}
+	return count
+}
+
 func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 	var q syntax.SyntaxValue
 	cur := p.curr()
@@ -693,6 +784,11 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		q1 := values.NewFloat(a)
 		q = p.wrapSyntax(q1, p.cur)
 		return q, p.cur, nil
+	case tokenizer.TokenizerStateSignedScientificNotation,
+		tokenizer.TokenizerStateUnsignedScientificNotation:
+		// Scientific notation like "1e10", "+2e-5", "100000e-4"
+		// Parser determines if result is integer or float
+		return p.parseScientificNotation()
 	case tokenizer.TokenizerStateUnsignedRationalFraction:
 		// Unsigned rational fractions like "3/4"
 		var q1 *values.Rational

--- a/go/tokenizer/edge_cases_test.go
+++ b/go/tokenizer/edge_cases_test.go
@@ -461,13 +461,14 @@ func TestCombinedRadixExactness(t *testing.T) {
 func TestKnownBugs(t *testing.T) {
 	t.Run("signed_integer_with_exponent_now_works", func(t *testing.T) {
 		// Previously documented as bug: +1e10 tokenized as two tokens
-		// This has been FIXED - now tokenizes correctly as single decimal fraction
+		// This has been FIXED - now tokenizes correctly as scientific notation
+		// Parser will determine if result is integer or float based on exponent
 		c := qt.New(t)
 		p := NewTokenizer(strings.NewReader("+1e10"), false)
 
 		tok, err := p.Next()
 		c.Assert(err, qt.IsNil)
-		c.Check(tok.Type(), qt.Equals, TokenizerStateSignedInteger)
+		c.Check(tok.Type(), qt.Equals, TokenizerStateSignedScientificNotation)
 		c.Check(tok.(*SimpleToken).src, qt.Equals, "+1e10")
 
 		// Verify no second token

--- a/go/tokenizer/final_coverage_test.go
+++ b/go/tokenizer/final_coverage_test.go
@@ -97,9 +97,9 @@ func TestTokenizer_UnsignedFractionalEdgeCases(t *testing.T) {
 		// Integer followed by decimal
 		{"+10.5", TokenizerStateSignedDecimalFraction},
 		{"-10.5", TokenizerStateSignedDecimalFraction},
-		// Integer with exponent
-		{"+10e5", TokenizerStateSignedInteger},
-		{"-10e-5", TokenizerStateSignedInteger},
+		// Integer with exponent (scientific notation - parser determines int vs float)
+		{"+10e5", TokenizerStateSignedScientificNotation},
+		{"-10e-5", TokenizerStateSignedScientificNotation},
 		// Rational fractions
 		{"+3/4", TokenizerStateSignedRationalFraction},
 		{"-3/4", TokenizerStateSignedRationalFraction},
@@ -668,9 +668,9 @@ func TestTokenizer_Vectors(t *testing.T) {
 // Test mayUnsignedFractional with exponents
 func TestTokenizer_MayUnsignedExponentBranches(t *testing.T) {
 	tests := []tokenizerTestCase{
-		// Integer with exponent branches
-		{"+10e5", TokenizerStateSignedInteger},
-		{"-10e5", TokenizerStateSignedInteger},
+		// Integer with exponent branches (scientific notation - parser determines int vs float)
+		{"+10e5", TokenizerStateSignedScientificNotation},
+		{"-10e5", TokenizerStateSignedScientificNotation},
 		// Decimal with exponent
 		{"+10.5e5", TokenizerStateSignedDecimalFraction},
 		{"-10.5e5", TokenizerStateSignedDecimalFraction},

--- a/go/tokenizer/tokenizer.go
+++ b/go/tokenizer/tokenizer.go
@@ -217,6 +217,13 @@ const (
 	// TokenizerStateUnsignedDecimalFraction represents 1.23 or 4.56.
 	TokenizerStateUnsignedDecimalFraction
 
+	// TokenizerStateSignedScientificNotation represents integers with exponents like +1e10, -2e-5.
+	// Parser determines if result is integer or float based on exponent sign and mantissa.
+	TokenizerStateSignedScientificNotation
+	// TokenizerStateUnsignedScientificNotation represents integers with exponents like 1e10, 2e-5.
+	// Parser determines if result is integer or float based on exponent sign and mantissa.
+	TokenizerStateUnsignedScientificNotation
+
 	// TokenizerStateEmptyList represents () (empty list).
 	TokenizerStateEmptyList
 	// TokenizerStateOpenParen represents ( (open parenthesis).
@@ -1323,9 +1330,9 @@ func (p *Tokenizer) readIntegerAndFraction(signed bool, r int) {
 		p.readDiv(r) //nolint:errcheck
 	case isExtendedExponentMarkerForRadix(p.curr()):
 		if signed {
-			p.state = TokenizerStateSignedInteger
+			p.state = TokenizerStateSignedScientificNotation
 		} else {
-			p.state = TokenizerStateUnsignedInteger
+			p.state = TokenizerStateUnsignedScientificNotation
 		}
 		p.mayReadExponent(r) //nolint:errcheck
 	}

--- a/go/tokenizer/tokenizer_test.go
+++ b/go/tokenizer/tokenizer_test.go
@@ -378,35 +378,35 @@ func TestTokenizer_TokenStream(t *testing.T) {
 			tokens: []TokenizerState{TokenizerStateUnsignedDecimalFraction},
 			err:    io.EOF,
 		},
-		// R7RS conformance: signed integers with exponents
+		// R7RS conformance: signed integers with exponents (scientific notation)
 		{
 			in:     "+1e10",
 			src:    []string{"+1e10"},
-			tokens: []TokenizerState{TokenizerStateSignedInteger},
+			tokens: []TokenizerState{TokenizerStateSignedScientificNotation},
 			err:    io.EOF,
 		},
 		{
 			in:     "-1e10",
 			src:    []string{"-1e10"},
-			tokens: []TokenizerState{TokenizerStateSignedInteger},
+			tokens: []TokenizerState{TokenizerStateSignedScientificNotation},
 			err:    io.EOF,
 		},
 		{
 			in:     "+1E10",
 			src:    []string{"+1E10"},
-			tokens: []TokenizerState{TokenizerStateSignedInteger},
+			tokens: []TokenizerState{TokenizerStateSignedScientificNotation},
 			err:    io.EOF,
 		},
 		{
 			in:     "-1e+10",
 			src:    []string{"-1e+10"},
-			tokens: []TokenizerState{TokenizerStateSignedInteger},
+			tokens: []TokenizerState{TokenizerStateSignedScientificNotation},
 			err:    io.EOF,
 		},
 		{
 			in:     "+1e-10",
 			src:    []string{"+1e-10"},
-			tokens: []TokenizerState{TokenizerStateSignedInteger},
+			tokens: []TokenizerState{TokenizerStateSignedScientificNotation},
 			err:    io.EOF,
 		},
 		// R7RS conformance: trailing dot with exponent
@@ -1145,19 +1145,19 @@ func TestTokenizer_read(t *testing.T) {
 			bs:    "34e10",
 			scan:  "34e10",
 			err0:  io.EOF,
-			state: TokenizerStateUnsignedInteger,
+			state: TokenizerStateUnsignedScientificNotation,
 		},
 		{
 			bs:    "-34e10",
 			scan:  "-34e10",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    "+34e10",
 			scan:  "+34e10",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    ".34e10",
@@ -1181,7 +1181,7 @@ func TestTokenizer_read(t *testing.T) {
 			bs:    "34e+10",
 			scan:  "34e+10",
 			err0:  io.EOF,
-			state: TokenizerStateUnsignedInteger,
+			state: TokenizerStateUnsignedScientificNotation,
 		},
 		{
 			bs:    ".34e+10",
@@ -1537,48 +1537,48 @@ func TestTokenizer_read(t *testing.T) {
 			err0:  io.EOF,
 			state: TokenizerStateSignedImaginary,
 		},
-		// Exponents edge cases
+		// Exponents edge cases (scientific notation - parser determines int vs float)
 		{
 			bs:    "1e0",
 			scan:  "1e0",
 			err0:  io.EOF,
-			state: TokenizerStateUnsignedInteger,
+			state: TokenizerStateUnsignedScientificNotation,
 		},
 		{
 			bs:    "1e-0",
 			scan:  "1e-0",
 			err0:  io.EOF,
-			state: TokenizerStateUnsignedInteger,
+			state: TokenizerStateUnsignedScientificNotation,
 		},
 		{
 			bs:    "1e+0",
 			scan:  "1e+0",
 			err0:  io.EOF,
-			state: TokenizerStateUnsignedInteger,
+			state: TokenizerStateUnsignedScientificNotation,
 		},
 		{
 			bs:    "-1e-0",
 			scan:  "-1e-0",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    "-1e+0",
 			scan:  "-1e+0",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    "+1e-0",
 			scan:  "+1e-0",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    "+1e+0",
 			scan:  "+1e+0",
 			err0:  io.EOF,
-			state: TokenizerStateSignedInteger,
+			state: TokenizerStateSignedScientificNotation,
 		},
 		{
 			bs:    ".5e0",


### PR DESCRIPTION
## Summary

- Add proper handling for scientific notation numbers without decimal points (e.g., `1e10`, `1e-10`)
- Previously these failed to parse because the tokenizer emitted them as integers but the parser couldn't handle the exponent notation
- Parser now determines result type based on exponent sign and mantissa trailing zeros

## Changes

**Tokenizer:**
- Add `TokenizerStateSignedScientificNotation` and `TokenizerStateUnsignedScientificNotation` token types
- Emit scientific notation tokens when exponent marker found on integers (no decimal point)

**Parser:**
- Add `parseScientificNotation()` helper that determines integer vs float:
  - Positive exponent → always integer (promotes to BigInteger if overflow)
  - Negative exponent → integer if mantissa has enough trailing zeros, otherwise float

## Examples

| Input | Result | Type |
|-------|--------|------|
| `1e10` | 10000000000 | Integer |
| `1e-10` | 0.0000000001 | Float |
| `100000e-4` | 10 | Integer (5 trailing zeros ≥ 4) |
| `10e-4` | 0.001 | Float (1 trailing zero < 4) |
| `1e20` | 100000000000000000000 | BigInteger |

## Test plan

- [x] `TestScientificNotationToInteger` - positive exponents and negative with sufficient trailing zeros
- [x] `TestScientificNotationToFloat` - negative exponents with insufficient trailing zeros
- [x] `TestScientificNotationToBigInteger` - large results promote to BigInteger
- [x] All existing tokenizer and parser tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)