### PR TITLE
Add Go embedding examples and fix README primitive signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Register a Go function as a Scheme primitive:
 engine.RegisterPrimitive(wile.PrimitiveSpec{
     Name:       "go-add",
     ParamCount: 2,
-    Impl: func(ctx context.Context, mc *machine.MachineContext, args ...values.Value) error {
-        a := args[0].(*values.Integer).Value
-        b := args[1].(*values.Integer).Value
+    Impl: func(ctx context.Context, mc *wile.MachineContext) error {
+        a := mc.Arg(0).(*values.Integer).Value
+        b := mc.Arg(1).(*values.Integer).Value
         mc.SetValue(values.NewInteger(a + b))
         return nil
     },

--- a/go/examples/embedding/basic.go
+++ b/go/examples/embedding/basic.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// basic demonstrates embedding the Wile Scheme interpreter in a Go program.
+//
+// Run with: go run ./examples/embedding/basic.go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aalpar/wile/go/values"
+	"github.com/aalpar/wile/go/wile"
+)
+
+func main() {
+	// 1. Create an engine with default (core) primitives.
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// 2. Evaluate a simple expression.
+	result, err := engine.Eval(ctx, "(+ 1 2 3)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("(+ 1 2 3) =>", result.SchemeString())
+
+	// 3. Push Go values into Scheme.
+	err = engine.Define("width", wile.NewInteger(800))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = engine.Define("height", wile.NewInteger(600))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err = engine.Eval(ctx, "(* width height)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("(* width height) =>", result.SchemeString())
+
+	// 4. Register a Go function as a Scheme primitive.
+	err = engine.RegisterPrimitive(wile.PrimitiveSpec{
+		Name:       "go-max",
+		ParamCount: 2,
+		Impl: func(_ context.Context, mc *wile.MachineContext) error {
+			a := mc.Arg(0).(*values.Integer).Value
+			b := mc.Arg(1).(*values.Integer).Value
+			if a > b {
+				mc.SetValue(values.NewInteger(a))
+			} else {
+				mc.SetValue(values.NewInteger(b))
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	result, err = engine.Eval(ctx, "(go-max 42 17)")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("(go-max 42 17) =>", result.SchemeString())
+
+	// 5. Define a Scheme function and call it from Go.
+	_, err = engine.EvalMultiple(ctx, `
+		(define (factorial n)
+		  (if (<= n 1)
+		      1
+		      (* n (factorial (- n 1)))))
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	proc, ok := engine.Get("factorial")
+	if !ok {
+		log.Fatal("factorial not found")
+	}
+
+	result, err = engine.Call(ctx, proc, wile.NewInteger(10))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("(factorial 10) =>", result.SchemeString())
+
+	// 6. Compile once, run with different inputs.
+	_, err = engine.Eval(ctx, "(define x 0)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	compiled, err := engine.Compile("(* x x)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, n := range []int64{3, 7, 11} {
+		err = engine.Define("x", wile.NewInteger(n))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		result, err = engine.Run(ctx, compiled)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("x=%d: (* x x) => %s\n", n, result.SchemeString())
+	}
+}

--- a/go/wile/example_test.go
+++ b/go/wile/example_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wile_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/aalpar/wile/go/extensions/io"
+	"github.com/aalpar/wile/go/values"
+	"github.com/aalpar/wile/go/wile"
+)
+
+func ExampleNewEngine() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	result, err := engine.Eval(ctx, "(+ 1 2 3)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.SchemeString())
+	// Output: 6
+}
+
+func ExampleEngine_EvalMultiple() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	result, err := engine.EvalMultiple(ctx, `
+		(define x 10)
+		(define y 20)
+		(+ x y)
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.SchemeString())
+	// Output: 30
+}
+
+func ExampleEngine_Compile() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Define a variable, then compile an expression that uses it.
+	ctx := context.Background()
+	_, err = engine.Eval(ctx, "(define x 0)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	compiled, err := engine.Compile("(* x x)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Run the same compiled code with different values of x.
+	for _, n := range []int64{3, 5, 7} {
+		err = engine.Define("x", wile.NewInteger(n))
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		result, err := engine.Run(ctx, compiled)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Println(result.SchemeString())
+	}
+	// Output:
+	// 9
+	// 25
+	// 49
+}
+
+func ExampleEngine_Define() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = engine.Define("width", wile.NewInteger(800))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = engine.Define("height", wile.NewInteger(600))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	result, err := engine.Eval(ctx, "(* width height)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.SchemeString())
+	// Output: 480000
+}
+
+func ExampleEngine_RegisterPrimitive() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Register a Go function that doubles an integer.
+	err = engine.RegisterPrimitive(wile.PrimitiveSpec{
+		Name:       "double",
+		ParamCount: 1,
+		Impl: func(_ context.Context, mc *wile.MachineContext) error {
+			n := mc.Arg(0).(*values.Integer).Value
+			mc.SetValue(values.NewInteger(n * 2))
+			return nil
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	result, err := engine.Eval(ctx, "(double 21)")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.SchemeString())
+	// Output: 42
+}
+
+func ExampleEngine_Call() {
+	engine, err := wile.NewEngine()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Define a Scheme function.
+	ctx := context.Background()
+	_, err = engine.EvalMultiple(ctx, `
+		(define (square x) (* x x))
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Retrieve and call it from Go.
+	proc, ok := engine.Get("square")
+	if !ok {
+		log.Fatal("square not found")
+	}
+
+	result, err := engine.Call(ctx, proc, wile.NewInteger(12))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.SchemeString())
+	// Output: 144
+}
+
+func ExampleNewEngine_withExtension() {
+	_, err := wile.NewEngine(
+		wile.WithExtension(io.Extension),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("engine created with I/O extension")
+	// Output: engine created with I/O extension
+}


### PR DESCRIPTION
## Summary

- Add 7 testable `Example*` functions in `go/wile/example_test.go` covering `NewEngine`, `Eval`, `EvalMultiple`, `Compile`, `Define`, `RegisterPrimitive`, `Call`, and `WithExtension` — these appear in `go doc` output and are validated by `go test`
- Add standalone runnable example in `go/examples/embedding/basic.go` demonstrating the full embedding workflow end-to-end
- Fix README primitive registration code snippet to use correct `ForeignFunction` signature (`func(ctx, mc *wile.MachineContext) error` with `mc.Arg(i)`) instead of incorrect variadic args parameter

## Test plan

- [x] `cd go && go test -v -run Example ./wile/...` — all 7 examples pass
- [x] `cd go && go run ./examples/embedding/basic.go` — standalone example runs
- [x] `cd go && go test ./...` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)