### PR TITLE
fix: resolve library-internal macro hygiene

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -384,12 +384,10 @@ R7RS Missing Features
 
 ### Macro/Library System
 
-**Library-Internal Binding Hygiene:**
-- [ ] **Issue:** Macros defined in a library that reference helper functions defined in the same library fail at use site with "no such binding"
-- [ ] **Root Cause:** Hygiene model doesn't preserve library bindings for macro-introduced identifiers
-- [ ] **Workaround:** Export helper functions with `%` prefix
-- [ ] **Complexity:** High - requires changes to hygiene model to track library boundaries
-- [ ] **Related:** `FreeIdResolution` struct in `compile_syntax_rules.go` tracks global vs local binding resolution
+**Library-Internal Binding Hygiene:** ~~Resolved.~~
+- [x] **Issue:** Macros defined in a library that reference helper functions defined in the same library fail at use site with "no such binding"
+- [x] **Root Cause:** `GlobalIndex` only stored the symbol name, so at runtime the VM looked up the binding in the use-site environment instead of the definition-site library environment
+- [x] **Fix:** Added `Env *GlobalEnvironmentFrame` field to `GlobalIndex`. `EnvironmentFrame.GetGlobalIndex` records the definition-site global frame, and VM load/store operations use it directly when set.
 
 ---
 
@@ -614,7 +612,7 @@ Items that must be resolved before a 1.0 release. Each references an existing TO
 
 1. ~~**Partial list handling audit**~~ — Resolved. All list-consuming primitives handle improper lists correctly.
 
