### PR TITLE
refactor: remove unnecessary syntax->datum in quasisyntax tests

### DIFF
--- a/go/integration/quasisyntax_test.go
+++ b/go/integration/quasisyntax_test.go
@@ -268,15 +268,15 @@ func TestQuasisyntaxRecursive(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Define a recursive macro using quasisyntax
+	// Demonstrates transparent syntax operations: car, cdr, cadr, cddr work directly on stx
 	_, err = engine.Eval(context.Background(), `
 		(define-syntax my-list
 		  (lambda (stx)
-		    (let ((datum (syntax->datum stx)))
-		      (if (null? (cdr datum))
-		          (quasisyntax '())
-		          (let ((first (cadr datum))
-		                (rest (cons 'my-list (cddr datum))))
-		            (quasisyntax (cons #,first #,rest)))))))
+		    (if (null? (cdr stx))
+		        (quasisyntax '())
+		        (let ((first (cadr stx))
+		              (rest (cons 'my-list (cddr stx))))
+		          (quasisyntax (cons #,first #,rest))))))
 	`)
 	c.Assert(err, qt.IsNil)
 


### PR DESCRIPTION
## Summary

Removes unnecessary `syntax->datum` conversion from `TestQuasisyntaxRecursive` to fully demonstrate transparent syntax operations working as intended.

## Context

After PR #84 made `car`, `cdr`, `cadr`, `cddr`, etc. work transparently on syntax objects via the `Tuple` interface, the test still had a leftover `syntax->datum` wrapper that is no longer needed.

## Changes

**Before:**
```scheme
(define-syntax my-list
  (lambda (stx)
    (let ((datum (syntax->datum stx)))  ; ❌ Unnecessary!
      (if (null? (cdr datum))
          ...
          (let ((first (cadr datum))
                (rest (cons 'my-list (cddr datum))))
```

**After:**
```scheme
(define-syntax my-list
  (lambda (stx)
    (if (null? (cdr stx))  ; ✅ Works directly!
        ...
        (let ((first (cadr stx))
              (rest (cons 'my-list (cddr stx))))
```

## Benefits

- Demonstrates transparent syntax operations working perfectly
- Cleaner, more idiomatic macro code
- Shows the value of the Tuple interface change from PR #84

## Testing

```bash
go test -v -run TestQuasisyntaxRecursive ./integration/  # Passes
go test -v -run Quasisyntax ./integration/               # All 28 tests pass
```

## Related

- PR #84: feat: comprehensive quasisyntax test coverage and transparent syntax operations