### PR TITLE
fix: re-activate R7RS conformance tests

### DIFF
--- a/go/integration/r7rs_test.go
+++ b/go/integration/r7rs_test.go
@@ -58,12 +58,7 @@ func getTestDataPath() string {
 //
 // The test suite uses (test-exit) which calls (exit 0) on success or (exit 1) on failure.
 //
-// KNOWN LIMITATIONS: Several tests are commented out due to known issues:
-//   - (read) returning eof-object on empty port
-//   - Parser panics on certain datum comment edge cases
 func TestR7RSConformance(t *testing.T) {
-	t.Skip("KNOWN LIMITATIONS: Several R7RS features not yet fully implemented. See test file comments and plans/ for details.")
-
 	// Check that the scheme binary exists
 	schemeBin := getSchemeBinary()
 	if _, err := os.Stat(schemeBin); os.IsNotExist(err) {

--- a/go/parser/parser.go
+++ b/go/parser/parser.go
@@ -1378,9 +1378,17 @@ func (p *Parser) parseComplex(s string) (values.Number, error) {
 	signPos := -1
 	for i := 1; i < len(s); i++ {
 		if s[i] == '+' || s[i] == '-' {
-			// Make sure this isn't part of an exponent (e.g., 1e+10)
-			if i > 0 && (s[i-1] == 'e' || s[i-1] == 'E') {
-				continue
+			// Make sure this isn't part of an exponent (e.g., 1e+10, 1s+10)
+			// R7RS §7.1.1: exponent markers are e, s, f, d, l (case-insensitive)
+			if i > 0 {
+				prev := s[i-1]
+				if prev == 'e' || prev == 'E' ||
+					prev == 's' || prev == 'S' ||
+					prev == 'f' || prev == 'F' ||
+					prev == 'd' || prev == 'D' ||
+					prev == 'l' || prev == 'L' {
+					continue
+				}
 			}
 			// Make sure this isn't the sign in inf.0 or nan.0 (after the '0')
 			// Check if this could be the start of the imaginary part
@@ -1476,7 +1484,7 @@ func parseFloatOrInfnan(s string) (float64, error) {
 		return num / den, nil
 	}
 
-	return strconv.ParseFloat(s, 64)
+	return strconv.ParseFloat(normalizeExponentMarker(s), 64)
 }
 
 // parseRealPart parses a real number that may be a float or infnan


### PR DESCRIPTION
## Summary
- Remove `t.Skip` from `TestR7RSConformance` to re-activate the R7RS test suite
- Fix complex number parsing for R7RS §7.1.1 short float exponent suffixes (`s`, `f`, `d`, `l`) — the sign-separator logic in `parseComplex` only skipped `+`/`-` after `e`/`E`, causing failures on literals like `1s2+1.0i`
- Normalize exponent markers in `parseFloatOrInfnan` so `strconv.ParseFloat` can handle them

## Test plan
- [x] `TestR7RSConformance` passes
- [x] `go test ./...` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)