### PR TITLE
feat: register hashtable primitives with Hashable key interface

### DIFF
--- a/PRIMITIVES.md
+++ b/PRIMITIVES.md
@@ -17,6 +17,7 @@ Complete list of supported types, primitives, and special forms in Wile.
 | String | Mutable UTF-8 text |
 | Bytevector | Fixed-size byte array, e.g., `#u8(0 1 2)` |
 | Box | Mutable single-value container, e.g., `#&42` |
+| Hashtable | Hash table mapping hashable values to values |
 | Procedure | Lambda or primitive function |
 
 ### Numeric Types
@@ -613,6 +614,21 @@ Complete list of supported types, primitives, and special forms in Wile.
 | `box?` | Test for box |
 | `unbox` | Extract the value from a box |
 | `set-box!` | Set the value in a box |
+
+## Hashtables
+
+| Primitive | Description |
+|-----------|-------------|
+| `make-hashtable` | Create a new empty hash table |
+| `hashtable?` | Test for hash table |
+| `hashtable-ref` | Look up key; `(hashtable-ref ht key)` errors if missing, `(hashtable-ref ht key default)` returns default |
+| `hashtable-set!` | Associate key with value |
+| `hashtable-delete!` | Remove key from hash table |
+| `hashtable-keys` | Return list of all keys |
+| `hashtable-values` | Return list of all values |
+| `hashtable-size` | Return number of entries |
+| `hashtable-copy` | Return shallow copy |
+| `hashtable-clear!` | Remove all entries |
 
 ## Evaluation
 

--- a/TODO.md
+++ b/TODO.md
@@ -398,11 +398,10 @@ R7RS Missing Features
 - [x] **Effort:** Low - just need to register existing type
 
 **Hashtable primitives:**
-- [ ] `make-hashtable`, `hashtable?`, `hashtable-ref`, `hashtable-set!`, `hashtable-delete!`
-- [ ] `hashtable-keys`, `hashtable-values`, `hashtable-size`, `hashtable-copy`, `hashtable-clear!`
-- [ ] Hashtable type exists in `go/values/hashtable.go`
-- [ ] **Issue:** Current implementation only supports string keys, not arbitrary Scheme values
-- [ ] **Effort:** Medium - need key hashing for Scheme values
+- [x] `make-hashtable`, `hashtable?`, `hashtable-ref`, `hashtable-set!`, `hashtable-delete!`
+- [x] `hashtable-keys`, `hashtable-values`, `hashtable-size`, `hashtable-copy`, `hashtable-clear!`
+- [x] Hashtable type refactored to support arbitrary `Hashable` keys via `HashCode()`/`EqualTo()` contract
+- [x] **Effort:** Medium - need key hashing for Scheme values
 
 **BigInteger:**
 - [ ] No automatic promotion from Integer when overflow
@@ -625,7 +624,7 @@ Items that must be resolved before a 1.0 release. Each references an existing TO
 
 7. ~~**Box primitives**~~ — Resolved. Primitives `box`, `box?`, `unbox`, `set-box!` registered at Runtime+Expand phases.
 
