### PR TITLE
fix: propagate auxiliary syntax exports to compile phase

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -79,11 +79,7 @@ Code Cleanup
 ---
 
 ### Auxiliary Syntax Exports
-- [ ] **Issue:** R7RS requires `(scheme base)` to export `else`, `=>`, `...`, `_` as auxiliary syntax
-- [ ] **Current State:** These are registered as compile-time bindings in `specialforms.go` (lines 44-51)
-- [ ] **Problem:** Export mechanism expects runtime `values.Value` objects; these are pattern literals
-- [ ] **Required:** Implement auxiliary syntax binding mechanism that allows library exports of non-value bindings
-- [ ] **Note:** Pattern matching for `else` and `=>` in `cond`/`case` works correctly; only export is broken
+- [x] **Resolved:** `CopyLibraryBindingsToEnvAtPhase` now propagates compile-phase bindings (auxiliary syntax) to the compile phase of the target environment for defense-in-depth. Auxiliary syntax (`else`, `=>`, `...`, `_`) is copied to both runtime phase 0 and compile phase (targetPhase+2).
 
 ---
 
@@ -446,7 +442,7 @@ Library Status
 
 | Library               | Status | Notes |
 |-----------------------|--------|-------|
-| scheme/base           | ~95%   | Missing: auxiliary syntax export mechanism |
+| scheme/base           | ~98%   | Auxiliary syntax exports resolved |
 | scheme/char           | 100%   | |
 | scheme/file           | 100%   | |
 | scheme/write          | 100%   | |

