### PR TITLE
Fix 1.0 release blockers: quiet flag, lint, file tests, docs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -304,6 +304,7 @@ R7RS Missing Features
 
 **BigInteger:**
 - [x] Automatic promotion from Integer on overflow (resolved in `312cf48`)
+- [x] Unterminated extended symbol error handling (resolved in `829ef8d`)
 - [ ] No `#bigint` reader syntax
 
 **BigFloat:**
@@ -496,6 +497,8 @@ Items that must be resolved before a 1.0 release.
 
 ### R7RS Conformance
 
+- [x] All R7RS conformance issues resolved (see `plans/R7RS_CONFORMANCE_PLAN.md`)
+
 ### User-Facing
 
-(No remaining items — REPL startup message already outputs to stderr.)
+- [x] REPL banner moved to REPL-only path; `--quiet` flag added

--- a/go/cmd/main.go
+++ b/go/cmd/main.go
@@ -41,6 +41,7 @@ type Options struct {
 	File        string `short:"f" long:"file" description:"Scheme file to run"`
 	LibraryPath string `short:"L" long:"library-path" description:"Library search path (colon-separated, prepended to SCHEME_LIBRARY_PATH)"`
 	Version     bool   `short:"V" long:"version" description:"Print version information and exit"`
+	Quiet       bool   `short:"q" long:"quiet" description:"Suppress informational messages"`
 }
 
 var (
@@ -86,7 +87,7 @@ func initLibraryRegistry(_ context.Context) *machine.LibraryRegistry {
 	return registry
 }
 
-func setupSignals() {
+func setupSignals(quiet bool) {
 	sigChan := make(chan os.Signal, 1)
 	// Notify the channel about SIGQUIT signals
 	signal.Notify(sigChan, syscall.SIGQUIT)
@@ -107,12 +108,12 @@ func setupSignals() {
 		}
 	}()
 
-	// ... rest of your program ...
-	fmt.Fprintln(os.Stderr, "Program running, send SIGQUIT (Ctrl+\\) to dump stacks.")
+	if !quiet {
+		fmt.Fprintln(os.Stderr, "Program running, send SIGQUIT (Ctrl+\\) to dump stacks.")
+	}
 }
 
 func main() {
-	setupSignals()
 	var fin io.RuneReader
 	var fd *os.File
 
@@ -156,7 +157,9 @@ func main() {
 	// include file if any
 	if opts.File != "" {
 		var err1 error
-		log.Printf("reading file %q", opts.File)
+		if !opts.Quiet {
+			log.Printf("reading file %q", opts.File)
+		}
 		fd, err1 = os.Open(opts.File)
 		if err1 != nil {
 			Failf(err1, "Cannot open file %s", opts.File)
@@ -166,6 +169,7 @@ func main() {
 		return
 	}
 	// interactive REPL using the repl package
+	setupSignals(opts.Quiet)
 	runREPL(ctx, env)
 }
 

--- a/go/extensions/files/prim_files_test.go
+++ b/go/extensions/files/prim_files_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package files_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	extfiles "github.com/aalpar/wile/go/extensions/files"
+	extio "github.com/aalpar/wile/go/extensions/io"
+	"github.com/aalpar/wile/go/values"
+	"github.com/aalpar/wile/go/wile"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// newEngine creates a Wile engine with core + io + files extensions.
+func newEngine(t *testing.T) *wile.Engine {
+	t.Helper()
+	engine, err := wile.NewEngine(
+		wile.WithExtension(extio.Extension),
+		wile.WithExtension(extfiles.Extension),
+	)
+	qt.Assert(t, err, qt.IsNil)
+	return engine
+}
+
+// eval runs Scheme code and returns the result.
+func eval(t *testing.T, engine *wile.Engine, code string) wile.Value {
+	t.Helper()
+	result, err := engine.Eval(context.Background(), code)
+	qt.Assert(t, err, qt.IsNil)
+	return result
+}
+
+// evalExpectError runs Scheme code and expects an error.
+func evalExpectError(t *testing.T, engine *wile.Engine, code string) {
+	t.Helper()
+	_, err := engine.Eval(context.Background(), code)
+	qt.Assert(t, err, qt.IsNotNil)
+}
+
+// writeTestFile creates a file with the given contents in the temp directory.
+func writeTestFile(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(contents), 0o644)
+	qt.Assert(t, err, qt.IsNil)
+	return path
+}
+
+func TestOpenInputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "hello.txt", "hello world")
+
+	// Happy path: opens file and returns an input port
+	result := eval(t, engine, fmt.Sprintf(`(input-port? (open-input-file %q))`, path))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+
+	// Nonexistent file: error
+	evalExpectError(t, engine, fmt.Sprintf(`(open-input-file %q)`, filepath.Join(dir, "nonexistent.txt")))
+
+	// Wrong type: error
+	evalExpectError(t, engine, `(open-input-file 42)`)
+}
+
+func TestOpenOutputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	outPath := filepath.Join(dir, "out.txt")
+
+	// Happy path: creates file and returns an output port
+	result := eval(t, engine, fmt.Sprintf(`(output-port? (open-output-file %q))`, outPath))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+
+	// File should exist after opening
+	_, err := os.Stat(outPath)
+	c.Assert(err, qt.IsNil)
+
+	// Wrong type: error
+	evalExpectError(t, engine, `(open-output-file 42)`)
+}
+
+func TestOpenBinaryInputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "data.bin", "\x00\x01\x02")
+
+	// Happy path: opens file and returns an input port
+	result := eval(t, engine, fmt.Sprintf(`(input-port? (open-binary-input-file %q))`, path))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+
+	// Nonexistent file: error
+	evalExpectError(t, engine, fmt.Sprintf(`(open-binary-input-file %q)`, filepath.Join(dir, "nope.bin")))
+}
+
+func TestOpenBinaryOutputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	outPath := filepath.Join(dir, "out.bin")
+
+	// Happy path: creates file and returns an output port
+	result := eval(t, engine, fmt.Sprintf(`(output-port? (open-binary-output-file %q))`, outPath))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+
+	// File should exist
+	_, err := os.Stat(outPath)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestFileExistsQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "exists.txt", "content")
+
+	// Existing file returns #t
+	result := eval(t, engine, fmt.Sprintf(`(file-exists? %q)`, path))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+
+	// Missing file returns #f
+	result = eval(t, engine, fmt.Sprintf(`(file-exists? %q)`, filepath.Join(dir, "missing.txt")))
+	c.Assert(result.Internal(), qt.Equals, values.FalseValue)
+
+	// Wrong type: error
+	evalExpectError(t, engine, `(file-exists? 42)`)
+}
+
+func TestDeleteFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "delete-me.txt", "content")
+
+	// Deletes existing file
+	eval(t, engine, fmt.Sprintf(`(delete-file %q)`, path))
+	_, err := os.Stat(path)
+	c.Assert(os.IsNotExist(err), qt.IsTrue)
+
+	// Error on nonexistent file
+	evalExpectError(t, engine, fmt.Sprintf(`(delete-file %q)`, filepath.Join(dir, "nope.txt")))
+
+	// Wrong type: error
+	evalExpectError(t, engine, `(delete-file 42)`)
+}
+
+func TestCallWithInputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "read-me.txt", "hello")
+
+	// Reads file contents via proc
+	result := eval(t, engine, fmt.Sprintf(
+		`(call-with-input-file %q (lambda (port) (read-char port)))`, path))
+	c.Assert(result.Internal().(*values.Character).Value, qt.Equals, 'h')
+
+	// Port is passed as argument
+	result = eval(t, engine, fmt.Sprintf(
+		`(call-with-input-file %q (lambda (port) (input-port? port)))`, path))
+	c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+}
+
+func TestCallWithOutputFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	outPath := filepath.Join(dir, "write-me.txt")
+
+	// Writes via proc
+	eval(t, engine, fmt.Sprintf(
+		`(call-with-output-file %q (lambda (port) (write-char #\A port)))`, outPath))
+
+	data, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, "A")
+}
+
+func TestWithInputFromFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	path := writeTestFile(t, dir, "input.txt", "X")
+
+	// Redirects current-input-port during thunk
+	result := eval(t, engine, fmt.Sprintf(
+		`(with-input-from-file %q (lambda () (read-char)))`, path))
+	c.Assert(result.Internal().(*values.Character).Value, qt.Equals, 'X')
+}
+
+func TestWithOutputToFile(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+	dir := t.TempDir()
+
+	outPath := filepath.Join(dir, "output.txt")
+
+	// Redirects current-output-port during thunk
+	eval(t, engine, fmt.Sprintf(
+		`(with-output-to-file %q (lambda () (write-char #\Z)))`, outPath))
+
+	data, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, "Z")
+}

