### PR TITLE
Fix port EOF handling and port predicate tests

### DIFF
--- a/go/cmd/main.go
+++ b/go/cmd/main.go
@@ -100,15 +100,15 @@ func setupSignals() {
 				stacktrace = make([]byte, len(stacktrace)*2)
 				length = gruntime.Stack(stacktrace, true)
 			}
-			fmt.Println("=== GOROUTINE STACK DUMP ===")
-			fmt.Println(string(stacktrace[:length]))
-			fmt.Println("=== END OF DUMP ===")
+			fmt.Fprintln(os.Stderr, "=== GOROUTINE STACK DUMP ===")
+			fmt.Fprintln(os.Stderr, string(stacktrace[:length]))
+			fmt.Fprintln(os.Stderr, "=== END OF DUMP ===")
 			// The program continues running after this point
 		}
 	}()
 
 	// ... rest of your program ...
-	fmt.Println("Program running, send SIGQUIT (Ctrl+\\) to dump stacks.")
+	fmt.Fprintln(os.Stderr, "Program running, send SIGQUIT (Ctrl+\\) to dump stacks.")
 }
 
 func main() {

--- a/go/extensions/io/prim_read_write.go
+++ b/go/extensions/io/prim_read_write.go
@@ -122,6 +122,10 @@ func PrimRead(_ context.Context, mc *machine.MachineContext) error {
 	}
 	syn, err := prss.Value().ReadSyntax(context.TODO())
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			mc.SetValue(values.EOFObject)
+			return nil
+		}
 		return values.WrapForeignReadErrorf(err, "error reading from input port")
 	}
 	// Use UnwrapAllShared to preserve object identity for datum labels (R7RS §2.4)
@@ -165,7 +169,8 @@ func PrimReadToken(_ context.Context, mc *machine.MachineContext) error {
 	}
 	q, err := tknz.Value().Next()
 	if errors.Is(err, io.EOF) {
-		return values.WrapForeignReadErrorf(err, "end of file")
+		mc.SetValue(values.EOFObject)
+		return nil
 	}
 	if err != nil {
 		return values.WrapForeignReadErrorf(err, "error reading token")
@@ -207,6 +212,10 @@ func PrimReadSyntax(_ context.Context, mc *machine.MachineContext) error {
 	}
 	q, err := prss.Value().ReadSyntax(context.TODO())
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			mc.SetValue(values.EOFObject)
+			return nil
+		}
 		return values.WrapForeignReadErrorf(err, "error reading syntax from input port")
 	}
 	mc.SetValue(q)

--- a/go/registry/core/prim_eof_object_test.go
+++ b/go/registry/core/prim_eof_object_test.go
@@ -22,28 +22,55 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-// EOF Object Tests (R7RS §6.13.1)
+// EOF Object Tests (R7RS §6.13.2)
 
 func TestEofObjectFromRead(t *testing.T) {
-	// Note: In this implementation, read from an empty port returns an error
-	// rather than eof-object. This is an implementation difference from R7RS.
-	// This test verifies the actual behavior.
-	_, err := runSchemeCode(t, `
+	// R7RS §6.13.2: "If an end of file is encountered in the input before any
+	// characters are found that can begin an object, then an end-of-file object
+	// is returned."
+	result, err := runSchemeCode(t, `
 		(let ((p (open-input-string "")))
-			(read p))
+			(eof-object? (read p)))
 	`)
-	qt.Assert(t, err, qt.IsNotNil) // Expect error on EOF
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectFromReadAfterData(t *testing.T) {
-	// Note: In this implementation, reading past the end returns an error
-	// rather than eof-object. This is an implementation difference from R7RS.
-	_, err := runSchemeCode(t, `
+	// Reading past the end of data returns eof-object
+	result, err := runSchemeCode(t, `
 		(let ((p (open-input-string "42")))
-			(read p)  ; consume the 42
-			(read p))  ; will error on EOF
+			(read p)
+			(eof-object? (read p)))
 	`)
-	qt.Assert(t, err, qt.IsNotNil) // Expect error on EOF
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestEofObjectFromReadCharAfterRead(t *testing.T) {
+	// After read consumes data, read-char also returns eof-object
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "42")))
+			(read p)
+			(eof-object? (read-char p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestEofObjectFromReadMultipleEof(t *testing.T) {
+	// Multiple reads past EOF all return eof-object
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "")))
+			(let ((a (read p))
+			      (b (read p))
+			      (c (read p)))
+				(and (eof-object? a)
+				     (eof-object? b)
+				     (eof-object? c))))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectUniqueness(t *testing.T) {

--- a/go/registry/core/prim_port_extra_test.go
+++ b/go/registry/core/prim_port_extra_test.go
@@ -83,16 +83,12 @@ func TestOutputPortPredicateWithNonPort(t *testing.T) {
 }
 
 func TestInputPortOpenPredicate(t *testing.T) {
-	// Note: input-port-open? currently only accepts CharacterInputPort
-	// (from current-input-port), not string or bytevector ports.
 	result, err := runSchemeCode(t, `(input-port-open? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
 }
 
 func TestOutputPortOpenPredicate(t *testing.T) {
-	// Note: output-port-open? currently only accepts CharacterOutputPort
-	// (from current-output-port), not string or bytevector ports.
 	result, err := runSchemeCode(t, `(output-port-open? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
@@ -154,6 +150,24 @@ func TestPortOpenPredicatesOnBytevectorPorts(t *testing.T) {
 	result, err = runSchemeCode(t, `(output-port-open? (open-output-bytevector))`)
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestPortOpenPredicatesOnStringPorts(t *testing.T) {
+	result, err := runSchemeCode(t, `(input-port-open? (open-input-string "test"))`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+
+	result, err = runSchemeCode(t, `(output-port-open? (open-output-string))`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+
+	result, err = runSchemeCode(t, `(let ((p (open-input-string "test"))) (close-input-port p) (input-port-open? p))`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+
+	result, err = runSchemeCode(t, `(let ((p (open-output-string))) (close-output-port p) (output-port-open? p))`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
 }
 
 func TestPortPredicatesWithCurrentPorts(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix `read`, `read-token`, and `read-syntax` to return `eof-object` on EOF instead of raising an error (R7RS §6.13.2 conformance)
- Write goroutine stack dumps to stderr instead of stdout in signal handler
- Update EOF object tests to verify correct R7RS behavior (eof-object return, not error)
- Add tests for `input-port-open?`/`output-port-open?` on string ports
- Remove outdated implementation-difference comments from port predicate tests

## Test plan

- [x] `cd go && go test ./registry/core/...` — EOF and port tests pass
- [x] `cd go && go test ./extensions/io/...` — read/write tests pass
- [x] `cd go && go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)