### PR TITLE
feat: support Go 1.23 by removing weak package dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.23"
           cache-dependency-path: go.sum
 
       - uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.23"
           cache-dependency-path: go.sum
 
       - uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aalpar/wile
 
-go 1.25
+go 1.23
 
 require (
 	github.com/ergochat/readline v0.1.3

--- a/internal/extensions/io/prim_ports.go
+++ b/internal/extensions/io/prim_ports.go
@@ -88,11 +88,11 @@ func PrimOutputPortOpenQ(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.1: Closes the resource associated with port.
 func PrimClosePort(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
-	p, ok := o.(values.Port)
+	_, ok := o.(values.Port)
 	if !ok {
 		return values.WrapForeignErrorf(values.ErrNotAnInputPort, "close-port: expected a port but got %T", o)
 	}
-	err := p.Close()
+	err := closePort(o)
 	if err != nil {
 		return values.WrapForeignErrorf(err, "close-port: %v", err)
 	}
@@ -234,7 +234,7 @@ func PrimCallWithPort(_ context.Context, mc *machine.MachineContext) error {
 	runErr := sub.Run()
 
 	// Close the port after proc returns (even if there was an error)
-	closePort(portArg)
+	_ = closePort(portArg)
 
 	// Handle any errors from running the procedure
 	if runErr != nil {
@@ -252,10 +252,15 @@ func PrimCallWithPort(_ context.Context, mc *machine.MachineContext) error {
 	return nil
 }
 
-// closePort closes a port regardless of its type.
-func closePort(o values.Value) {
+// closePort closes a port regardless of its type and evicts
+// any cached tokenizer/parser for the port.
+func closePort(o values.Value) error {
+	var err error
 	p, ok := o.(values.Port)
 	if ok {
-		p.Close() //nolint:errcheck
+		err = p.Close()
 	}
+	delete(Tokenizers, o)
+	delete(Parsers, o)
+	return err
 }

--- a/internal/extensions/io/prim_read_write.go
+++ b/internal/extensions/io/prim_read_write.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"io"
 	"unicode/utf8"
-	"weak"
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/internal/parser"
@@ -116,13 +115,15 @@ func PrimRead(_ context.Context, mc *machine.MachineContext) error {
 	}
 
 	prss, ok := Parsers[port]
-	if !ok || prss.Value() == nil {
-		prss = weak.Make(parser.NewParser(mc.EnvironmentFrame(), true, port))
+	if !ok || prss == nil {
+		prss = parser.NewParser(mc.EnvironmentFrame(), true, port)
 		Parsers[port] = prss
 	}
-	syn, err := prss.Value().ReadSyntax(context.TODO())
+	syn, err := prss.ReadSyntax(context.TODO())
 	if err != nil {
 		if errors.Is(err, io.EOF) {
+			// Port is exhausted; evict the cached parser.
+			delete(Parsers, port)
 			mc.SetValue(values.EOFObject)
 			return nil
 		}
@@ -163,12 +164,14 @@ func PrimReadToken(_ context.Context, mc *machine.MachineContext) error {
 
 	tknz, ok := Tokenizers[port]
 	// Create a new tokenizer if none exists for the port
-	if !ok || tknz.Value() == nil {
-		tknz = weak.Make(tokenizer.NewTokenizer(port, false))
+	if !ok || tknz == nil {
+		tknz = tokenizer.NewTokenizer(port, false)
 		Tokenizers[port] = tknz
 	}
-	q, err := tknz.Value().Next()
+	q, err := tknz.Next()
 	if errors.Is(err, io.EOF) {
+		// Port is exhausted; evict the cached tokenizer.
+		delete(Tokenizers, port)
 		mc.SetValue(values.EOFObject)
 		return nil
 	}
@@ -206,13 +209,15 @@ func PrimReadSyntax(_ context.Context, mc *machine.MachineContext) error {
 
 	// Get or create a parser if one does not exist
 	prss, ok := Parsers[port]
-	if !ok || prss.Value() == nil {
-		prss = weak.Make(parser.NewParser(mc.EnvironmentFrame(), true, port))
+	if !ok || prss == nil {
+		prss = parser.NewParser(mc.EnvironmentFrame(), true, port)
 		Parsers[port] = prss
 	}
-	q, err := prss.Value().ReadSyntax(context.TODO())
+	q, err := prss.ReadSyntax(context.TODO())
 	if err != nil {
 		if errors.Is(err, io.EOF) {
+			// Port is exhausted; evict the cached parser.
+			delete(Parsers, port)
 			mc.SetValue(values.EOFObject)
 			return nil
 		}

--- a/internal/extensions/io/state.go
+++ b/internal/extensions/io/state.go
@@ -17,7 +17,6 @@ package io
 import (
 	"os"
 	"time"
-	"weak"
 
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/internal/tokenizer"
@@ -34,10 +33,22 @@ var (
 	currentOutputPortParam *machine.Parameter
 	// currentErrorPortParam is the parameter holding the current error port.
 	currentErrorPortParam *machine.Parameter
-	// Tokenizers caches tokenizers per input port using weak references.
-	Tokenizers map[values.Value]weak.Pointer[tokenizer.Tokenizer]
-	// Parsers caches parsers per input port using weak references.
-	Parsers map[values.Value]weak.Pointer[parser.Parser]
+	// Tokenizers caches tokenizers per input port.
+	//
+	// These are strong references: closing a port does not evict its cache
+	// entry, so the tokenizer (and its internal buffers) remain reachable
+	// as long as the port value itself is reachable as a map key. In
+	// long-running programs that open many transient ports, this can leak
+	// memory. If that becomes a problem, switch to weak.Pointer[T] (Go 1.24+)
+	// or add explicit eviction on port close.
+	//
+	// To diagnose: run with GODEBUG=gctrace=1 or use runtime/pprof to
+	// inspect heap; look for tokenizer.Tokenizer / parser.Parser objects
+	// retained via this map.
+	Tokenizers map[values.Value]*tokenizer.Tokenizer
+	// Parsers caches parsers per input port.
+	// Same retention caveat as Tokenizers above.
+	Parsers map[values.Value]*parser.Parser
 	// ProgramStartTime is used for current-jiffy to measure elapsed time.
 	ProgramStartTime = time.Now()
 )
@@ -53,8 +64,8 @@ func InitState() {
 	}
 	stateInitialized = true
 
-	Tokenizers = map[values.Value]weak.Pointer[tokenizer.Tokenizer]{}
-	Parsers = map[values.Value]weak.Pointer[parser.Parser]{}
+	Tokenizers = map[values.Value]*tokenizer.Tokenizer{}
+	Parsers = map[values.Value]*parser.Parser{}
 
 	// Initialize port parameters with default values
 	currentInputPortParam = machine.NewParameter(

--- a/registry/core/prim_read_extra_test.go
+++ b/registry/core/prim_read_extra_test.go
@@ -45,6 +45,74 @@ func TestReadSyntaxReturnsSyntaxObject(t *testing.T) {
 	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("foo"))
 }
 
+func TestReadEOFOnExhaustedPort(t *testing.T) {
+	// After reading all data, subsequent reads return eof-object
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "42")))
+			(read p)       ; consume the datum
+			(eof-object? (read p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestReadRepeatedEOF(t *testing.T) {
+	// Multiple reads past EOF all return eof-object
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "")))
+			(let ((a (read p))
+			      (b (read p)))
+				(and (eof-object? a) (eof-object? b))))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestReadSyntaxEOFOnExhaustedPort(t *testing.T) {
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "foo")))
+			(read-syntax p)
+			(eof-object? (read-syntax p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestReadTokenEOFOnExhaustedPort(t *testing.T) {
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "x")))
+			(read-token p)
+			(eof-object? (read-token p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestClosePortThenRead(t *testing.T) {
+	// After close-port, reading returns eof-object (the cached parser
+	// was evicted by close-port, and a fresh read on the closed port
+	// yields EOF immediately).
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "42")))
+			(close-port p)
+			(eof-object? (read p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
+func TestCallWithPortClosesOnReturn(t *testing.T) {
+	// call-with-port closes the port after proc returns
+	result, err := runSchemeCode(t, `
+		(let ((p (open-input-string "hello")))
+			(call-with-port p
+				(lambda (port) (read port)))
+			(not (input-port-open? p)))
+	`)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+}
+
 func TestReadTokenReturnsToken(t *testing.T) {
 	// read-token should return a token object or value
 	result, err := runSchemeCode(t, `


### PR DESCRIPTION
## Summary

- Replace `weak.Pointer[T]` (Go 1.24+) with plain `*T` in the I/O extension's tokenizer/parser cache
- Evict cache entries on EOF (`read`, `read-syntax`, `read-token`), `close-port`, and `call-with-port`
- Unify port closing through `closePort()` which returns an error
- Lower `go.mod` and CI/release workflows from Go 1.25 to Go 1.23

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `make test` passes all packages
- [x] 6 new Scheme-level tests for EOF eviction, close-then-read, and call-with-port lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)