### PR TITLE
docs: add values import to RegisterPrimitive example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ val, ok := engine.Get("my-var")
 Register a Go function as a Scheme primitive:
 
 ```go
+import "github.com/aalpar/wile/values"
+
 engine.RegisterPrimitive(wile.PrimitiveSpec{
     Name:       "go-add",
     ParamCount: 2,


### PR DESCRIPTION
## Summary

- Add missing `values` package import to the `RegisterPrimitive` Go embedding example in the README, since the `Impl` function uses `values.Integer` and `values.NewInteger`

## Test plan

- [x] Verified example matches `example_test.go` usage pattern