### PR TITLE
fix: error on unterminated extended symbols and strings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -370,9 +370,10 @@ R7RS Missing Features
 ### Tokenizer (R7RS 7.1.1 Lexical Structure)
 
 **Extended Symbols (`|...|`):**
-- [x] **Basic parsing:** `readExtendedSymbol()` exists (tokenizer.go:1920-1944)
-- [x] **Escape sequences:** Calls `readIntraExtendedToken()` → `readEscapeSequence('|')`
-- [ ] **Verification needed:** Confirm all R7RS escape sequences supported (`\a`, `\b`, `\t`, `\n`, `\r`, `\|`, `\\`, `\x<hex>;`)
+- [x] **Basic parsing:** `readExtendedSymbol()` exists (tokenizer.go:1937-1961)
+- [x] **Escape sequences:** Calls `readIntraExtendedToken()` → `readEscapeSequence()`. All R7RS escapes verified: `\a`, `\b`, `\t`, `\n`, `\r`, `\|`, `\\`, `\x<hex>;`, and line continuations.
+- [x] **Verification complete:** All R7RS 7.1.1 escape sequences confirmed with tests in `edge_cases_test.go`.
+- [ ] **Bug:** Unterminated extended symbols (`|foo` at EOF) silently produce a valid symbol token instead of an error. `readExtendedSymbol` exits the loop on `p.err == io.EOF` without distinguishing EOF from a closing `|`.
 
 **Inexact Digit Placeholder:**
 - [ ] R7RS allows `#` in inexact numbers (e.g., `1.2###`)
