### PR TITLE
Register box primitives

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -16,6 +16,7 @@ Complete list of supported types, primitives, and special forms in Wile.
 | Vector | Fixed-size mutable array, e.g., `#(1 2 3)` |
 | String | Mutable UTF-8 text |
 | Bytevector | Fixed-size byte array, e.g., `#u8(0 1 2)` |
+| Box | Mutable single-value container, e.g., `#&42` |
 | Procedure | Lambda or primitive function |
 
 ### Numeric Types
@@ -603,6 +604,15 @@ Complete list of supported types, primitives, and special forms in Wile.
 |-----------|-------------|
 | `make-parameter` | Create a parameter object |
 | `parameter?` | Test for parameter |
+
+## Boxes
+
+| Primitive | Description |
+|-----------|-------------|
+| `box` | Create a box containing a value |
+| `box?` | Test for box |
+| `unbox` | Extract the value from a box |
+| `set-box!` | Set the value in a box |
 
 ## Evaluation
 

--- a/TODO.md
+++ b/TODO.md
@@ -393,9 +393,9 @@ R7RS Missing Features
 ### Primitives
 
 **Box primitives:**
-- [ ] `box`, `box?`, `unbox`, `set-box!`
-- [ ] Box type exists in `go/values/box.go` but no Scheme primitives registered
-- [ ] **Effort:** Low - just need to register existing type
+- [x] `box`, `box?`, `unbox`, `set-box!`
+- [x] Box type exists in `go/values/box.go` but no Scheme primitives registered
+- [x] **Effort:** Low - just need to register existing type
 
 **Hashtable primitives:**
 - [ ] `make-hashtable`, `hashtable?`, `hashtable-ref`, `hashtable-set!`, `hashtable-delete!`
@@ -623,7 +623,7 @@ Items that must be resolved before a 1.0 release. Each references an existing TO
 
 ### Embedding API
 
-7. **Box primitives** — See [Box primitives](#box-primitives) under R7RS Missing Features / Primitives. Type exists but no Scheme-side registration.
+7. ~~**Box primitives**~~ — Resolved. Primitives `box`, `box?`, `unbox`, `set-box!` registered at Runtime+Expand phases.
 
 8. **Hashtable primitives** — See [Hashtable primitives](#hashtable-primitives) under R7RS Missing Features / Primitives. Type exists but only supports string keys, not arbitrary Scheme values.
 

--- a/go/registry/core/boxes.go
+++ b/go/registry/core/boxes.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:govet // Using unkeyed struct fields for concise primitive specs
+package core
+
+import (
+	"github.com/aalpar/wile/go/registry"
+)
+
+func addBoxes(r *registry.Registry) error {
+	r.AddPrimitives([]registry.PrimitiveSpec{
+		{"box", 1, false, PrimBox},
+		{"box?", 1, false, PrimBoxQ},
+		{"unbox", 1, false, PrimUnbox},
+		{"set-box!", 2, false, PrimSetBox},
+	}, registry.PhaseRuntime|registry.PhaseExpand)
+
+	return nil
+}

--- a/go/registry/core/prim_box_test.go
+++ b/go/registry/core/prim_box_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"testing"
+
+	"github.com/aalpar/wile/go/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// =============================================================================
+// box Tests
+// =============================================================================
+
+func TestBox(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+		out  values.Value
+	}{
+		{
+			name: "box creates a box",
+			code: "(box? (box 42))",
+			out:  values.TrueValue,
+		},
+		{
+			name: "box with string",
+			code: "(unbox (box \"hello\"))",
+			out:  values.NewString("hello"),
+		},
+		{
+			name: "box with boolean",
+			code: "(unbox (box #t))",
+			out:  values.TrueValue,
+		},
+		{
+			name: "box with empty list",
+			code: "(unbox (box '()))",
+			out:  values.EmptyList,
+		},
+		{
+			name: "nested boxes",
+			code: "(unbox (unbox (box (box 1))))",
+			out:  values.NewInteger(1),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, values.SchemeEquals, tc.out)
+		})
+	}
+}
+
+// =============================================================================
+// box? Tests
+// =============================================================================
+
+func TestBoxQ(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+		out  values.Value
+	}{
+		{
+			name: "box? returns true for box",
+			code: "(box? (box 42))",
+			out:  values.TrueValue,
+		},
+		{
+			name: "box? returns false for integer",
+			code: "(box? 42)",
+			out:  values.FalseValue,
+		},
+		{
+			name: "box? returns false for string",
+			code: "(box? \"hello\")",
+			out:  values.FalseValue,
+		},
+		{
+			name: "box? returns false for pair",
+			code: "(box? '(1 2))",
+			out:  values.FalseValue,
+		},
+		{
+			name: "box? returns false for boolean",
+			code: "(box? #t)",
+			out:  values.FalseValue,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, values.SchemeEquals, tc.out)
+		})
+	}
+}
+
+// =============================================================================
+// unbox Tests
+// =============================================================================
+
+func TestUnbox(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+		out  values.Value
+	}{
+		{
+			name: "unbox extracts integer",
+			code: "(unbox (box 42))",
+			out:  values.NewInteger(42),
+		},
+		{
+			name: "unbox extracts symbol",
+			code: "(unbox (box 'foo))",
+			out:  values.NewSymbol("foo"),
+		},
+		{
+			name: "unbox extracts list",
+			code: "(unbox (box '(1 2 3)))",
+			out:  values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, values.SchemeEquals, tc.out)
+		})
+	}
+}
+
+func TestUnboxErrors(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{
+			name: "unbox non-box integer",
+			code: "(unbox 42)",
+		},
+		{
+			name: "unbox non-box string",
+			code: "(unbox \"hello\")",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNotNil)
+		})
+	}
+}
+
+// =============================================================================
+// set-box! Tests
+// =============================================================================
+
+func TestSetBox(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+		out  values.Value
+	}{
+		{
+			name: "set-box! mutates box",
+			code: "(let ((b (box 1))) (set-box! b 2) (unbox b))",
+			out:  values.NewInteger(2),
+		},
+		{
+			name: "set-box! returns void",
+			code: "(void? (set-box! (box 1) 2))",
+			out:  values.TrueValue,
+		},
+		{
+			name: "set-box! with different type",
+			code: "(let ((b (box 42))) (set-box! b \"hello\") (unbox b))",
+			out:  values.NewString("hello"),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, values.SchemeEquals, tc.out)
+		})
+	}
+}
+
+func TestSetBoxErrors(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{
+			name: "set-box! non-box integer",
+			code: "(set-box! 42 1)",
+		},
+		{
+			name: "set-box! non-box string",
+			code: "(set-box! \"hello\" 1)",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNotNil)
+		})
+	}
+}
+
+// =============================================================================
+// equal? on boxes
+// =============================================================================
+
+func TestBoxEqual(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+		out  values.Value
+	}{
+		{
+			name: "equal? on boxes with equal contents",
+			code: "(equal? (box 42) (box 42))",
+			out:  values.TrueValue,
+		},
+		{
+			name: "equal? on boxes with different contents",
+			code: "(equal? (box 1) (box 2))",
+			out:  values.FalseValue,
+		},
+		{
+			name: "equal? on nested boxes",
+			code: "(equal? (box (box 1)) (box (box 1)))",
+			out:  values.TrueValue,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, values.SchemeEquals, tc.out)
+		})
+	}
+}