-2. **Library-internal binding hygiene** — See [Library-Internal Binding Hygiene](#library-internal-binding-hygiene) under R7RS Missing Features. Macros defined in a library that reference same-library helpers fail at use site. Current workaround: export helpers with `%` prefix.
+2. ~~**Library-internal binding hygiene**~~ — Resolved. `GlobalIndex.Env` now records the definition-site global frame for cross-library macro hygiene.
 
 3. **Eval optional environment** — See [Eval Optional Environment](#eval-optional-environment). `eval` should accept 1 or 2 args per R7RS; currently requires both.
 

--- a/go/environment/environment_frame.go
+++ b/go/environment/environment_frame.go
@@ -586,6 +586,8 @@ func (p *EnvironmentFrame) MaybeCreateOwnGlobalBinding(key *values.Symbol, bt Bi
 
 // GetGlobalIndex returns the GlobalIndex of the binding for the given symbol, searching global bindings in the current and parent environments.
 // It returns nil if the binding does not exist.
+// The returned GlobalIndex records the specific global frame where the binding
+// was found, enabling cross-library macro hygiene (see GlobalIndex.Env).
 func (p *EnvironmentFrame) GetGlobalIndex(key *values.Symbol) *GlobalIndex {
 	ge := p
 	_, ok := ge.global.keys[*key]
@@ -596,7 +598,9 @@ func (p *EnvironmentFrame) GetGlobalIndex(key *values.Symbol) *GlobalIndex {
 	if !ok {
 		return nil
 	}
-	return NewGlobalIndex(key)
+	gi := NewGlobalIndex(key)
+	gi.Env = ge.global
+	return gi
 }
 
 // GetGlobalBinding returns the binding for the given GlobalIndex, searching global bindings in the current and parent environments.

--- a/go/environment/global_environment_frame.go
+++ b/go/environment/global_environment_frame.go
@@ -26,8 +26,15 @@ import (
 // GlobalIndex identifies a global binding by its symbol key.
 // Unlike LocalIndex which uses numeric indices, GlobalIndex uses the symbol
 // directly since global bindings are accessed by name at runtime.
+//
+// Env records the definition-site global frame for cross-library macro hygiene.
+// When a macro references a non-exported helper from its defining library,
+// Env ensures the VM resolves the binding in the library's environment rather
+// than the use-site environment. Nil means "use the current environment"
+// (backward compatible default).
 type GlobalIndex struct {
 	Index *values.Symbol
+	Env   *GlobalEnvironmentFrame
 }
 
 // NewGlobalIndex creates a new GlobalIndex for the given symbol.

--- a/go/machine/library_scheme_test.go
+++ b/go/machine/library_scheme_test.go
@@ -228,6 +228,79 @@ func TestSchemeLibraryImportsWithUsage(t *testing.T) {
 	c.Assert(result, values.SchemeEquals, values.NewFloat(1.0))
 }
 
+// TestLibraryInternalMacroHygiene tests that macros defined in a library can
+// reference non-exported helper functions. The macro's free identifier references
+// should resolve in the library's definition-site environment, not the use-site
+// environment where the helper doesn't exist.
+//
+// This is the core cross-library hygiene scenario: GlobalIndex.Env records
+// the definition-site global frame so the VM can look up the helper binding
+// directly in the library environment.
+func TestLibraryInternalMacroHygiene(t *testing.T) {
+	c := qt.New(t)
+	env := setupSchemeLibraryTest(t)
+	defer func() { machine.LibraryEnvFactory = nil }()
+
+	// Step 1: Compile and execute a library with a non-exported helper
+	// and a macro that references it. We replicate what loadLibraryFromFile
+	// does: compile with a library callback, execute the template, register.
+	libCode := `(define-library (test hygiene-lib)
+	  (export my-macro)
+	  (import (scheme base))
+	  (begin
+	    (define (helper x) (+ x 1))
+	    (define-syntax my-macro
+	      (syntax-rules ()
+	        ((my-macro x) (helper x))))))`
+
+	sv := parseSchemeExpr(t, env, libCode)
+
+	// Expand
+	ectx := machine.NewExpandTimeCallContext()
+	expanded, err := machine.NewExpanderTimeContinuation(env).ExpandExpression(ectx, sv)
+	c.Assert(err, qt.IsNil, qt.Commentf("library expansion should succeed"))
+
+	// Compile with library callback to capture the CompiledLibrary
+	tpl := machine.NewNativeTemplate(0, 0, false)
+	compiler := machine.NewCompiletimeContinuation(tpl, env)
+	var compiledLib *machine.CompiledLibrary
+	compiler.SetLibraryCallback(func(lib *machine.CompiledLibrary) {
+		compiledLib = lib
+	})
+	ctctx := machine.NewCompileTimeCallContext(false, true, env)
+	err = compiler.CompileExpression(ctctx, expanded)
+	c.Assert(err, qt.IsNil, qt.Commentf("library compilation should succeed"))
+	c.Assert(compiledLib, qt.IsNotNil, qt.Commentf("library callback should have been called"))
+
+	// Execute the library template to populate bindings
+	if compiledLib.Template != nil {
+		cont := machine.NewMachineContinuation(nil, compiledLib.Template, compiledLib.Env)
+		mc := machine.NewMachineContext(context.Background(), cont)
+		err = mc.Run()
+		c.Assert(err, qt.IsNil, qt.Commentf("library execution should succeed"))
+	}
+
+	// Register the library so import can find it
+	registryAny := env.LibraryRegistry()
+	registry := registryAny.(*machine.LibraryRegistry)
+	err = registry.Register(compiledLib)
+	c.Assert(err, qt.IsNil)
+
+	// Step 2: Import the library into the caller environment
+	importCode := `(import (test hygiene-lib))`
+	sv = parseSchemeExpr(t, env, importCode)
+	_, err = compileAndRun(t, env, sv)
+	c.Assert(err, qt.IsNil, qt.Commentf("import should succeed"))
+
+	// Step 3: Use the macro — helper is not exported, but the macro's
+	// GlobalIndex.Env should point to the library's global frame
+	useCode := `(my-macro 5)`
+	sv = parseSchemeExpr(t, env, useCode)
+	result, err := compileAndRun(t, env, sv)
+	c.Assert(err, qt.IsNil, qt.Commentf("macro using non-exported helper should work"))
+	c.Assert(result, values.SchemeEquals, values.NewInteger(6))
+}
+
 // TestIndividualSchemeLibraries tests each scheme library can be imported individually
 func TestIndividualSchemeLibraries(t *testing.T) {
 	libraries := []struct {

--- a/go/machine/operation_load_global_by_global_index_literal_index_immediate.go
+++ b/go/machine/operation_load_global_by_global_index_literal_index_immediate.go
@@ -58,10 +58,17 @@ func (p *OperationLoadGlobalByGlobalIndexLiteralIndexImmediate) Apply(ctx contex
 	if !ok {
 		return nil, mc.Error(fmt.Sprintf("literal %v is not a global index", o))
 	}
-	// Use GetGlobalBinding which traverses the parent chain.
-	// This is necessary for cross-phase lookups (e.g., expand-time primitives
-	// accessed from syntax-case fenders running in a child environment).
-	bd := mc.env.GetGlobalBinding(gi)
+	// If the GlobalIndex carries a definition-site environment (cross-library
+	// macro hygiene), look up directly in that frame. Otherwise fall back to
+	// GetGlobalBinding which traverses the parent chain — necessary for
+	// cross-phase lookups (e.g., expand-time primitives accessed from
+	// syntax-case fenders running in a child environment).
+	var bd *environment.Binding
+	if gi.Env != nil {
+		bd = gi.Env.GetOwnGlobalBinding(gi)
+	} else {
+		bd = mc.env.GetGlobalBinding(gi)
+	}
 	if bd == nil {
 		return nil, mc.Error(fmt.Sprintf("no such global binding for %s", gi.SchemeString()))
 	}

--- a/go/machine/operation_store_global_by_global_index_literal_index_immediate.go
+++ b/go/machine/operation_store_global_by_global_index_literal_index_immediate.go
@@ -56,7 +56,12 @@ func (p *OperationStoreGlobalByGlobalIndexLiteralIndexImmediate) Apply(ctx conte
 		return nil, mc.Error(fmt.Sprintf("literal %v is not a global index", o))
 	}
 	val := mc.evals.Pop()
-	err := mc.env.GlobalEnvironment().SetOwnGlobalValue(gi, val)
+	var err error
+	if gi.Env != nil {
+		err = gi.Env.SetOwnGlobalValue(gi, val)
+	} else {
+		err = mc.env.GlobalEnvironment().SetOwnGlobalValue(gi, val)
+	}
 	if err != nil {
 		return nil, mc.WrapError(err, fmt.Sprintf("no such global binding for %s", gi.SchemeString()))
 	}


### PR DESCRIPTION
## Summary
- Added `Env *GlobalEnvironmentFrame` field to `GlobalIndex` to record the definition-site global frame for cross-library macro hygiene
- VM load/store operations now resolve bindings in the library's environment when `GlobalIndex.Env` is set, falling back to the use-site environment otherwise
- Updated `TODO.md` to mark library-internal binding hygiene as resolved

## Test plan
- [x] Added `TestLibraryInternalMacroHygiene` covering a macro that references a non-exported helper function across library boundaries
- [ ] Run full test suite (`cd go && make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)