### PR TITLE
chore: set 1.0.0 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [1.0.0] - UNRELEASED
+## [1.0.0] - 2026-02-04
 
 ### Added
 


### PR DESCRIPTION
## Summary
- Stamp the 1.0.0 release date as 2026-02-04 in CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)