--- a/go/registry/core/prim_boxes.go
+++ b/go/registry/core/prim_boxes.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/aalpar/wile/go/machine"
+	"github.com/aalpar/wile/go/utils"
+	"github.com/aalpar/wile/go/values"
+)
+
+// PrimBox implements the box primitive.
+// Creates a new box containing the given value.
+func PrimBox(_ context.Context, mc *machine.MachineContext) error {
+	mc.SetValue(values.NewBox(mc.Arg(0)))
+	return nil
+}
+
+// PrimBoxQ implements the box? predicate.
+// Returns #t if the argument is a box, #f otherwise.
+func PrimBoxQ(_ context.Context, mc *machine.MachineContext) error {
+	_, ok := mc.Arg(0).(*values.Box)
+	mc.SetValue(utils.BoolToBoolean(ok))
+	return nil
+}
+
+// PrimUnbox implements the unbox primitive.
+// Returns the value contained in a box.
+func PrimUnbox(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	b, ok := o.(*values.Box)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotABox, "unbox: expected a box but got %T", o)
+	}
+	mc.SetValue(b.Unbox())
+	return nil
+}
+
+// PrimSetBox implements the set-box! primitive.
+// Sets the value contained in a box.
+func PrimSetBox(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	b, ok := o.(*values.Box)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotABox, "set-box!: expected a box but got %T", o)
+	}
+	b.Value = mc.Arg(1)
+	mc.SetValue(values.Void)
+	return nil
+}

--- a/go/registry/core/register.go
+++ b/go/registry/core/register.go
@@ -40,6 +40,7 @@ var Builder = registry.NewRegistryBuilder(
 	addSyntax,
 	addParameters,
 	addPrompts,
+	addBoxes,
 	addBootstrapMacros,
 )
 

--- a/go/values/foreign_error.go
+++ b/go/values/foreign_error.go
@@ -24,6 +24,7 @@ var (
 	ErrNotABoolean                 = NewStaticError("not a boolean")
 	ErrNotAnInputPort              = NewStaticError("not an input port")
 	ErrNotAnOutputPort             = NewStaticError("not an output port")
+	ErrNotABox                     = NewStaticError("not a box")
 	ErrNotAByte                    = NewStaticError("not a byte")
 	ErrNotAByteInputPort           = NewStaticError("not a byte input port")
 	ErrNotAByteOutputPort          = NewStaticError("not a byte output port")


### PR DESCRIPTION
## Summary

- Register `box`, `box?`, `unbox`, `set-box!` primitives at Runtime+Expand phases
- Add `ErrNotABox` sentinel error to `values/foreign_error.go`
- Add 21 table-driven tests covering all four primitives, error cases, and `equal?` on boxes
- Update PRIMITIVES.md with Box type and Boxes section
- Mark v1.0 blocker #7 as resolved in TODO.md

## Test plan

- [x] `go test -v -run TestBox ./registry/core/` — all 21 tests pass
- [x] `go test ./values/...` — no regressions
- [x] `go test ./registry/core/...` — full suite passes