@@ -616,7 +617,7 @@ Items that must be resolved before a 1.0 release. Each references an existing TO
 
 4. **Inexact digit placeholder** — See [Inexact Digit Placeholder](#inexact-digit-placeholder) under R7RS Missing Features / Tokenizer. R7RS allows `#` in inexact numbers (e.g., `1.2###`). Not implemented.
 
-5. **Extended symbol escape verification** — See [Extended Symbols](#extended-symbols) under R7RS Missing Features / Tokenizer. `|...|` symbols parse but escape sequences haven't been verified against R7RS 7.1.1.
+5. ~~**Extended symbol escape verification**~~ — Resolved. All R7RS 7.1.1 escape sequences verified and tested. Minor bug remains: unterminated `|...|` symbols silently succeed instead of erroring.
 
 6. **BigInteger overflow promotion** — See [BigInteger](#biginteger) under R7RS Missing Features / Primitives. No automatic Integer → BigInteger on overflow. R7RS requires exact integers to have unbounded range.
 

--- a/go/tokenizer/edge_cases_test.go
+++ b/go/tokenizer/edge_cases_test.go
@@ -15,6 +15,7 @@
 package tokenizer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -141,6 +142,43 @@ func TestExtendedSymbols(t *testing.T) {
 			val:   "λ",
 			err:   io.EOF,
 		},
+		// Line continuation within extended symbol (R7RS 7.1.1)
+		{
+			input: "|hello\\\nworld|",
+			state: TokenizerStateSymbol,
+			span:  "|hello\\\nworld|",
+			val:   "helloworld",
+			err:   io.EOF,
+		},
+		{
+			input: "|hello\\  \n  world|",
+			state: TokenizerStateSymbol,
+			span:  "|hello\\  \n  world|",
+			val:   "helloworld",
+			err:   io.EOF,
+		},
+		{
+			input: "|hello\\\r\nworld|",
+			state: TokenizerStateSymbol,
+			span:  "|hello\\\r\nworld|",
+			val:   "helloworld",
+			err:   io.EOF,
+		},
+		// Multiple escapes combined in one symbol
+		{
+			input: `|tab\there\nnewline|`,
+			state: TokenizerStateSymbol,
+			span:  `|tab\there\nnewline|`,
+			val:   "tab\there\nnewline",
+			err:   io.EOF,
+		},
+		{
+			input: `|\x48;\x65;\x6C;\x6C;\x6F;|`, // "Hello" via hex escapes
+			state: TokenizerStateSymbol,
+			span:  `|\x48;\x65;\x6C;\x6C;\x6F;|`,
+			val:   "Hello",
+			err:   io.EOF,
+		},
 		// Extended symbol followed by other tokens
 		{
 			input: "|foo| bar",
@@ -167,6 +205,74 @@ func TestExtendedSymbols(t *testing.T) {
 			c.Check(tok.Type(), qt.Equals, tc.state)
 			c.Check(tok.String(), qt.Equals, tc.span)
 			c.Check(tok.Value(), qt.Equals, tc.val)
+		})
+	}
+}
+
+// TestUnterminatedExtendedSymbol tests that unterminated extended symbols
+// produce a TokenizerError (not a bare io.EOF) per R7RS §7.1.1.
+func TestUnterminatedExtendedSymbol(t *testing.T) {
+	tcs := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "no closing pipe",
+			input: "|foo",
+		},
+		{
+			name:  "trailing backslash",
+			input: `|foo\`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			p := NewTokenizer(strings.NewReader(tc.input), false)
+			_, err1 := p.Next()
+			_, err2 := p.Next()
+			// Combine: error may surface on either call
+			combined := err1
+			if combined == nil {
+				combined = err2
+			}
+			c.Assert(combined, qt.IsNotNil)
+			var te *TokenizerError
+			c.Check(errors.As(combined, &te), qt.IsTrue,
+				qt.Commentf("expected TokenizerError, got %T: %v", combined, combined))
+		})
+	}
+}
+
+// TestExtendedSymbolEscapeErrors tests that invalid escape sequences within
+// extended symbols produce errors per R7RS 7.1.1.
+func TestExtendedSymbolEscapeErrors(t *testing.T) {
+	tcs := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "invalid escape character",
+			input: `|foo\qbar|`,
+		},
+		{
+			name:  "hex escape missing semicolon",
+			input: `|\x41|`,
+		},
+		{
+			name:  "hex escape with no digits",
+			input: `|\x;|`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			p := NewTokenizer(strings.NewReader(tc.input), false)
+			_, err1 := p.Next()
+			_, err2 := p.Next()
+			// Error may surface on either the first or second Next() call
+			hasError := err1 != nil || (err2 != nil && err2 != io.EOF)
+			c.Check(hasError, qt.IsTrue, qt.Commentf("err1=%v err2=%v", err1, err2))
 		})
 	}
 }
@@ -514,8 +620,10 @@ func TestInvalidStrings(t *testing.T) {
 			p := NewTokenizer(strings.NewReader(tc.input), false)
 			p.mark()
 			p.read()
-			// Should either error or reach EOF without completing string
-			c.Check(p.err, qt.IsNotNil)
+			c.Assert(p.err, qt.IsNotNil)
+			var te *TokenizerError
+			c.Check(errors.As(p.err, &te), qt.IsTrue,
+				qt.Commentf("expected TokenizerError, got %T: %v", p.err, p.err))
 		})
 	}
 }

--- a/go/tokenizer/tokenizer.go
+++ b/go/tokenizer/tokenizer.go
@@ -81,6 +81,8 @@ const (
 	MessageInvalidHexEscape                      = "character code point is a surrogate (0xD800-0xDFFF)"
 	MessageInvalidCharacterHexEscape             = "invalid character hex escape"
 	MessageInvalidCharacterMnemonic              = "invalid character mnemonic"
+	MessageUnterminatedExtendedSymbol            = "unterminated extended symbol"
+	MessageUnterminatedString                    = "unterminated string"
 )
 
 // ErrNotAnUnsignedByteMarker is returned when parsing fails on an unsigned byte marker.
@@ -669,6 +671,9 @@ func (p *Tokenizer) readString() {
 		if isBackSlash(p.curr()) {
 			p.next() // skip \
 			if p.err != nil {
+				if errors.Is(p.err, io.EOF) {
+					p.err = NewTokenizerError(MessageUnterminatedString, p.tokenStart, p.tokenEnd)
+				}
 				return
 			}
 			p.readIntraStringEscape() //nolint:errcheck
@@ -681,6 +686,9 @@ func (p *Tokenizer) readString() {
 		p.value += string(p.curr())
 		p.next()
 		if p.err != nil {
+			if errors.Is(p.err, io.EOF) {
+				p.err = NewTokenizerError(MessageUnterminatedString, p.tokenStart, p.tokenEnd)
+			}
 			return
 		}
 	}
@@ -1942,6 +1950,9 @@ func (p *Tokenizer) readExtendedSymbol() {
 			// skip backslash and read next intra-extended token character
 			p.next()
 			if p.err != nil {
+				if errors.Is(p.err, io.EOF) {
+					p.err = NewTokenizerError(MessageUnterminatedExtendedSymbol, p.tokenStart, p.tokenEnd)
+				}
 				return
 			}
 			p.readIntraExtendedToken()
@@ -1954,6 +1965,9 @@ func (p *Tokenizer) readExtendedSymbol() {
 		p.next()
 	}
 	if p.err != nil {
+		if errors.Is(p.err, io.EOF) {
+			p.err = NewTokenizerError(MessageUnterminatedExtendedSymbol, p.tokenStart, p.tokenEnd)
+		}
 		return
 	}
 	// consume closing '|'


### PR DESCRIPTION
## Summary

- `readExtendedSymbol()` and `readString()` silently accepted unterminated literals when EOF was reached before the closing delimiter (`|` or `"`), producing valid tokens instead of errors
- Convert `io.EOF` to `TokenizerError` at all exit points in both functions (4 sites total)
- Add `MessageUnterminatedExtendedSymbol` and `MessageUnterminatedString` error constants
- Add `TestUnterminatedExtendedSymbol` test covering `|foo` and `|foo\` cases
- Strengthen `TestInvalidStrings` to assert errors are `*TokenizerError`, not just non-nil

## Test plan

- [x] `go test -run 'TestUnterminated|TestInvalidStrings|TestExtendedSymbol' ./tokenizer/` — all pass
- [x] `go test ./tokenizer/...` — full tokenizer suite passes