--- a/go/parser/parser_coverage_test.go
+++ b/go/parser/parser_coverage_test.go
@@ -658,7 +658,7 @@ func TestCoverage_ComplexInfNan(t *testing.T) {
 			name:      "1.0+nan.0i",
 			input:     "1.0+nan.0i",
 			checkReal: func(f float64) bool { return f == 1.0 },
-			checkImag: func(f float64) bool { return math.IsNaN(f) },
+			checkImag: math.IsNaN,
 		},
 		{
 			name:      "+inf.0+inf.0i",

--- a/go/values/port_coverage_test.go
+++ b/go/values/port_coverage_test.go
@@ -194,8 +194,8 @@ func TestStringOutputPort_Basic(t *testing.T) {
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
 
-	// Write
-	n, err := port.Write([]byte("hi"))
+	// WriteString
+	n, err := port.WriteString("hi")
 	c.Assert(err, qt.IsNil)
 	c.Assert(n, qt.Equals, 2)
 
@@ -274,8 +274,8 @@ func TestCharacterOutputPort_Basic(t *testing.T) {
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
 
-	// Write
-	n, err := port.Write([]byte("hi"))
+	// WriteString
+	n, err := port.WriteString("hi")
 	c.Assert(err, qt.IsNil)
 	c.Assert(n, qt.Equals, 2)
 

--- a/go/values/value_methods_coverage_test.go
+++ b/go/values/value_methods_coverage_test.go
@@ -76,8 +76,8 @@ func TestNativeError_EqualTo_Coverage(t *testing.T) {
 
 	c.Assert(err1.EqualTo(err1), qt.IsTrue)
 	c.Assert(err1.EqualTo(err2), qt.IsTrue)
-	c.Assert(err1.EqualTo(err3), qt.IsFalse)  // different message
-	c.Assert(err1.EqualTo(err4), qt.IsFalse)  // different kind
+	c.Assert(err1.EqualTo(err3), qt.IsFalse) // different message
+	c.Assert(err1.EqualTo(err4), qt.IsFalse) // different kind
 	c.Assert(err1.EqualTo(NewInteger(1)), qt.IsFalse)
 
 	var nilErr *NativeError

--- a/plans/RELEASE_1_0_READINESS.md
+++ b/plans/RELEASE_1_0_READINESS.md
@@ -1,0 +1,198 @@
+# Wile 1.0 Release Readiness Assessment
+
+**Current version:** v0.8.6-alpha
+**Date:** 2026-02-03
+
+---
+
+## Executive Summary
+
+Wile is a well-architected Scheme implementation with a clean embedding API, comprehensive standard library coverage, and solid testing infrastructure. The project is substantially complete but has specific gaps that prevent a credible 1.0 release. The gaps fall into three categories: **correctness issues** (things that silently produce wrong results), **completeness issues** (things that are missing), and **release hygiene** (things expected of a 1.0 project).
+
+---
+
+## 1. Blocking: Correctness Issues
+
+These produce wrong behavior and undermine trust in the implementation.
+
+### 1.1 ~~BigInteger Overflow Promotion~~ — RESOLVED
+
+Implemented in commit `312cf48` ("feat: integer overflow promotion and short float exponent suffixes"). The helpers `addInt64`, `subInt64`, `mulInt64`, and `negateInt64` in `go/values/integer.go:97-136` detect overflow and promote to `BigInteger`. All `Integer` arithmetic methods (`Add`, `Subtract`, `Multiply`, `Abs`, `Negate`) use these helpers. Tests in `go/values/integer_test.go` verify `MaxInt64+1`, `MinInt64-1`, `MaxInt64*2`, `MinInt64*2`, `Negate(MinInt64)`, and `Abs(MinInt64)` all produce `*BigInteger`. The TODO.md entry is **stale and should be closed.**
+
+### 1.2 ~~R7RS Conformance Test Suite Is Skipped~~ — RESOLVED
+
+Re-activated in commit `c487f61` ("fix: re-activate R7RS conformance tests and fix short exponent complex parsing"). The test is now running in CI with a 5-minute timeout.
+
+### 1.3 ~~Parser Panic on Datum Comments~~ — RESOLVED
+
+Fixed in commit `a619591` ("fixup comment parsing error"). Added proper EOF handling for datum comments and fixed case-insensitive prefix matching. Existing datum comment tests pass. No reproducing test case for the original panic was ever identified; the parser now has proper error handling at all datum comment code paths.
+
+### 1.4 ~~Unterminated Extended Symbol Bug~~ — RESOLVED
+
+Fixed in commit `829ef8d` ("fix: error on unterminated extended symbols and strings"), merged via PR #73. Both `readExtendedSymbol()` and `readString()` now convert `io.EOF` to `TokenizerError` at all exit points (`go/tokenizer/tokenizer.go:2003-2004`, `2018-2019`). Tests in `go/tokenizer/edge_cases_test.go` (`TestUnterminatedExtendedSymbol`, `TestExtendedSymbolEscapeErrors`) verify that `|foo`, `|foo\`, and `|foo\x` all produce proper errors. The TODO.md entry is **stale and should be closed.**
+
+---
+
+## 2. Blocking: Completeness Issues
+
+### 2.1 Missing Numeric Features
+
+| Feature | R7RS Section | Status |
+|---------|-------------|--------|
+| ~~Inexact digit placeholder (`1.2###`)~~ | ~~§7.1.1~~ | **RESOLVED** — implemented in `5ee4a04` |
+| ~~Non-decimal base fractions (`#x10/2`)~~ | ~~§7.1.1~~ | **RESOLVED** — implemented in tokenizer |
+| ~~`(read)` returning `eof-object` on empty port~~ | ~~§6.13.2~~ | **RESOLVED** — implemented in `prim_read_write.go`, tested in `prim_eof_object_test.go` |
+
+All numeric feature gaps in this section have been resolved.
+
+### 2.2 ~~REPL Startup Message to stdout~~ — RESOLVED
+
+`setupSignals()` moved to REPL-only path (no longer runs in file execution mode). Added `--quiet`/`-q` flag to suppress informational messages. The `log.Printf` for file reading is also gated on `!opts.Quiet`.
+
+---
+
+## 3. Blocking: Release Hygiene
+
+### 3.1 ~~Documentation Consistency~~ — RESOLVED
+
+README usage example is correct (`--file` with double dash). TODO.md, conformance plan, and semantic differences doc are now consistent: all R7RS conformance issues are resolved. Documentation reconciled.
+
+### 3.2 ~~CHANGELOG~~ — RESOLVED
+
+CHANGELOG.md created in commit `bf7f4fd`.
+
+### 3.3 Extension Test Coverage
+
+**Packages with 0% test coverage (no test files at all):**
+
+| Package | Risk |
+|---------|------|
+| `extensions/eval` | Medium — eval is core functionality |
+| `extensions/exceptions` | Medium — exception handling is user-facing |
+| ~~`extensions/files`~~ | ~~High~~ — **RESOLVED**: 10 tests covering all primitives |
+| `extensions/math` | Medium — math extensions affect numeric correctness |
+| `extensions/system` | Low — system interface |
+| `extensions/threads` | Low — documented as experimental |
+| `forms` | Low — covered indirectly by integration tests |
+| `repl` | Low — UI code |
+| `cmd` | Low — thin entry point |
+
+The `extensions/files` gap is the most concerning. File I/O primitives without unit tests is a risk for a 1.0.
+
+### 3.4 Core Package Coverage
+
+| Package | Coverage | Assessment |
+|---------|----------|------------|
+| `define_syntax` | 97.4% | Excellent |
+| `utils` | 86.6% | Good |
+| `registry/core` | 85.6% | Good |
+| `tokenizer` | 83.0% | Good |
+| `syntax` | 79.2% | Acceptable |
+| `validate` | 74.8% | Acceptable |
+| `environment` | 73.2% | Needs improvement |
+| `parser` | 70.1% | Needs improvement |
+| `wile` | 70.1% | Acceptable for API package |
+| `machine` | 65.9% | Below target — this is the largest package |
+| `registry` | 62.7% | Below target |
+| `match` | 61.5% | Below target |
+| `values` | 57.9% | Below target — fundamental types |
+| `runtime` | 51.4% | Below target |
+
+For a 1.0, the `values` and `machine` packages are the foundation. 57.9% and 65.9% coverage respectively means substantial code paths are untested.
+
+---
+
+## 4. Non-Blocking but Recommended
+
+### 4.1 Code Quality Issues
+
+- **Parser error return:** `go/parser/parser.go:134` has a `FIXME: rework error return` — not a crash risk but tech debt in a core path.
+- **`machine_context.go` and `operation_apply.go`:** Marked as needing unit tests via FIXME comments.
+- **EmptyList/Void type safety:** Three files note these should be proper types, not sentinel values. Not a correctness issue but a design debt.
+
+### 4.2 Missing Embedding API Features
+
+Per TODO.md, these are not implemented:
+- BigInteger/BigFloat value constructors in the `wile` package
+- Reflection API (list bound symbols, type predicates from Go)
+- Event callbacks for expansion/compilation
+
+These are nice-to-have for 1.0 but not blocking. The current API is functional and well-documented.
+
+### 4.3 Performance
+
+Performance is explicitly deprioritized per project vision. No benchmarks exist. This is fine for 1.0 given the stated positioning, but a benchmark suite would set a baseline for regressions.
+
+---
+
+## 5. What's Ready
+
+These areas are solid and need no further work for 1.0:
+
+| Area | Status |
+|------|--------|
+| Core Scheme semantics | Working correctly for common use cases |
+| Hygienic macros (sets of scopes) | Fully implemented |
+| Bytecode compiler + stack VM | Working with proper tail calls |
+| Continuations + `dynamic-wind` | Implemented |
+| Standard libraries (15/16 R7RS) | Comprehensive |
+| Embedding API | Clean, documented, with examples |
+| Dependencies | Minimal (5 direct), production-grade |
+| CI pipeline | Lint + build + test on every push |
+| Architecture | Clean separation, well-documented packages |
+| Licensing | Apache 2.0, copyright headers present |
+
+---
+
+## 6. Proposed 1.0 Checklist
+
+### Must-Do (Release Blockers)
+
+- [x] ~~Verify BigInteger overflow promotion status~~ — Confirmed implemented in `312cf48`. Close stale TODO entry.
+- [x] ~~Fix parser panic on datum comment edge cases~~ — Fixed in `a619591`. Parser has proper error handling at all datum comment paths.
+- [x] ~~Fix `(read)` to return `eof-object` on empty port~~ — Implemented and tested in `prim_eof_object_test.go`.
+- [x] ~~Fix unterminated `|...|` symbol to error instead of succeed~~ — Fixed in `829ef8d` (PR #73).
+- [x] ~~Unskip `TestR7RSConformance`~~ — Re-activated in `c487f61`.
+- [x] ~~Move REPL startup banner to stderr; add `--quiet` flag~~ — `setupSignals()` moved to REPL-only path, `--quiet`/`-q` flag added
+- [x] ~~`eval` requires two arguments~~ — This is correct per R7RS §6.12; the environment-specifier is required, not optional.
+- [x] ~~Reconcile documentation: TODO.md, conformance plan, semantic differences doc, README~~ — All consistent
+- [x] ~~Fix README usage example (`-file` → `--file`)~~ — Already correct
+- [x] ~~Create CHANGELOG.md or release notes~~ — Created in `bf7f4fd`
+- [x] ~~Add tests for `extensions/files` package~~ — 10 tests covering all primitives
+- [x] ~~Inexact digit placeholder and non-decimal base fractions~~ — Implemented in `5ee4a04`
+
+### Should-Do (Strengthen the Release)
+
+- [ ] Increase `values` package test coverage above 70%
+- [ ] Increase `machine` package test coverage above 75%
+- [ ] Add tests for `extensions/eval` and `extensions/exceptions`
+- [ ] Add BigInteger/BigFloat constructors to `wile` public API
+- [ ] Address `parser.go:134` FIXME for error return
+- [ ] Add unit tests for `machine_context.go` functions marked with FIXME
+- [ ] Create a basic benchmark suite for regression detection
+
+### Nice-to-Have (Can Follow in 1.1)
+
+- [ ] EmptyList/Void as proper types instead of sentinel values
+- [ ] Reflection API for embedding
+- [ ] Event callbacks for expansion/compilation
+- [ ] Performance optimization phases (from OPTIMIZATION_PLAN.md)
+- [ ] SRFI-18 threading
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| ~~Silent integer overflow~~ | ~~Medium~~ | ~~High~~ | Resolved in `312cf48` |
+| Parser crash on malformed input | Low | High | Fix datum comment panic |
+| Users rely on R7RS claims that aren't met | Medium | Medium | Honest documentation |
+| File I/O bugs in untested extensions | Low | Medium | Add extension tests |
+| API breaking changes needed post-1.0 | Low | High | Review `wile` package API stability now |
+
+---
+
+## Conclusion
+
+The project is roughly 90% of the way to a credible 1.0. The remaining work is concentrated in three areas: fixing a small number of correctness issues, adding tests for undertested packages, and reconciling documentation so it accurately reflects the implementation state. None of the gaps are architectural — the foundation is sound.


### PR DESCRIPTION
## Summary

- Add `--quiet`/`-q` flag to suppress informational messages (REPL banner, file-reading log)
- Move `setupSignals()` to REPL-only path so it no longer runs during file execution
- Add 10 tests for `extensions/files` covering all file I/O primitives
- Fix 4 lint issues (unlambda, preferStringWriter, goimports formatting)
- Reconcile TODO.md and release readiness plan with current project state

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes (all tests green)
- [x] `echo "(+ 1 2)" | ./dist/scheme -q` outputs `3` with no banner
- [x] `./dist/scheme -q --file example.scm` suppresses log output
- [x] `./dist/scheme` REPL still shows SIGQUIT message when not quiet
- [x] All 10 `extensions/files` tests pass