### PR TITLE
fix: recover division-by-zero panics at VM boundary

### DIFF
--- a/go/machine/operation_foreign_function_call.go
+++ b/go/machine/operation_foreign_function_call.go
@@ -34,10 +34,50 @@ func NewOperationForeignFunctionCall(ffn ForeignFunction) *OperationForeignFunct
 	}
 }
 
-func (p *OperationForeignFunctionCall) Apply(ctx context.Context, mc *MachineContext) (*MachineContext, error) {
+// goErrorToSchemeException converts a Go error to a Scheme exception escape.
+// It detects ForeignFileError and ForeignReadError to set the appropriate
+// NativeError kind per R7RS §6.11.
+func goErrorToSchemeException(err error) error {
+	kind := values.NativeErrorKindGeneric
+	var fileErr *values.ForeignFileError
+	var readErr *values.ForeignReadError
+	if errors.As(err, &fileErr) {
+		kind = values.NativeErrorKindFile
+	} else if errors.As(err, &readErr) {
+		kind = values.NativeErrorKindRead
+	}
+	errObj := values.NewErrorObjectWithCauseAndKind(err.Error(), err, kind)
+	return &ErrExceptionEscape{
+		Condition:   errObj,
+		Continuable: false,
+		Handled:     false,
+	}
+}
+
+func (p *OperationForeignFunctionCall) Apply(ctx context.Context, mc *MachineContext) (rmc *MachineContext, rerr error) {
 	if p.Function == nil {
 		return nil, fmt.Errorf("foreign function is nil")
 	}
+	// Recover panics from the values package (e.g., ErrDivisionByZero, ErrNotANumber,
+	// ErrNotAList) and convert them to Scheme exceptions. The Number interface methods
+	// signal these conditions via panic because the interface returns Number, not
+	// (Number, error). Recovered panics are always plain Go errors, never continuation
+	// escapes or prompt aborts, so they go directly through error-to-exception conversion.
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		var err error
+		switch v := r.(type) {
+		case error:
+			err = v
+		default:
+			err = fmt.Errorf("%v", v)
+		}
+		rmc = nil
+		rerr = goErrorToSchemeException(err)
+	}()
 	err := p.Function(ctx, mc)
 	if err != nil {
 		// Check if this is a continuation escape.
@@ -69,20 +109,7 @@ func (p *OperationForeignFunctionCall) Apply(ctx context.Context, mc *MachineCon
 		// Convert Go error to Scheme exception so guard/with-exception-handler can catch it.
 		// Create an error object that wraps the original Go error for debugging.
 		// Use errors.As to detect ForeignFileError/ForeignReadError and set the appropriate kind.
-		kind := values.NativeErrorKindGeneric
-		var fileErr *values.ForeignFileError
-		var readErr *values.ForeignReadError
-		if errors.As(err, &fileErr) {
-			kind = values.NativeErrorKindFile
-		} else if errors.As(err, &readErr) {
-			kind = values.NativeErrorKindRead
-		}
-		errObj := values.NewErrorObjectWithCauseAndKind(err.Error(), err, kind)
-		return nil, &ErrExceptionEscape{
-			Condition:   errObj,
-			Continuable: false,
-			Handled:     false,
-		}
+		return nil, goErrorToSchemeException(err)
 	}
 	mc.pc++
 	return mc, nil

--- a/go/registry/core/prim_arithmetic_test.go
+++ b/go/registry/core/prim_arithmetic_test.go
@@ -1171,3 +1171,58 @@ func TestLcm_Errors(t *testing.T) {
 		runSchemeCodeExpectError(t, `(lcm 4 #t)`)
 	})
 }
+
+// TestDivisionByZero_SchemeException verifies that division by zero across all
+// numeric types is caught at the VM boundary and converted to a proper Scheme
+// exception that guard can handle. This tests the recover in
+// OperationForeignFunctionCall.Apply, not just the values package panic.
+func TestDivisionByZero_SchemeException(t *testing.T) {
+	c := qt.New(t)
+	tcs := []schemeCodeTestCase{
+		// Integer / 0
+		{"integer div zero caught by guard",
+			`(guard (exn (#t "caught")) (/ 1 0))`,
+			values.NewString("caught")},
+		// BigInteger / 0 (Issue #22)
+		{"biginteger div zero caught by guard",
+			`(guard (exn (#t "caught")) (/ (expt 2 100) 0))`,
+			values.NewString("caught")},
+		// Float / 0
+		{"float div zero caught by guard",
+			`(guard (exn (#t "caught")) (/ 1.5 0))`,
+			values.NewString("caught")},
+		// Rational / 0
+		{"rational div zero caught by guard",
+			`(guard (exn (#t "caught")) (/ 1/3 0))`,
+			values.NewString("caught")},
+		// Complex / 0
+		{"complex div zero caught by guard",
+			`(guard (exn (#t "caught")) (/ 1+2i 0))`,
+			values.NewString("caught")},
+	}
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			result, err := runSchemeCode(t, tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+// TestDivisionByZero_ReturnsError verifies that division by zero returns an
+// error through the VM rather than panicking.
+func TestDivisionByZero_ReturnsError(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{"integer / 0", `(/ 1 0)`},
+		{"biginteger / 0", `(/ (expt 2 100) 0)`},
+		{"float / 0", `(/ 1.5 0)`},
+		{"rational / 0", `(/ 1/3 0)`},
+		{"complex / 0", `(/ 1+2i 0)`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNotNil)
+		})
+	}
+}

--- a/go/values/values.go
+++ b/go/values/values.go
@@ -198,6 +198,21 @@ type Comparable interface {
 //
 // R7RS §6.2.1: Numbers form a tower: number ⊃ complex ⊃ real ⊃ rational ⊃ integer.
 // All numeric types implement this interface for uniform arithmetic operations.
+//
+// # Error signaling
+//
+// Arithmetic methods signal errors by panicking with a static sentinel error
+// (e.g., ErrDivisionByZero, ErrNotANumber). This follows the same convention
+// used by Go's math/big package, where (*big.Int).Div, (*big.Int).QuoRem,
+// and (*big.Float).Quo all panic on division by zero, and mirrors Go's own
+// runtime behavior for built-in integer division.
+//
+// The panic convention is a deliberate design choice: arithmetic methods return
+// Number (not (Number, error)), keeping the interface algebraic and composable.
+// Callers that need error values should recover panics at their boundary.
+// The VM does this in OperationForeignFunctionCall.Apply, which recovers panics
+// and converts them to Scheme exceptions catchable by guard and
+// with-exception-handler.
 type Number interface {
 	Value
 	Add(Number) Number


### PR DESCRIPTION
## Summary

- Add `recover()` in `OperationForeignFunctionCall.Apply` to catch panics from the values package (division by zero, not-a-number, not-a-list) and convert them to Scheme exceptions
- Extract `goErrorToSchemeException` helper to deduplicate error-to-exception conversion
- Document the Number interface error signaling convention (panic, following Go's `math/big` convention)
- Add tests verifying `guard` can catch division-by-zero across all numeric types

Closes #22

## Test plan

- [x] `TestDivisionByZero_SchemeException` — `guard` catches divide-by-zero for Integer, BigInteger, Float, Rational, Complex
- [x] `TestDivisionByZero_ReturnsError` — `(/ x 0)` returns error (not panic) for all numeric types
- [x] Full test suite passes
- [x] Linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)