### PR TITLE
feat: multi-platform builds with dist/{os}/{arch} layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           args: -v ./...
 
       - name: Build
-        run: make build
+        run: make build-all
 
       - name: Test
         run: make test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Interactive REPL with readline support and debug commands
 - File execution mode with positional argument and `--file` flag
 - SIGQUIT handler for goroutine stack dumps
-- Docker build support with cross-platform compilation
+- Multi-platform builds: `dist/{os}/{arch}/scheme` layout with targets for darwin/linux on arm64/amd64
+- Docker build support with `TARGETOS`/`TARGETARCH` platform awareness
+- CI builds all four OS/architecture combinations
 - R7RS conformance test suite running in CI
 

--- a/Makefile
+++ b/Makefile
@@ -22,30 +22,61 @@ DOCKER_PLATFORM ?=
 DOCKER_SHELL ?=
 
 
-# Build the scheme binary to ./dist/scheme with embedded git SHA and version.
+# Build the scheme binary for the current platform to ./dist/{os}/{arch}/scheme.
 # Rebuilds only when Go source files change.
 #   make build
 #
-# Cross-compile for a specific OS/architecture:
-#   GOOS=linux GOARCH=amd64 make build    # Linux x86-64
-#   GOOS=linux GOARCH=arm64 make build    # Linux ARM64
-#   GOOS=darwin GOARCH=arm64 make build   # macOS Apple Silicon
-#   GOOS=darwin GOARCH=amd64 make build   # macOS Intel
-#   GOOS=windows GOARCH=amd64 make build  # Windows x86-64
+# Build for a specific OS/architecture:
+#   make build-darwin-arm64     # macOS Apple Silicon
+#   make build-darwin-amd64     # macOS Intel
+#   make build-linux-arm64      # Linux ARM64
+#   make build-linux-amd64      # Linux x86-64
+#   make build-all              # All OS/arch combinations
 #
 # Docker build:
 #   docker build -f docker/Dockerfile -t wile .
-#   docker run wile                                  # run tests
-#   docker run wile ./dist/scheme --file example.scm # run a file
+#   docker run wile ./dist/${TARGETOS}/${TARGETARCH}/scheme --file example.scm
 #
 # Cross-platform Docker build:
 #   docker build --platform linux/amd64 -f docker/Dockerfile -t wile .
 #   docker build --platform linux/arm64 -f docker/Dockerfile -t wile .
-.PHONY: build
-build: $(DIST_DIR)/$(MY_BIN)
 
-$(DIST_DIR)/$(MY_BIN): $(SOURCES) $(EMBED_SOURCES)
-	$(GO_BUILD) -o $(DIST_DIR)/$(MY_BIN) -ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)" ./cmd
+LDFLAGS=-ldflags "-X main.BuildSHA=$(BUILD_SHA) -X main.BuildVersion=$(BUILD_VERSION)"
+
+# Detect host OS and architecture using Go conventions
+HOST_OS := $(shell $(GO) env GOOS)
+RAW_ARCH := $(shell uname -m)
+ifeq ($(RAW_ARCH),x86_64)
+HOST_ARCH := amd64
+else
+HOST_ARCH := $(RAW_ARCH)
+endif
+
+.PHONY: build
+build: $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN)
+
+# Generic build rule for any OS/arch combination
+$(DIST_DIR)/%/$(MY_BIN): $(SOURCES) $(EMBED_SOURCES)
+	$(eval OS_ARCH := $(subst /, ,$*))
+	$(eval TARGET_OS := $(word 1,$(OS_ARCH)))
+	$(eval TARGET_ARCH := $(word 2,$(OS_ARCH)))
+	@mkdir -p $(DIST_DIR)/$*
+	GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) $(GO_BUILD) -o $(DIST_DIR)/$*/$(MY_BIN) $(LDFLAGS) ./cmd
+
+.PHONY: build-darwin-arm64
+build-darwin-arm64: $(DIST_DIR)/darwin/arm64/$(MY_BIN)
+
+.PHONY: build-darwin-amd64
+build-darwin-amd64: $(DIST_DIR)/darwin/amd64/$(MY_BIN)
+
+.PHONY: build-linux-arm64
+build-linux-arm64: $(DIST_DIR)/linux/arm64/$(MY_BIN)
+
+.PHONY: build-linux-amd64
+build-linux-amd64: $(DIST_DIR)/linux/amd64/$(MY_BIN)
+
+.PHONY: build-all
+build-all: build-darwin-arm64 build-darwin-amd64 build-linux-arm64 build-linux-amd64
 
 # Compile tests for all packages without running them.
 # Useful for verifying that tests compile after refactoring.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,12 @@
 
 FROM golang:1.25-bookworm
 
+# TARGETOS and TARGETARCH are set automatically by Docker from --platform (e.g., linux/amd64)
+ARG TARGETOS=linux
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS}
+ENV TARGETARCH=${TARGETARCH}
+
 # Install GNU development tools and build essentials
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Core Tools
@@ -69,11 +75,11 @@ RUN go mod download
 # Copy the rest of the source
 COPY . .
 
-# Build the project
-RUN make build
+# Build the project for the target OS/architecture
+RUN make build-${TARGETOS}-${TARGETARCH}
 
 # Verify build
-RUN ./dist/scheme --version || true
+RUN ./dist/${TARGETOS}/${TARGETARCH}/scheme --version || true
 
 # Default command: run tests
 CMD ["make", "test"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -36,7 +36,7 @@ shell: build
 
 .PHONY: repl
 repl: build
-	$(DOCKER) run --rm -it $(PLATFORM_FLAG) $(IMAGE_NAME)$(TAG_SUFFIX) ../dist/scheme
+	$(DOCKER) run --rm -it $(PLATFORM_FLAG) $(IMAGE_NAME)$(TAG_SUFFIX) bash -c './dist/$$TARGETOS/$$TARGETARCH/scheme'
 
 .PHONY: dev
 dev: build


### PR DESCRIPTION
## Summary
- Restructure dist output to `dist/{os}/{arch}/scheme` (e.g., `dist/linux/amd64/scheme`, `dist/darwin/arm64/scheme`)
- Add per-platform Make targets: `build-darwin-arm64`, `build-darwin-amd64`, `build-linux-arm64`, `build-linux-amd64`, `build-all`
- Generic Makefile rule handles any OS/arch combination via pattern matching
- Dockerfile uses Docker's `TARGETOS`/`TARGETARCH` build args, promoted to ENV for runtime access
- CI now builds all four OS/arch combinations

## Test plan
- [ ] `make build` produces `dist/{host_os}/{host_arch}/scheme`
- [ ] `make build-all` produces all four binaries
- [ ] CI passes with `build-all`
- [ ] Docker build with `--platform linux/amd64` places binary in `dist/linux/amd64/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)