-8. **Hashtable primitives** — See [Hashtable primitives](#hashtable-primitives) under R7RS Missing Features / Primitives. Type exists but only supports string keys, not arbitrary Scheme values.
+8. ~~**Hashtable primitives**~~ — Resolved. 10 primitives registered at Runtime+Expand phases. Hashtable refactored from `map[string]Value` to custom `Hashable`-keyed bucket-chain map with FNV-1a hashing.
 
 ### User-Facing
 

--- a/go/registry/core/hashtables.go
+++ b/go/registry/core/hashtables.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:govet // Using unkeyed struct fields for concise primitive specs
+package core
+
+import (
+	"github.com/aalpar/wile/go/registry"
+)
+
+func addHashtables(r *registry.Registry) error {
+	r.AddPrimitives([]registry.PrimitiveSpec{
+		{"make-hashtable", 0, false, PrimMakeHashtable},
+		{"hashtable?", 1, false, PrimHashtableQ},
+		{"hashtable-ref", 3, true, PrimHashtableRef},
+		{"hashtable-set!", 3, false, PrimHashtableSet},
+		{"hashtable-delete!", 2, false, PrimHashtableDelete},
+		{"hashtable-keys", 1, false, PrimHashtableKeys},
+		{"hashtable-values", 1, false, PrimHashtableValues},
+		{"hashtable-size", 1, false, PrimHashtableSize},
+		{"hashtable-copy", 1, false, PrimHashtableCopy},
+		{"hashtable-clear!", 1, false, PrimHashtableClear},
+	}, registry.PhaseRuntime|registry.PhaseExpand)
+
+	return nil
+}

--- a/go/registry/core/prim_hashtable_test.go
+++ b/go/registry/core/prim_hashtable_test.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/go/values"
+)
+
+func TestHashtable_MakeAndPredicate(t *testing.T) {
+	c := qt.New(t)
+	tcs := []schemeCodeTestCase{
+		{"make-hashtable returns hashtable", `(hashtable? (make-hashtable))`, values.TrueValue},
+		{"integer is not hashtable", `(hashtable? 42)`, values.FalseValue},
+		{"string is not hashtable", `(hashtable? "hello")`, values.FalseValue},
+		{"pair is not hashtable", `(hashtable? '(1 2))`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			result, err := runSchemeCode(t, tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+func TestHashtable_SetAndRef(t *testing.T) {
+	c := qt.New(t)
+	tcs := []schemeCodeTestCase{
+		{
+			"set and ref round-trip",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht 'key 42)
+			   (hashtable-ref ht 'key))`,
+			values.NewInteger(42),
+		},
+		{
+			"ref with default on missing key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-ref ht 'missing 99))`,
+			values.NewInteger(99),
+		},
+		{
+			"integer key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht 1 "one")
+			   (hashtable-ref ht 1))`,
+			values.NewString("one"),
+		},
+		{
+			"string key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht "key" 100)
+			   (hashtable-ref ht "key"))`,
+			values.NewInteger(100),
+		},
+		{
+			"boolean key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht #t "yes")
+			   (hashtable-ref ht #t))`,
+			values.NewString("yes"),
+		},
+		{
+			"overwrite existing key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht 'key 1)
+			   (hashtable-set! ht 'key 2)
+			   (hashtable-ref ht 'key))`,
+			values.NewInteger(2),
+		},
+	}
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			result, err := runSchemeCode(t, tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+func TestHashtable_RefErrorOnMissing(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{
+			"ref errors on missing key without default",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-ref ht 'missing))`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runSchemeCodeExpectError(t, tc.code)
+		})
+	}
+}
+
+func TestHashtable_Delete(t *testing.T) {
+	c := qt.New(t)
+	tcs := []schemeCodeTestCase{
+		{
+			"delete removes key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht 'key 42)
+			   (hashtable-delete! ht 'key)
+			   (hashtable-size ht))`,
+			values.NewInteger(0),
+		},
+		{
+			"delete non-existent key is no-op",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-delete! ht 'missing)
+			   (hashtable-size ht))`,
+			values.NewInteger(0),
+		},
+	}
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			result, err := runSchemeCode(t, tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+func TestHashtable_Size(t *testing.T) {
+	c := qt.New(t)
+	tcs := []schemeCodeTestCase{
+		{
+			"empty hashtable size",
+			`(hashtable-size (make-hashtable))`,
+			values.NewInteger(0),
+		},
+		{
+			"size after inserts",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht 'a 1)
+			   (hashtable-set! ht 'b 2)
+			   (hashtable-set! ht 'c 3)
+			   (hashtable-size ht))`,
+			values.NewInteger(3),
+		},
+	}
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			result, err := runSchemeCode(t, tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+func TestHashtable_KeysAndValues(t *testing.T) {
+	c := qt.New(t)
+
+	// Keys returns a list of keys
+	result, err := runSchemeCode(t, `
+		(let ((ht (make-hashtable)))
+		  (hashtable-set! ht 'only 1)
+		  (car (hashtable-keys ht)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewSymbol("only"))
+
+	// Values returns a list of values
+	result, err = runSchemeCode(t, `
+		(let ((ht (make-hashtable)))
+		  (hashtable-set! ht 'only 99)
+		  (car (hashtable-values ht)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewInteger(99))
+
+	// Empty hashtable returns empty lists
+	result, err = runSchemeCode(t, `(null? (hashtable-keys (make-hashtable)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.TrueValue)
+
+	result, err = runSchemeCode(t, `(null? (hashtable-values (make-hashtable)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestHashtable_Copy(t *testing.T) {
+	c := qt.New(t)
+
+	// Copy is independent
+	result, err := runSchemeCode(t, `
+		(let ((ht (make-hashtable)))
+		  (hashtable-set! ht 'a 1)
+		  (let ((cp (hashtable-copy ht)))
+		    (hashtable-set! ht 'b 2)
+		    (hashtable-size cp)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+
+	// Copy preserves content
+	result, err = runSchemeCode(t, `
+		(let ((ht (make-hashtable)))
+		  (hashtable-set! ht 'a 1)
+		  (let ((cp (hashtable-copy ht)))
+		    (hashtable-ref cp 'a)))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+}
+
+func TestHashtable_Clear(t *testing.T) {
+	c := qt.New(t)
+	result, err := runSchemeCode(t, `
+		(let ((ht (make-hashtable)))
+		  (hashtable-set! ht 'a 1)
+		  (hashtable-set! ht 'b 2)
+		  (hashtable-clear! ht)
+		  (hashtable-size ht))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.NewInteger(0))
+}
+
+func TestHashtable_EqualQ(t *testing.T) {
+	c := qt.New(t)
+
+	// equal? on identical content
+	result, err := runSchemeCode(t, `
+		(let ((a (make-hashtable))
+		      (b (make-hashtable)))
+		  (hashtable-set! a 'x 1)
+		  (hashtable-set! b 'x 1)
+		  (equal? a b))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.TrueValue)
+
+	// equal? on different content
+	result, err = runSchemeCode(t, `
+		(let ((a (make-hashtable))
+		      (b (make-hashtable)))
+		  (hashtable-set! a 'x 1)
+		  (hashtable-set! b 'x 2)
+		  (equal? a b))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result, values.SchemeEquals, values.FalseValue)
+}
+
+func TestHashtable_TypeErrors(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{"hashtable-ref on non-hashtable", `(hashtable-ref 42 'key)`},
+		{"hashtable-set! on non-hashtable", `(hashtable-set! 42 'key 1)`},
+		{"hashtable-delete! on non-hashtable", `(hashtable-delete! 42 'key)`},
+		{"hashtable-keys on non-hashtable", `(hashtable-keys 42)`},
+		{"hashtable-values on non-hashtable", `(hashtable-values 42)`},
+		{"hashtable-size on non-hashtable", `(hashtable-size 42)`},
+		{"hashtable-copy on non-hashtable", `(hashtable-copy 42)`},
+		{"hashtable-clear! on non-hashtable", `(hashtable-clear! 42)`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runSchemeCodeExpectError(t, tc.code)
+		})
+	}
+}
+
+func TestHashtable_NonComparableKeyError(t *testing.T) {
+	tcs := []schemeCodeErrorTestCase{
+		{
+			"set with non-comparable key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-set! ht '(1 2) "val"))`,
+		},
+		{
+			"ref with non-comparable key",
+			`(let ((ht (make-hashtable)))
+			   (hashtable-ref ht '(1 2)))`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			runSchemeCodeExpectError(t, tc.code)
+		})
+	}
+}

--- a/go/registry/core/prim_hashtables.go
+++ b/go/registry/core/prim_hashtables.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/aalpar/wile/go/machine"
+	"github.com/aalpar/wile/go/utils"
+	"github.com/aalpar/wile/go/values"
+)
+
+// PrimMakeHashtable implements the make-hashtable primitive.
+// Creates a new empty hash table.
+func PrimMakeHashtable(_ context.Context, mc *machine.MachineContext) error {
+	mc.SetValue(values.NewEmptyHashtable())
+	return nil
+}
+
+// PrimHashtableQ implements the hashtable? predicate.
+// Returns #t if the argument is a hash table, #f otherwise.
+func PrimHashtableQ(_ context.Context, mc *machine.MachineContext) error {
+	_, ok := mc.Arg(0).(*values.Hashtable)
+	mc.SetValue(utils.BoolToBoolean(ok))
+	return nil
+}
+
+// PrimHashtableRef implements the hashtable-ref primitive.
+// (hashtable-ref ht key) — errors if key is missing.
+// (hashtable-ref ht key default) — returns default if key is missing.
+func PrimHashtableRef(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-ref: expected a hashtable but got %s", o.SchemeString())
+	}
+	key := mc.Arg(1)
+	rest := mc.Arg(2)
+
+	val, found, err := ht.Get(key)
+	if err != nil {
+		return err
+	}
+	if found {
+		mc.SetValue(val)
+		return nil
+	}
+
+	// Check for optional default value
+	if rest != values.EmptyList {
+		tuple, ok := rest.(values.Tuple)
+		if !ok {
+			return values.WrapForeignErrorf(values.ErrInvalidArgument, "hashtable-ref: improper argument list")
+		}
+		mc.SetValue(tuple.Car())
+		return nil
+	}
+
+	return values.NewForeignErrorf("hashtable-ref: key not found: %s", key.SchemeString())
+}
+
+// PrimHashtableSet implements the hashtable-set! primitive.
+// (hashtable-set! ht key value)
+func PrimHashtableSet(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-set!: expected a hashtable but got %s", o.SchemeString())
+	}
+	err := ht.Set(mc.Arg(1), mc.Arg(2))
+	if err != nil {
+		return err
+	}
+	mc.SetValue(values.Void)
+	return nil
+}
+
+// PrimHashtableDelete implements the hashtable-delete! primitive.
+// (hashtable-delete! ht key)
+func PrimHashtableDelete(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-delete!: expected a hashtable but got %s", o.SchemeString())
+	}
+	err := ht.Delete(mc.Arg(1))
+	if err != nil {
+		return err
+	}
+	mc.SetValue(values.Void)
+	return nil
+}
+
+// PrimHashtableKeys implements the hashtable-keys primitive.
+// Returns a list of all keys in the hash table.
+func PrimHashtableKeys(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-keys: expected a hashtable but got %s", o.SchemeString())
+	}
+	mc.SetValue(ht.Keys())
+	return nil
+}
+
+// PrimHashtableValues implements the hashtable-values primitive.
+// Returns a list of all values in the hash table.
+func PrimHashtableValues(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-values: expected a hashtable but got %s", o.SchemeString())
+	}
+	mc.SetValue(ht.Values())
+	return nil
+}
+
+// PrimHashtableSize implements the hashtable-size primitive.
+// Returns the number of entries in the hash table.
+func PrimHashtableSize(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-size: expected a hashtable but got %s", o.SchemeString())
+	}
+	mc.SetValue(values.NewInteger(int64(ht.Size())))
+	return nil
+}
+
+// PrimHashtableCopy implements the hashtable-copy primitive.
+// Returns a shallow copy of the hash table.
+func PrimHashtableCopy(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-copy: expected a hashtable but got %s", o.SchemeString())
+	}
+	mc.SetValue(ht.Copy())
+	return nil
+}
+
+// PrimHashtableClear implements the hashtable-clear! primitive.
+// Removes all entries from the hash table.
+func PrimHashtableClear(_ context.Context, mc *machine.MachineContext) error {
+	o := mc.Arg(0)
+	ht, ok := o.(*values.Hashtable)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotAHashtable, "hashtable-clear!: expected a hashtable but got %s", o.SchemeString())
+	}
+	ht.Clear()
+	mc.SetValue(values.Void)
+	return nil
+}

--- a/go/registry/core/register.go
+++ b/go/registry/core/register.go
@@ -41,6 +41,7 @@ var Builder = registry.NewRegistryBuilder(
 	addParameters,
 	addPrompts,
 	addBoxes,
+	addHashtables,
 	addBootstrapMacros,
 )
 

--- a/go/values/big_integer.go
+++ b/go/values/big_integer.go
@@ -19,8 +19,9 @@ import (
 )
 
 var (
-	_ Value  = (*BigInteger)(nil)
-	_ Number = (*BigInteger)(nil)
+	_ Value    = (*BigInteger)(nil)
+	_ Number   = (*BigInteger)(nil)
+	_ Hashable = (*BigInteger)(nil)
 )
 
 // BigInteger represents an arbitrary-precision integer.
@@ -37,6 +38,12 @@ var (
 // BigInteger provides this capability using Go's math/big.Int.
 type BigInteger struct {
 	value *big.Int
+}
+
+// HashCode returns a hash of the big integer value.
+// Uses the canonical string representation.
+func (p *BigInteger) HashCode() uint64 {
+	return hashString(0x7, p.value.String())
 }
 
 // NewBigInteger creates a new BigInteger from a big.Int.

--- a/go/values/boolean.go
+++ b/go/values/boolean.go
@@ -15,7 +15,8 @@
 package values
 
 var (
-	_ Value = (*Boolean)(nil)
+	_ Value    = (*Boolean)(nil)
+	_ Hashable = (*Boolean)(nil)
 
 	// FalseValue is the singleton false boolean.
 	FalseValue = NewBoolean(false)
@@ -32,6 +33,14 @@ type Boolean struct {
 func NewBoolean(v bool) *Boolean {
 	q := &Boolean{Value: v}
 	return q
+}
+
+// HashCode returns a hash of the boolean value.
+func (p *Boolean) HashCode() uint64 {
+	if p.Value {
+		return 1
+	}
+	return 0
 }
 
 // Datum returns the underlying boolean value.

--- a/go/values/byte.go
+++ b/go/values/byte.go
@@ -16,7 +16,10 @@ package values
 
 import "fmt"
 
-var _ Value = (*Byte)(nil)
+var (
+	_ Value    = (*Byte)(nil)
+	_ Hashable = (*Byte)(nil)
+)
 
 // Byte represents a Scheme byte value (0-255).
 type Byte struct {
@@ -27,6 +30,11 @@ type Byte struct {
 func NewByte(v uint8) *Byte {
 	q := &Byte{Value: v}
 	return q
+}
+
+// HashCode returns a hash of the byte value.
+func (p *Byte) HashCode() uint64 {
+	return hashUint64(0x8, uint64(p.Value))
 }
 
 // Datum returns the underlying byte value.

--- a/go/values/character.go
+++ b/go/values/character.go
@@ -19,7 +19,10 @@ import (
 	"unicode/utf8"
 )
 
-var _ Value = (*Character)(nil)
+var (
+	_ Value    = (*Character)(nil)
+	_ Hashable = (*Character)(nil)
+)
 
 // Character represents a Scheme character value.
 type Character struct {
@@ -30,6 +33,11 @@ type Character struct {
 func NewCharacter(v rune) *Character {
 	q := &Character{Value: v}
 	return q
+}
+
+// HashCode returns a hash of the character value.
+func (p *Character) HashCode() uint64 {
+	return hashUint64(0x4, uint64(p.Value))
 }
 
 // Datum returns the underlying rune value.

--- a/go/values/float.go
+++ b/go/values/float.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	_ Value  = (*Float)(nil)
-	_ Number = (*Float)(nil)
+	_ Value    = (*Float)(nil)
+	_ Number   = (*Float)(nil)
+	_ Hashable = (*Float)(nil)
 	// _ Comparable = (*Float)(nil)
 )
 
@@ -35,6 +36,13 @@ type Float struct {
 func NewFloat(v float64) *Float {
 	q := &Float{Value: v}
 	return q
+}
+
+// HashCode returns a hash of the float value.
+// Uses the IEEE 754 bit representation to ensure +0.0 and -0.0
+// hash differently (they are not EqualTo each other in Scheme).
+func (p *Float) HashCode() uint64 {
+	return hashUint64(0x5, math.Float64bits(p.Value))
 }
 
 // Datum returns the underlying float64 value.

--- a/go/values/foreign_error.go
+++ b/go/values/foreign_error.go
@@ -94,6 +94,7 @@ var (
 	ErrNotAOnce              = NewStaticError("not a once")
 	ErrNotAnAtomic           = NewStaticError("not an atomic")
 	ErrPortClosed            = NewStaticError("port is closed")
+	ErrNotAHashtable         = NewStaticError("not a hashtable")
 )
 
 // StaticError represents a compile-time or static error.

--- a/go/values/hash.go
+++ b/go/values/hash.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package values
+
+// FNV-1a hash constants.
+// See Fowler-Noll-Vo hash function.
+const (
+	fnvOffset uint64 = 14695981039346656037
+	fnvPrime  uint64 = 1099511628211
+)
+
+// hashString computes an FNV-1a hash of a string with a type seed.
+// The seed differentiates types that share the same underlying data
+// (e.g., symbol "foo" vs string "foo").
+func hashString(seed byte, s string) uint64 {
+	h := fnvOffset
+	h ^= uint64(seed)
+	h *= fnvPrime
+	for i := range len(s) {
+		h ^= uint64(s[i])
+		h *= fnvPrime
+	}
+	return h
+}
+
+// hashUint64 computes an FNV-1a hash of a uint64 with a type seed.
+func hashUint64(seed byte, v uint64) uint64 {
+	h := fnvOffset
+	h ^= uint64(seed)
+	h *= fnvPrime
+	for i := range 8 {
+		h ^= (v >> (i * 8)) & 0xff
+		h *= fnvPrime
+	}
+	return h
+}

--- a/go/values/hashtable.go
+++ b/go/values/hashtable.go
@@ -15,27 +15,34 @@
 package values
 
 import (
-	"fmt"
+	"sort"
+	"strings"
 )
 
 var _ Value = (*Hashtable)(nil)
 
-// Hashtable represents a Scheme hash table mapping strings to values.
-type Hashtable struct {
-	Value map[string]Value
+// hashtableEntry stores a key-value pair in the hash table.
+type hashtableEntry struct {
+	key   Hashable
+	value Value
 }
 
-// NewHashtable creates a new hash table from the given map.
-func NewHashtable(v map[string]Value) *Hashtable {
+// Hashtable represents a Scheme hash table mapping hashable values to values.
+//
+// Keys must implement the Hashable interface (Value + HashCode()).
+// Uses bucket chaining with FNV-1a hashing for O(1) amortized operations
+// and EqualTo() for key comparison within buckets.
+type Hashtable struct {
+	buckets map[uint64][]hashtableEntry
+	size    int
+}
+
+// NewEmptyHashtable creates a new empty hash table.
+func NewEmptyHashtable() *Hashtable {
 	q := &Hashtable{
-		Value: v,
+		buckets: make(map[uint64][]hashtableEntry),
 	}
 	return q
-}
-
-// Datum returns the underlying map.
-func (p *Hashtable) Datum() map[string]Value {
-	return p.Value
 }
 
 // IsVoid returns true if this hash table is nil.
@@ -44,29 +51,24 @@ func (p *Hashtable) IsVoid() bool {
 }
 
 // EqualTo returns true if both hash tables have equal contents.
+// Uses structural equality (EqualTo) for both keys and values.
 func (p *Hashtable) EqualTo(o Value) bool {
 	v, ok := o.(*Hashtable)
 	if !ok {
 		return false
 	}
-	if len(p.Value) != len(v.Value) {
+	if p.size != v.size {
 		return false
 	}
-	for k := range p.Value {
-		_, ok = v.Value[k]
-		if !ok {
-			return false
-		}
-	}
-	for k := range v.Value {
-		_, ok = p.Value[k]
-		if !ok {
-			return false
-		}
-	}
-	for k := range p.Value {
-		if !p.Value[k].EqualTo(v.Value[k]) {
-			return false
+	for _, bucket := range p.buckets {
+		for _, entry := range bucket {
+			vval, found := v.get(entry.key)
+			if !found {
+				return false
+			}
+			if !entry.value.EqualTo(vval) {
+				return false
+			}
 		}
 	}
 	return true
@@ -74,5 +76,156 @@ func (p *Hashtable) EqualTo(o Value) bool {
 
 // SchemeString returns the Scheme representation of this hash table.
 func (p *Hashtable) SchemeString() string {
-	return fmt.Sprintf("%v", p.Value)
+	q := &strings.Builder{}
+	q.WriteString("#hash(")
+	// Collect all entries and sort for deterministic output.
+	entries := make([]hashtableEntry, 0, p.size)
+	for _, bucket := range p.buckets {
+		entries = append(entries, bucket...)
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key.SchemeString() < entries[j].key.SchemeString()
+	})
+	for i, e := range entries {
+		if i > 0 {
+			q.WriteString(" ")
+		}
+		q.WriteString("(")
+		q.WriteString(e.key.SchemeString())
+		q.WriteString(" . ")
+		q.WriteString(e.value.SchemeString())
+		q.WriteString(")")
+	}
+	q.WriteString(")")
+	return q.String()
+}
+
+// get is the internal lookup used by EqualTo and other methods.
+func (p *Hashtable) get(key Hashable) (Value, bool) {
+	h := key.HashCode()
+	bucket := p.buckets[h]
+	for _, e := range bucket {
+		if e.key.EqualTo(key) {
+			return e.value, true
+		}
+	}
+	return nil, false
+}
+
+// Get retrieves the value associated with key.
+// Returns the value and whether the key was found.
+// Returns ErrInvalidArgument if the key does not implement Hashable.
+func (p *Hashtable) Get(key Value) (Value, bool, error) {
+	hk, ok := key.(Hashable)
+	if !ok {
+		return nil, false, WrapForeignErrorf(ErrInvalidArgument, "hashtable: key is not hashable: %s", key.SchemeString())
+	}
+	val, found := p.get(hk)
+	return val, found, nil
+}
+
+// Set associates key with val in the hash table.
+// Returns ErrInvalidArgument if the key does not implement Hashable.
+func (p *Hashtable) Set(key Value, val Value) error {
+	hk, ok := key.(Hashable)
+	if !ok {
+		return WrapForeignErrorf(ErrInvalidArgument, "hashtable: key is not hashable: %s", key.SchemeString())
+	}
+	h := hk.HashCode()
+	bucket := p.buckets[h]
+	for i, e := range bucket {
+		if e.key.EqualTo(hk) {
+			p.buckets[h][i].value = val
+			return nil
+		}
+	}
+	p.buckets[h] = append(bucket, hashtableEntry{key: hk, value: val})
+	p.size++
+	return nil
+}
+
+// HasKey returns whether the key exists in the hash table.
+// Returns ErrInvalidArgument if the key does not implement Hashable.
+func (p *Hashtable) HasKey(key Value) (bool, error) {
+	hk, ok := key.(Hashable)
+	if !ok {
+		return false, WrapForeignErrorf(ErrInvalidArgument, "hashtable: key is not hashable: %s", key.SchemeString())
+	}
+	_, found := p.get(hk)
+	return found, nil
+}
+
+// Delete removes the entry for key from the hash table.
+// Returns ErrInvalidArgument if the key does not implement Hashable.
+func (p *Hashtable) Delete(key Value) error {
+	hk, ok := key.(Hashable)
+	if !ok {
+		return WrapForeignErrorf(ErrInvalidArgument, "hashtable: key is not hashable: %s", key.SchemeString())
+	}
+	h := hk.HashCode()
+	bucket := p.buckets[h]
+	for i, e := range bucket {
+		if e.key.EqualTo(hk) {
+			p.buckets[h] = append(bucket[:i], bucket[i+1:]...)
+			p.size--
+			if len(p.buckets[h]) == 0 {
+				delete(p.buckets, h)
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// Keys returns a list of all keys in the hash table.
+func (p *Hashtable) Keys() *Pair {
+	if p.size == 0 {
+		return EmptyList
+	}
+	keys := make([]Value, 0, p.size)
+	for _, bucket := range p.buckets {
+		for _, e := range bucket {
+			keys = append(keys, e.key)
+		}
+	}
+	return List(keys...)
+}
+
+// Values returns a list of all values in the hash table.
+func (p *Hashtable) Values() *Pair {
+	if p.size == 0 {
+		return EmptyList
+	}
+	vals := make([]Value, 0, p.size)
+	for _, bucket := range p.buckets {
+		for _, e := range bucket {
+			vals = append(vals, e.value)
+		}
+	}
+	return List(vals...)
+}
+
+// Size returns the number of entries in the hash table.
+func (p *Hashtable) Size() int {
+	return p.size
+}
+
+// Copy returns a shallow copy of the hash table.
+func (p *Hashtable) Copy() *Hashtable {
+	q := &Hashtable{
+		buckets: make(map[uint64][]hashtableEntry, len(p.buckets)),
+		size:    p.size,
+	}
+	for h, bucket := range p.buckets {
+		cp := make([]hashtableEntry, len(bucket))
+		copy(cp, bucket)
+		q.buckets[h] = cp
+	}
+	return q
+}
+
+// Clear removes all entries from the hash table.
+func (p *Hashtable) Clear() {
+	p.buckets = make(map[uint64][]hashtableEntry)
+	p.size = 0
 }

--- a/go/values/hashtable_test.go
+++ b/go/values/hashtable_test.go
@@ -20,34 +20,230 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+// helper to build a hashtable from key-value pairs for tests.
+func makeHT(kvs ...any) *Hashtable {
+	ht := NewEmptyHashtable()
+	for i := 0; i < len(kvs); i += 2 {
+		_ = ht.Set(kvs[i].(Value), kvs[i+1].(Value))
+	}
+	return ht
+}
+
 func TestHashtable_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
-		out bool
+		name string
+		in0  Value
+		in1  Value
+		out  bool
 	}{
 		{
-			in0: NewHashtable(map[string]Value{
-				"key1": NewInteger(1),
-			}),
-			in1: NewHashtable(map[string]Value{
-				"key2": NewInteger(1),
-			}),
-			out: false,
+			name: "different keys",
+			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
+			in1:  makeHT(NewSymbol("key2"), NewInteger(1)),
+			out:  false,
 		},
 		{
-			in0: NewHashtable(map[string]Value{
-				"key1": NewInteger(1),
-			}),
-			in1: NewHashtable(map[string]Value{
-				"key1": NewInteger(1),
-			}),
-			out: true,
+			name: "equal contents",
+			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
+			in1:  makeHT(NewSymbol("key1"), NewInteger(1)),
+			out:  true,
+		},
+		{
+			name: "different values",
+			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
+			in1:  makeHT(NewSymbol("key1"), NewInteger(2)),
+			out:  false,
+		},
+		{
+			name: "different sizes",
+			in0:  makeHT(NewSymbol("a"), NewInteger(1), NewSymbol("b"), NewInteger(2)),
+			in1:  makeHT(NewSymbol("a"), NewInteger(1)),
+			out:  false,
+		},
+		{
+			name: "not a hashtable",
+			in0:  NewEmptyHashtable(),
+			in1:  NewInteger(1),
+			out:  false,
+		},
+		{
+			name: "empty hashtables equal",
+			in0:  NewEmptyHashtable(),
+			in1:  NewEmptyHashtable(),
+			out:  true,
+		},
+		{
+			name: "integer keys",
+			in0:  makeHT(NewInteger(1), NewString("one")),
+			in1:  makeHT(NewInteger(1), NewString("one")),
+			out:  true,
 		},
 	}
 	for _, tc := range tcs {
-		t.Run("", func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			qt.Assert(t, tc.in0.EqualTo(tc.in1), qt.Equals, tc.out)
 		})
 	}
+}
+
+func TestHashtable_SchemeString(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+	c.Assert(ht.SchemeString(), qt.Equals, "#hash()")
+
+	ht2 := makeHT(NewSymbol("a"), NewInteger(1))
+	c.Assert(ht2.SchemeString(), qt.Equals, "#hash((a . 1))")
+}
+
+func TestHashtable_NewEmptyHashtable(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+	c.Assert(ht.Size(), qt.Equals, 0)
+	c.Assert(ht.IsVoid(), qt.IsFalse)
+}
+
+func TestHashtable_GetSetDelete(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+
+	// Set and Get — uses structural equality, not pointer identity
+	err := ht.Set(NewSymbol("key"), NewInteger(42))
+	c.Assert(err, qt.IsNil)
+
+	val, found, err := ht.Get(NewSymbol("key"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsTrue)
+	c.Assert(val, SchemeEquals, NewInteger(42))
+
+	// HasKey
+	found, err = ht.HasKey(NewSymbol("key"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsTrue)
+
+	found, err = ht.HasKey(NewSymbol("missing"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsFalse)
+
+	// Get missing
+	_, found, err = ht.Get(NewSymbol("missing"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsFalse)
+
+	// Delete
+	err = ht.Delete(NewSymbol("key"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ht.Size(), qt.Equals, 0)
+}
+
+func TestHashtable_KeysValues(t *testing.T) {
+	c := qt.New(t)
+
+	ht := NewEmptyHashtable()
+	c.Assert(ht.Keys(), qt.Equals, EmptyList)
+	c.Assert(ht.Values(), qt.Equals, EmptyList)
+
+	err := ht.Set(NewSymbol("a"), NewInteger(1))
+	c.Assert(err, qt.IsNil)
+
+	keys := ht.Keys()
+	c.Assert(keys.Length(), qt.Equals, 1)
+	c.Assert(keys.Car(), SchemeEquals, NewSymbol("a"))
+
+	vals := ht.Values()
+	c.Assert(vals.Length(), qt.Equals, 1)
+	c.Assert(vals.Car(), SchemeEquals, NewInteger(1))
+}
+
+func TestHashtable_CopyClear(t *testing.T) {
+	c := qt.New(t)
+
+	ht := NewEmptyHashtable()
+	err := ht.Set(NewSymbol("a"), NewInteger(1))
+	c.Assert(err, qt.IsNil)
+
+	// Copy is independent
+	cp := ht.Copy()
+	c.Assert(cp.Size(), qt.Equals, 1)
+
+	err = ht.Set(NewSymbol("b"), NewInteger(2))
+	c.Assert(err, qt.IsNil)
+	c.Assert(ht.Size(), qt.Equals, 2)
+	c.Assert(cp.Size(), qt.Equals, 1)
+
+	// Clear
+	ht.Clear()
+	c.Assert(ht.Size(), qt.Equals, 0)
+	c.Assert(cp.Size(), qt.Equals, 1)
+}
+
+func TestHashtable_NonHashableKey(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+	key := NewCons(NewInteger(1), NewInteger(2))
+
+	err := ht.Set(key, NewInteger(1))
+	c.Assert(err, qt.IsNotNil)
+
+	_, _, err = ht.Get(key)
+	c.Assert(err, qt.IsNotNil)
+
+	_, err = ht.HasKey(key)
+	c.Assert(err, qt.IsNotNil)
+
+	err = ht.Delete(key)
+	c.Assert(err, qt.IsNotNil)
+}
+
+func TestHashtable_VariousKeyTypes(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+
+	// Symbol key
+	err := ht.Set(NewSymbol("sym"), NewInteger(1))
+	c.Assert(err, qt.IsNil)
+
+	// Integer key
+	err = ht.Set(NewInteger(42), NewInteger(2))
+	c.Assert(err, qt.IsNil)
+
+	// String key
+	err = ht.Set(NewString("str"), NewInteger(3))
+	c.Assert(err, qt.IsNil)
+
+	// Boolean key
+	err = ht.Set(TrueValue, NewInteger(4))
+	c.Assert(err, qt.IsNil)
+
+	// Character key
+	err = ht.Set(NewCharacter('x'), NewInteger(5))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(ht.Size(), qt.Equals, 5)
+
+	// Look up with new pointers — structural equality
+	val, found, err := ht.Get(NewInteger(42))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsTrue)
+	c.Assert(val, SchemeEquals, NewInteger(2))
+
+	val, found, err = ht.Get(NewSymbol("sym"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsTrue)
+	c.Assert(val, SchemeEquals, NewInteger(1))
+}
+
+func TestHashtable_OverwriteKey(t *testing.T) {
+	c := qt.New(t)
+	ht := NewEmptyHashtable()
+
+	err := ht.Set(NewSymbol("k"), NewInteger(1))
+	c.Assert(err, qt.IsNil)
+	err = ht.Set(NewSymbol("k"), NewInteger(2))
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(ht.Size(), qt.Equals, 1)
+	val, found, err := ht.Get(NewSymbol("k"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(found, qt.IsTrue)
+	c.Assert(val, SchemeEquals, NewInteger(2))
 }

--- a/go/values/integer.go
+++ b/go/values/integer.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	_ Value  = (*Integer)(nil)
-	_ Number = (*Integer)(nil)
+	_ Value    = (*Integer)(nil)
+	_ Number   = (*Integer)(nil)
+	_ Hashable = (*Integer)(nil)
 	// _ Comparable = (*Integer)(nil)
 )
 
@@ -60,6 +61,11 @@ func NewInteger(v int64) *Integer {
 		return intCache[v-intCacheMin]
 	}
 	return &Integer{Value: v}
+}
+
+// HashCode returns a hash of the integer value.
+func (p *Integer) HashCode() uint64 {
+	return hashUint64(0x2, uint64(p.Value))
 }
 
 // Datum returns the underlying int64 value.

--- a/go/values/rational.go
+++ b/go/values/rational.go
@@ -19,13 +19,20 @@ import (
 )
 
 var (
-	_ Value  = (*Rational)(nil)
-	_ Number = (*Rational)(nil)
+	_ Value    = (*Rational)(nil)
+	_ Number   = (*Rational)(nil)
+	_ Hashable = (*Rational)(nil)
 )
 
 // Rational represents a Scheme rational number (exact fraction).
 type Rational struct {
 	value *big.Rat
+}
+
+// HashCode returns a hash of the rational value.
+// Uses the canonical string representation of the reduced fraction.
+func (p *Rational) HashCode() uint64 {
+	return hashString(0x6, p.value.RatString())
 }
 
 // NewRational creates a new Rational from numerator and denominator.

--- a/go/values/string.go
+++ b/go/values/string.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	_ Value        = (*String)(nil)
+	_ Hashable     = (*String)(nil)
 	_ fmt.Stringer = (*String)(nil)
 )
 
@@ -60,6 +61,11 @@ func InternString(str string) *String {
 	newStr := &String{Value: str}
 	actual, _ := stringInterns.LoadOrStore(str, newStr)
 	return actual.(*String)
+}
+
+// HashCode returns a hash of the string value.
+func (p *String) HashCode() uint64 {
+	return hashString(0x3, p.Value)
 }
 
 // Datum returns the underlying string value.

--- a/go/values/symbol.go
+++ b/go/values/symbol.go
@@ -19,7 +19,10 @@ import (
 	"unicode"
 )
 
-var _ Value = (*Symbol)(nil)
+var (
+	_ Value    = (*Symbol)(nil)
+	_ Hashable = (*Symbol)(nil)
+)
 
 // Symbol represents a Scheme symbol.
 type Symbol struct {
@@ -30,6 +33,11 @@ type Symbol struct {
 func NewSymbol(key string) *Symbol {
 	q := &Symbol{Key: key}
 	return q
+}
+
+// HashCode returns a hash of the symbol's key.
+func (p *Symbol) HashCode() uint64 {
+	return hashString(0x1, p.Key)
 }
 
 // Datum returns the symbol's key string.

--- a/go/values/values.go
+++ b/go/values/values.go
@@ -54,13 +54,12 @@ func (eofType) EqualTo(v Value) bool {
 // EOFObject is the singleton EOF value.
 var EOFObject Value = eofType{}
 
-// Table represents a key-value mapping interface.
-type Table interface {
-	HasKey(Value) bool
-	Get(Value) (Value, bool)
-	Set(Value, Value)
-	Keys() Tuple
-	Values() Tuple
+// Hashable represents a Value that can be used as a hashtable key.
+// Types implementing Hashable must satisfy the contract:
+// if a.EqualTo(b) then a.HashCode() == b.HashCode().
+type Hashable interface {
+	Value
+	HashCode() uint64
 }
 
 // Wrapped represents a value that wraps another value.


### PR DESCRIPTION
## Summary

- Add `Hashable` interface (`Value` + `HashCode() uint64`) to `values` package, implemented by 9 types: Symbol, Integer, BigInteger, String, Character, Boolean, Float, Rational, Byte
- Refactor `Hashtable` from `map[string]Value` to a custom bucket-chain map using FNV-1a hashing with `EqualTo()` for collision resolution — O(1) amortized with structural key equality
- Register 10 primitives at Runtime+Expand: `make-hashtable`, `hashtable?`, `hashtable-ref` (with optional default), `hashtable-set!`, `hashtable-delete!`, `hashtable-keys`, `hashtable-values`, `hashtable-size`, `hashtable-copy`, `hashtable-clear!`
- Non-`Hashable` keys (pairs, vectors) produce a clear error at the Scheme level

## Test plan

- [x] `go test ./values/...` — Hashtable unit tests (EqualTo, SchemeString, Get/Set/Delete, Keys/Values, Copy/Clear, non-hashable key errors, various key types, overwrite)
- [x] `go test ./registry/core/...` — Scheme-level integration tests (creation, predicate, set/ref round-trip, ref with default, ref error on missing, delete, keys/values, size, copy independence, clear, equal?, type errors, non-hashable key errors)
- [x] `go build ./...` — Full project builds clean

Resolves v1.0 blocker #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)