### PR TITLE
feat: add GoReleaser for automated GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go.sum
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+version: 2
+
+builds:
+  - id: scheme
+    binary: scheme
+    dir: ./cmd
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -X main.BuildSHA={{ .ShortCommit }} -X main.BuildVersion={{ .Tag }}
+
+archives:
+  - id: scheme
+    ids:
+      - scheme
+    name_template: "wile-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github-native
+
+release:
+  header: |
+    ## Wile Scheme {{ .Tag }}
+  footer: |
+    **Full Changelog**: https://github.com/aalpar/wile/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Automated release builds with prebuilt binaries for darwin/linux on arm64/amd64
+
 ## [1.0.0] - 2026-02-04
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ DIST_DIR=./dist
 TEST_DIR=./test
 MY_BIN=scheme
 
+GORELEASER=goreleaser
+
 DOCKER_IMAGE ?= wile
 DOCKER_PLATFORM ?=
 DOCKER_SHELL ?=
@@ -92,7 +94,7 @@ buildtest:
 # Run all tests with verbose output.
 #   make test
 .PHONY: test
-test:
+test: build
 	$(GO_TEST) -v ./...
 
 # Run all benchmarks with memory allocation statistics.
@@ -208,6 +210,26 @@ bump-minor:
 .PHONY: bump-patch
 bump-patch:
 	$(SH_TOOLS_DIR)/bump-version.sh patch
+
+# Validate the .goreleaser.yml configuration.
+#   make release-check
+.PHONY: release-check
+release-check:
+	$(GORELEASER) check
+
+# Build a local snapshot release without publishing.
+# Produces archives and checksums in ./dist/.
+#   make release-snapshot
+.PHONY: release-snapshot
+release-snapshot:
+	$(GORELEASER) release --snapshot --clean
+
+# Build and publish a release to GitHub.
+# Requires a clean git tag (v*) on HEAD and GITHUB_TOKEN set.
+#   make release
+.PHONY: release
+release:
+	$(GORELEASER) release --clean
 
 # Build the Docker image containing the Go toolchain and compiled binary.
 # Delegates to tools/sh/docker-build.sh.

--- a/integration/r7rs_test.go
+++ b/integration/r7rs_test.go
@@ -33,9 +33,9 @@ func getProjectRoot() string {
 	return filepath.Join(filepath.Dir(filename), "..")
 }
 
-// getSchemeBinary returns the path to the scheme binary.
+// getSchemeBinary returns the path to the scheme binary for the current platform.
 func getSchemeBinary() string {
-	return filepath.Join(getProjectRoot(), "dist", "scheme")
+	return filepath.Join(getProjectRoot(), "dist", runtime.GOOS, runtime.GOARCH, "scheme")
 }
 
 // getLibPath returns the path to the lib/ directory.


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yml` (v2) and `.github/workflows/release.yml` triggered on `v*` tag pushes
- Builds `scheme` binary for darwin/linux × arm64/amd64 with tar.gz archives and checksums
- Add `release-check`, `release-snapshot`, and `release` Make targets
- Fix integration test binary path to use `dist/{os}/{arch}` layout from multi-platform builds
- Add `build` dependency to `make test` since integration tests require the binary

## Test plan

- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean` produces 4 archives + checksums
- [x] `make test` passes (integration tests find binary at new path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)