--- a/go/machine/library.go
+++ b/go/machine/library.go
@@ -313,29 +313,36 @@ func CopyLibraryBindingsToEnv(lib *CompiledLibrary, bindings map[string]string, 
 //   - targetPhase < 0: For-template import. Bindings shifted to negative phase
 //     (used for generating code that will run at a lower phase).
 func CopyLibraryBindingsToEnvAtPhase(lib *CompiledLibrary, bindings map[string]string, targetEnv *environment.EnvironmentFrame, targetPhase int) error {
+	// Source environments to search for exported bindings, in priority order.
+	// Phase 0 (runtime) holds variables, phase 1 (expand) holds syntax bindings
+	// from define-syntax, phase 2 (compile) holds auxiliary syntax (else, =>, ..., _).
+	sourceEnvs := []struct {
+		env   *environment.EnvironmentFrame
+		phase int
+	}{
+		{lib.Env, environment.PhaseRuntime},
+		{lib.Env.Expand(), environment.PhaseExpand},
+		{lib.Env.Compile(), environment.PhaseCompile},
+	}
+
 	for localName, externalName := range bindings {
 		internalName := lib.GetInternalName(externalName)
 		if internalName == "" {
 			internalName = externalName
 		}
 
-		// Get the binding from the library's environment
-		// First check the runtime environment, then the expand environment for syntax bindings,
-		// then the compile environment for auxiliary syntax (else, =>)
+		// Search source environments in phase order for the binding.
 		libSym := lib.Env.InternSymbol(values.NewSymbol(internalName))
-		libBinding := lib.Env.GetBinding(libSym)
-		if libBinding == nil {
-			// Syntax bindings (define-syntax) are stored in the expand environment
-			expandEnv := lib.Env.Expand()
-			if expandEnv != nil {
-				libBinding = expandEnv.GetBinding(libSym)
+		var libBinding *environment.Binding
+		sourcePhase := 0
+		for _, src := range sourceEnvs {
+			if src.env == nil {
+				continue
 			}
-		}
-		if libBinding == nil {
-			// Auxiliary syntax (else, =>) are stored in the compile environment
-			compileEnv := lib.Env.Compile()
-			if compileEnv != nil {
-				libBinding = compileEnv.GetBinding(libSym)
+			libBinding = src.env.GetBinding(libSym)
+			if libBinding != nil {
+				sourcePhase = src.phase
+				break
 			}
 		}
 		if libBinding == nil {
@@ -343,11 +350,9 @@ func CopyLibraryBindingsToEnvAtPhase(lib *CompiledLibrary, bindings map[string]s
 				lib.Name.SchemeString(), internalName)
 		}
 
-		// Get the target environment at the specified phase
+		// Create binding in the target at the base phase.
 		phaseEnv := targetEnv.AtPhase(targetPhase)
 		localSym := phaseEnv.InternSymbol(values.NewSymbol(localName))
-
-		// Create binding in the target phase environment
 		_, _ = phaseEnv.MaybeCreateOwnGlobalBinding(localSym, libBinding.BindingType())
 		globalIdx := phaseEnv.GetGlobalIndex(localSym)
 		if globalIdx != nil {
@@ -357,15 +362,17 @@ func CopyLibraryBindingsToEnvAtPhase(lib *CompiledLibrary, bindings map[string]s
 			}
 		}
 
-		// If it's a syntax binding, also copy to the next phase up (for expansion)
-		// This ensures macros are available during expansion at targetPhase+1
-		if libBinding.BindingType() == environment.BindingTypeSyntax {
-			expandPhaseEnv := targetEnv.AtPhase(targetPhase + 1)
-			expandLocalSym := expandPhaseEnv.InternSymbol(values.NewSymbol(localName))
-			_, _ = expandPhaseEnv.MaybeCreateOwnGlobalBinding(expandLocalSym, environment.BindingTypeSyntax)
-			expandIdx := expandPhaseEnv.GetGlobalIndex(expandLocalSym)
-			if expandIdx != nil {
-				_ = expandPhaseEnv.SetOwnGlobalValue(expandIdx, libBinding.Value())
+		// Propagate to the source phase in the target so the binding is available
+		// in the same phase it originated from. Syntax bindings (phase 1) need to
+		// be in the expand phase for macro expansion; compile-phase bindings
+		// (auxiliary syntax, phase 2) need to be in the compile phase.
+		if sourcePhase > 0 {
+			propagateEnv := targetEnv.AtPhase(targetPhase + sourcePhase)
+			propagateSym := propagateEnv.InternSymbol(values.NewSymbol(localName))
+			_, _ = propagateEnv.MaybeCreateOwnGlobalBinding(propagateSym, libBinding.BindingType())
+			propagateIdx := propagateEnv.GetGlobalIndex(propagateSym)
+			if propagateIdx != nil {
+				_ = propagateEnv.SetOwnGlobalValue(propagateIdx, libBinding.Value())
 			}
 		}
 	}

--- a/go/machine/library_test.go
+++ b/go/machine/library_test.go
@@ -670,6 +670,52 @@ func TestLibraryRegistryRegisterAndLookupAdditional(t *testing.T) {
 	qt.Assert(t, notFound, qt.IsNil)
 }
 
+// TestCopyLibraryBindingsToEnv_CompilePhase verifies that compile-phase bindings
+// (auxiliary syntax like else, =>) are propagated to both the runtime phase and
+// the compile phase of the target environment.
+func TestCopyLibraryBindingsToEnv_CompilePhase(t *testing.T) {
+	c := qt.New(t)
+
+	// Create source library with a compile-phase binding (auxiliary syntax)
+	srcEnv := environment.NewTopLevelEnvironment().Runtime()
+	libName := machine.NewLibraryName("test", "auxlib")
+	lib := machine.NewCompiledLibrary(libName, srcEnv)
+
+	// Register "else" in the compile environment (phase 2), mimicking
+	// how specialforms.go registers auxiliary syntax
+	elseSym := srcEnv.InternSymbol(values.NewSymbol("else"))
+	compileEnv := srcEnv.Compile()
+	_, _ = compileEnv.MaybeCreateOwnGlobalBinding(elseSym, environment.BindingTypeVariable)
+	elseIdx := compileEnv.GetGlobalIndex(elseSym)
+	mockValue := values.NewSymbol("else-marker")
+	_ = compileEnv.SetOwnGlobalValue(elseIdx, mockValue)
+	lib.AddExport("else", "")
+
+	// Create target environment
+	targetEnv := environment.NewTopLevelEnvironment().Runtime()
+
+	bindings := map[string]string{
+		"else": "else",
+	}
+
+	// Copy bindings
+	err := machine.CopyLibraryBindingsToEnv(lib, bindings, targetEnv)
+	c.Assert(err, qt.IsNil)
+
+	// Verify binding is present in runtime phase (phase 0)
+	elseTarget := targetEnv.InternSymbol(values.NewSymbol("else"))
+	runtimeBinding := targetEnv.GetBinding(elseTarget)
+	c.Assert(runtimeBinding, qt.IsNotNil, qt.Commentf("else should be in runtime phase"))
+	c.Assert(runtimeBinding.Value(), values.SchemeEquals, mockValue)
+
+	// Verify binding is also present in compile phase (phase 2)
+	targetCompileEnv := targetEnv.AtPhase(2)
+	elseCompileSym := targetCompileEnv.InternSymbol(values.NewSymbol("else"))
+	compileBinding := targetCompileEnv.GetBinding(elseCompileSym)
+	c.Assert(compileBinding, qt.IsNotNil, qt.Commentf("else should be propagated to compile phase"))
+	c.Assert(compileBinding.Value(), values.SchemeEquals, mockValue)
+}
+
 // TestLibraryForwardReferences tests that library bodies support forward references
 // per R7RS §5.3.2: Internal definitions use letrec* semantics.
 //

--- a/go/registry/core/prim_auxiliary_syntax_test.go
+++ b/go/registry/core/prim_auxiliary_syntax_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/go/registry/testhelpers"
+	"github.com/aalpar/wile/go/values"
+)
+
+// TestAuxiliarySyntax_CondElse verifies that auxiliary syntax `else` works
+// correctly in `cond` forms after importing (scheme base).
+func TestAuxiliarySyntax_CondElse(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := testhelpers.RunSchemeCode(t, "(cond (else 42))")
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+}
+
+// TestAuxiliarySyntax_CondArrow verifies that auxiliary syntax `=>` works
+// correctly in `cond` forms after importing (scheme base).
+func TestAuxiliarySyntax_CondArrow(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := testhelpers.RunSchemeCode(t, "(cond (#t => (lambda (x) x)))")
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.TrueValue)
+}
+
+// TestAuxiliarySyntax_CaseElse verifies that auxiliary syntax `else` works
+// correctly in `case` forms after importing (scheme base).
+func TestAuxiliarySyntax_CaseElse(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := testhelpers.RunSchemeCode(t, "(case 1 (else 'ok))")
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewSymbol("ok"))
+}


### PR DESCRIPTION
## Summary

- Refactor `CopyLibraryBindingsToEnvAtPhase` to search source environments via a phase-ordered collection instead of three hand-unrolled if-blocks
- Bindings found above phase 0 are propagated to their source phase in the target, ensuring auxiliary syntax (`else`, `=>`, `...`, `_`) reaches the compile phase
- Add unit test verifying compile-phase propagation and integration tests for `cond`/`case` with auxiliary syntax
- Mark auxiliary syntax exports as resolved in TODO.md

## Test plan

- [x] `TestCopyLibraryBindingsToEnv_CompilePhase` — verifies binding exists in both phase 0 and phase 2 after copy
- [x] `TestAuxiliarySyntax_CondElse` — `(cond (else 42))` → `42`
- [x] `TestAuxiliarySyntax_CondArrow` — `(cond (#t => (lambda (x) x)))` → `#t`
- [x] `TestAuxiliarySyntax_CaseElse` — `(case 1 (else 'ok))` → `ok`
- [x] Full test suite passes, 0 lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)