### PR TITLE
feat: add R7RS square bracket support

### DIFF
--- a/internal/parser/bracket_test.go
+++ b/internal/parser/bracket_test.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aalpar/wile/environment"
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestParser_Brackets tests R7RS §2.1 square bracket support.
+// Square brackets [ and ] are equivalent to ( and ) but must match.
+func TestParser_Brackets(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name   string
+		in     string
+		expect values.Value
+	}{
+		{
+			name:   "empty bracket list",
+			in:     "[]",
+			expect: values.EmptyList,
+		},
+		{
+			name:   "bracket list with integers",
+			in:     "[1 2 3]",
+			expect: values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+		},
+		{
+			name:   "bracket improper list",
+			in:     "[a . b]",
+			expect: values.NewCons(values.NewSymbol("a"), values.NewSymbol("b")),
+		},
+		{
+			name:   "nested brackets",
+			in:     "[[a] [b]]",
+			expect: values.List(values.List(values.NewSymbol("a")), values.List(values.NewSymbol("b"))),
+		},
+		{
+			name:   "mixed parens and brackets - outer paren",
+			in:     "([a] (b))",
+			expect: values.List(values.List(values.NewSymbol("a")), values.List(values.NewSymbol("b"))),
+		},
+		{
+			name:   "mixed parens and brackets - outer bracket",
+			in:     "[(a) [b]]",
+			expect: values.List(values.List(values.NewSymbol("a")), values.List(values.NewSymbol("b"))),
+		},
+		{
+			name:   "quote with bracket",
+			in:     "'[a b]",
+			expect: values.List(values.NewSymbol("quote"), values.List(values.NewSymbol("a"), values.NewSymbol("b"))),
+		},
+		{
+			name:   "bracket list single element",
+			in:     "[x]",
+			expect: values.List(values.NewSymbol("x")),
+		},
+		{
+			name: "bracket improper list multiple elements",
+			in:   "[a b . c]",
+			expect: values.NewCons(
+				values.NewSymbol("a"),
+				values.NewCons(values.NewSymbol("b"), values.NewSymbol("c")),
+			),
+		},
+		{
+			name:   "deeply nested mixed delimiters",
+			in:     "[([a])]",
+			expect: values.List(values.List(values.List(values.NewSymbol("a")))),
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			env := environment.NewTopLevelEnvironment().Runtime()
+			p := NewParser(env, true, strings.NewReader(tc.in))
+			stx, err := p.ReadSyntax(context.Background())
+			c.Assert(err, qt.IsNil)
+			c.Assert(stx.UnwrapAll(), values.SchemeEquals, tc.expect)
+		})
+	}
+}
+
+// TestParser_BracketMismatch tests that bracket/paren mismatches are detected.
+func TestParser_BracketMismatch(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name        string
+		in          string
+		errContains string
+	}{
+		{
+			name:        "open paren close bracket",
+			in:          "(a]",
+			errContains: "mismatched delimiters",
+		},
+		{
+			name:        "open bracket close paren",
+			in:          "[a)",
+			errContains: "mismatched delimiters",
+		},
+		{
+			name:        "nested mismatch - inner",
+			in:          "[(a])",
+			errContains: "mismatched delimiters",
+		},
+		{
+			name:        "improper list mismatch",
+			in:          "(a . b]",
+			errContains: "mismatched delimiters",
+		},
+		{
+			name:        "improper list mismatch bracket",
+			in:          "[a . b)",
+			errContains: "mismatched delimiters",
+		},
+		{
+			name:        "unexpected close bracket at top level",
+			in:          "]",
+			errContains: "unexpected close ]",
+		},
+		{
+			name:        "unexpected close paren at top level",
+			in:          ")",
+			errContains: "unexpected close )",
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			env := environment.NewTopLevelEnvironment().Runtime()
+			p := NewParser(env, true, strings.NewReader(tc.in))
+			_, err := p.ReadSyntax(context.Background())
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tc.errContains)
+		})
+	}
+}
+
+// TestParser_BracketDatumLabels tests bracket support with datum labels.
+func TestParser_BracketDatumLabels(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name   string
+		in     string
+		expect values.Value
+	}{
+		{
+			name:   "datum label with bracket list",
+			in:     "#0=[a b]",
+			expect: values.List(values.NewSymbol("a"), values.NewSymbol("b")),
+		},
+		{
+			name:   "datum label reference in bracket",
+			in:     "[#0=a #0#]",
+			expect: values.List(values.NewSymbol("a"), values.NewSymbol("a")),
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			env := environment.NewTopLevelEnvironment().Runtime()
+			p := NewParser(env, true, strings.NewReader(tc.in))
+			stx, err := p.ReadSyntax(context.Background())
+			c.Assert(err, qt.IsNil)
+			// For datum label assignments, unwrap the assignment to get the actual list
+			unwrapped := stx.UnwrapAll()
+			c.Assert(unwrapped, values.SchemeEquals, tc.expect)
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -96,6 +96,42 @@ func (p *Parser) curr() tokenizer.Token {
 	return p.cur
 }
 
+// isListOpener returns true if the token type is ( or [.
+// Provided for symmetry with isListCloser; may be useful for future code.
+func (p *Parser) isListOpener(t tokenizer.TokenizerState) bool { //nolint:unused
+	return t == tokenizer.TokenizerStateOpenParen || t == tokenizer.TokenizerStateOpenBracket
+}
+
+// isListCloser returns true if the token type is ) or ].
+func (p *Parser) isListCloser(t tokenizer.TokenizerState) bool {
+	return t == tokenizer.TokenizerStateCloseParen || t == tokenizer.TokenizerStateCloseBracket
+}
+
+// matchingClose returns the expected close delimiter for the given opener.
+// R7RS §2.1: ( must match ), and [ must match ].
+func (p *Parser) matchingClose(opener tokenizer.TokenizerState) tokenizer.TokenizerState {
+	if opener == tokenizer.TokenizerStateOpenBracket {
+		return tokenizer.TokenizerStateCloseBracket
+	}
+	return tokenizer.TokenizerStateCloseParen
+}
+
+// delimiterString returns a human-readable string for a delimiter token type.
+func (p *Parser) delimiterString(t tokenizer.TokenizerState) string {
+	switch t {
+	case tokenizer.TokenizerStateOpenParen:
+		return "("
+	case tokenizer.TokenizerStateCloseParen:
+		return ")"
+	case tokenizer.TokenizerStateOpenBracket:
+		return "["
+	case tokenizer.TokenizerStateCloseBracket:
+		return "]"
+	default:
+		return "unknown"
+	}
+}
+
 // Text returns the current text being parsed.
 func (p *Parser) Text() string {
 	return p.toks.Text()
@@ -122,10 +158,10 @@ func (p *Parser) ReadSyntax(_ context.Context) (syntax.SyntaxValue, error) {
 			p.err = err
 			return nil, p.err
 		}
-		// R7RS: unexpected close parenthesis at top level is a read error
-		if q == nil && p.cur != nil && p.cur.Type() == tokenizer.TokenizerStateCloseParen {
+		// R7RS: unexpected close delimiter at top level is a read error
+		if q == nil && p.cur != nil && p.isListCloser(p.cur.Type()) {
 			p.toks = nil
-			p.err = NewParserErrorf(p.cur, "unexpected close parenthesis")
+			p.err = NewParserErrorf(p.cur, "unexpected close %s", p.delimiterString(p.cur.Type()))
 			return nil, p.err
 		}
 		// Advance to the next token for the next ReadSyntax() call
@@ -227,23 +263,31 @@ func (p *Parser) processFoldCaseDirective(d *syntax.SyntaxDirective) {
 // readLabeledList reads a list into a pre-created placeholder pair.
 // This enables circular references where the list refers to itself via datum labels.
 // The placeholder must already be registered in datumLabels before calling this.
+// The opener parameter indicates whether ( or [ was used, for bracket matching.
 //
 // R7RS §2.4: Datum labels enable representing shared/circular structures.
 // For #0=(1 . #0#), we:
 //  1. Pre-create a pair and register it as label 0
 //  2. Read the list contents, which may include #0# references
 //  3. Populate the pair with the read values
-func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair) (syntax.SyntaxValue, error) {
-	// Skip the opening paren
+func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair, opener tokenizer.TokenizerState) (syntax.SyntaxValue, error) {
+	expectedClose := p.matchingClose(opener)
+
+	// Skip the opening paren/bracket
 	p.cur, p.err = p.toks.Next()
 	if p.err != nil {
 		return nil, p.err
 	}
 
-	// Handle empty list: ()
-	if p.cur.Type() == tokenizer.TokenizerStateCloseParen {
+	// Handle empty list: () or []
+	if p.cur.Type() == expectedClose {
 		// Empty list - return the placeholder unchanged (nil . nil)
 		return placeholder, nil
+	}
+	// Check for bracket mismatch on close
+	if p.isListCloser(p.cur.Type()) && p.cur.Type() != expectedClose {
+		return nil, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+			p.delimiterString(opener), p.delimiterString(p.cur.Type()))
 	}
 
 	// Read the first element
@@ -259,7 +303,7 @@ func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair) (syntax.SyntaxV
 		return nil, p.err
 	}
 
-	// Check for improper list: (a . b)
+	// Check for improper list: (a . b) or [a . b]
 	if p.cur.Type() == tokenizer.TokenizerStateCons {
 		// Skip the dot
 		p.cur, p.err = p.toks.Next()
@@ -272,27 +316,37 @@ func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair) (syntax.SyntaxV
 			return nil, err
 		}
 		placeholder.SetCdr(cdr)
-		// Advance past the cdr and expect close paren
+		// Advance past the cdr and expect matching close delimiter
 		p.cur, p.err = p.toks.Next()
 		if p.err != nil {
 			return nil, p.err
 		}
-		if p.cur.Type() != tokenizer.TokenizerStateCloseParen {
-			return nil, NewParserErrorf(p.cur, "expected ')' after improper list cdr")
+		if p.cur.Type() != expectedClose {
+			if p.isListCloser(p.cur.Type()) {
+				return nil, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+					p.delimiterString(opener), p.delimiterString(p.cur.Type()))
+			}
+			return nil, NewParserErrorf(p.cur, "expected %s after improper list cdr",
+				p.delimiterString(expectedClose))
 		}
 		return placeholder, nil
 	}
 
 	// Check for end of list
-	if p.cur.Type() == tokenizer.TokenizerStateCloseParen {
+	if p.cur.Type() == expectedClose {
 		// Single element list - set cdr to empty list
 		placeholder.SetCdr(syntax.NewSyntaxEmptyList(p.newSourceContext(p.cur)))
 		return placeholder, nil
 	}
+	// Check for bracket mismatch
+	if p.isListCloser(p.cur.Type()) && p.cur.Type() != expectedClose {
+		return nil, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+			p.delimiterString(opener), p.delimiterString(p.cur.Type()))
+	}
 
 	// Continue reading remaining elements
 	current := placeholder
-	for p.cur.Type() != tokenizer.TokenizerStateCloseParen && p.cur.Type() != tokenizer.TokenizerStateCons {
+	for !p.isListCloser(p.cur.Type()) && p.cur.Type() != tokenizer.TokenizerStateCons {
 		// Create a new pair for this element
 		nextPair := p.wrapSyntaxPair(nil, nil, p.cur)
 
@@ -314,8 +368,9 @@ func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair) (syntax.SyntaxV
 		}
 	}
 
-	// Handle improper list ending: (a b . c)
-	if p.cur.Type() == tokenizer.TokenizerStateCons {
+	// Handle improper list ending: (a b . c) or [a b . c]
+	switch {
+	case p.cur.Type() == tokenizer.TokenizerStateCons:
 		// Skip the dot
 		p.cur, p.err = p.toks.Next()
 		if p.err != nil {
@@ -327,17 +382,26 @@ func (p *Parser) readLabeledList(placeholder *syntax.SyntaxPair) (syntax.SyntaxV
 			return nil, err
 		}
 		current.SetCdr(cdr)
-		// Advance past the cdr and expect close paren
+		// Advance past the cdr and expect matching close delimiter
 		p.cur, p.err = p.toks.Next()
 		if p.err != nil {
 			return nil, p.err
 		}
-		if p.cur.Type() != tokenizer.TokenizerStateCloseParen {
-			return nil, NewParserErrorf(p.cur, "expected ')' after improper list cdr")
+		if p.cur.Type() != expectedClose {
+			if p.isListCloser(p.cur.Type()) {
+				return nil, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+					p.delimiterString(opener), p.delimiterString(p.cur.Type()))
+			}
+			return nil, NewParserErrorf(p.cur, "expected %s after improper list cdr",
+				p.delimiterString(expectedClose))
 		}
-	} else {
+	case p.cur.Type() == expectedClose:
 		// Proper list - terminate with empty list
 		current.SetCdr(syntax.NewSyntaxEmptyList(p.newSourceContext(p.cur)))
+	case p.isListCloser(p.cur.Type()):
+		// Bracket mismatch
+		return nil, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+			p.delimiterString(opener), p.delimiterString(p.cur.Type()))
 	}
 
 	return placeholder, nil
@@ -641,12 +705,13 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		// For these, we pre-register a placeholder to support circular references
 		var v syntax.SyntaxValue
 		switch p.cur.Type() {
-		case tokenizer.TokenizerStateOpenParen:
+		case tokenizer.TokenizerStateOpenParen, tokenizer.TokenizerStateOpenBracket:
 			// Pre-register an empty pair for potential circular references
+			opener := p.cur.Type()
 			placeholder := p.wrapSyntaxPair(nil, nil, p.cur)
 			p.datumLabels[labelNum] = placeholder
 			// Now read the list contents, which can reference this label
-			v, p.err = p.readLabeledList(placeholder)
+			v, p.err = p.readLabeledList(placeholder, opener)
 			if p.err != nil {
 				return nil, p.cur, p.err
 			}
@@ -710,7 +775,10 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		// Use beginTok.String() for correct label, but p.cur for source context (matches old behavior)
 		q = p.wrapSyntaxDatumComment(beginTok.String(), v, p.cur)
 		return q, p.cur, nil
-	case tokenizer.TokenizerStateOpenParen:
+	case tokenizer.TokenizerStateOpenParen, tokenizer.TokenizerStateOpenBracket:
+		// R7RS §2.1: ( and [ are equivalent for opening lists, but must match
+		opener := p.cur.Type()
+		expectedClose := p.matchingClose(opener)
 		var pr syntax.SyntaxValue
 		pr = p.wrapSyntaxPair(nil, nil, p.cur)
 		p.cur, p.err = p.toks.Next()
@@ -719,13 +787,13 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		}
 		q0 := pr
 		pr0 := p.wrapSyntaxPair(nil, nil, p.cur)
-		for p.cur.Type() != tokenizer.TokenizerStateCloseParen && p.cur.Type() != tokenizer.TokenizerStateCons {
+		for !p.isListCloser(p.cur.Type()) && p.cur.Type() != tokenizer.TokenizerStateCons {
 			var v syntax.SyntaxValue
 			v, _, p.err = p.readSyntax()
 			if p.err != nil {
 				return nil, p.cur, p.err
 			}
-			// After skipping comments, we may have landed on a delimiter (close paren or cons)
+			// After skipping comments, we may have landed on a delimiter (close paren/bracket or cons)
 			// In that case, readSyntax returns nil and we should exit the loop
 			if v == nil {
 				break
@@ -739,32 +807,42 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 				return nil, p.cur, p.err
 			}
 		}
-		if p.cur.Type() == tokenizer.TokenizerStateCons {
+		switch {
+		case p.cur.Type() == tokenizer.TokenizerStateCons:
 			// skip the '.' token
 			p.cur, p.err = p.toks.Next()
 			if p.err != nil {
 				return nil, p.cur, p.err
 			}
-			// read first value in list
+			// read cdr value in improper list
 			var v syntax.SyntaxValue
 			v, _, p.err = p.readSyntax()
 			if p.err != nil {
 				return nil, p.cur, p.err
 			}
 			pr = v
-			// ??
 			p.cur, p.err = p.toks.Next()
 			if p.err != nil {
 				return nil, p.cur, p.err
 			}
-			if p.cur.Type() != tokenizer.TokenizerStateCloseParen {
-				return nil, p.cur, NewParserErrorWithWrapf(values.ErrNotACloseParen, p.cur, "expected close parenthesis after dotted pair, got %s", p.cur.String())
+			// Check for bracket mismatch
+			if p.cur.Type() != expectedClose {
+				if p.isListCloser(p.cur.Type()) {
+					return nil, p.cur, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+						p.delimiterString(opener), p.delimiterString(p.cur.Type()))
+				}
+				return nil, p.cur, NewParserErrorWithWrapf(values.ErrNotACloseParen, p.cur, "expected %s after dotted pair, got %s",
+					p.delimiterString(expectedClose), p.cur.String())
 			}
 			pr0.SetCdr(pr)
-		} else {
-			// CloseParen was not found, so we assume the list is empty.
+		case p.cur.Type() == expectedClose:
+			// Proper list terminated with matching delimiter
 			pr = p.wrapSyntaxEmptyList(p.cur)
 			pr0.SetCdr(pr)
+		case p.isListCloser(p.cur.Type()):
+			// Bracket mismatch
+			return nil, p.cur, NewParserErrorf(p.cur, "mismatched delimiters: opened with %s but closed with %s",
+				p.delimiterString(opener), p.delimiterString(p.cur.Type()))
 		}
 		return q0, p.cur, nil
 	case tokenizer.TokenizerStateOpenVector:
@@ -1181,7 +1259,8 @@ func (p *Parser) readSyntax() (syntax.SyntaxValue, tokenizer.Token, error) {
 		q1 := values.NewString(p.cur.Value())
 		q = p.wrapSyntax(q1, p.cur)
 		return q, p.cur, nil
-	case tokenizer.TokenizerStateCloseParen:
+	case tokenizer.TokenizerStateCloseParen, tokenizer.TokenizerStateCloseBracket:
+		// Close delimiters return nil to signal end of compound form
 		return q, p.cur, nil
 	}
 	return q, nil, NewParserErrorWithWrapf(ErrUnknownTokenType, p.cur, "unknown token type: %q", p.cur.String())

--- a/internal/parser/parser_coverage_test.go
+++ b/internal/parser/parser_coverage_test.go
@@ -824,7 +824,7 @@ func TestCoverage_UnexpectedCloseParen(t *testing.T) {
 	p := NewParser(env, true, strings.NewReader(")"))
 	_, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(strings.Contains(err.Error(), "unexpected close parenthesis"), qt.IsTrue)
+	c.Assert(strings.Contains(err.Error(), "unexpected close )"), qt.IsTrue)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tokenizer/bracket_test.go
+++ b/internal/tokenizer/bracket_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokenizer
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestTokenizer_Brackets tests R7RS §2.1 square bracket support.
+// Square brackets [ and ] are equivalent to ( and ) but must match.
+func TestTokenizer_Brackets(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name   string
+		in     string
+		tokens []TokenizerState
+		src    []string
+	}{
+		{
+			name:   "open bracket",
+			in:     "[",
+			tokens: []TokenizerState{TokenizerStateOpenBracket},
+			src:    []string{"["},
+		},
+		{
+			name:   "close bracket",
+			in:     "]",
+			tokens: []TokenizerState{TokenizerStateCloseBracket},
+			src:    []string{"]"},
+		},
+		{
+			name:   "empty bracket list",
+			in:     "[]",
+			tokens: []TokenizerState{TokenizerStateEmptyList},
+			src:    []string{"[]"},
+		},
+		{
+			name:   "bracket list with elements",
+			in:     "[1 2 3]",
+			tokens: []TokenizerState{TokenizerStateOpenBracket, TokenizerStateUnsignedInteger, TokenizerStateUnsignedInteger, TokenizerStateUnsignedInteger, TokenizerStateCloseBracket},
+			src:    []string{"[", "1", "2", "3", "]"},
+		},
+		{
+			name:   "bracket improper list",
+			in:     "[a . b]",
+			tokens: []TokenizerState{TokenizerStateOpenBracket, TokenizerStateSymbol, TokenizerStateCons, TokenizerStateSymbol, TokenizerStateCloseBracket},
+			src:    []string{"[", "a", ".", "b", "]"},
+		},
+		{
+			name:   "nested brackets",
+			in:     "[[a] [b]]",
+			tokens: []TokenizerState{TokenizerStateOpenBracket, TokenizerStateOpenBracket, TokenizerStateSymbol, TokenizerStateCloseBracket, TokenizerStateOpenBracket, TokenizerStateSymbol, TokenizerStateCloseBracket, TokenizerStateCloseBracket},
+			src:    []string{"[", "[", "a", "]", "[", "b", "]", "]"},
+		},
+		{
+			name:   "mixed parens and brackets",
+			in:     "([a] (b))",
+			tokens: []TokenizerState{TokenizerStateOpenParen, TokenizerStateOpenBracket, TokenizerStateSymbol, TokenizerStateCloseBracket, TokenizerStateOpenParen, TokenizerStateSymbol, TokenizerStateCloseParen, TokenizerStateCloseParen},
+			src:    []string{"(", "[", "a", "]", "(", "b", ")", ")"},
+		},
+		{
+			name:   "quote with bracket",
+			in:     "'[a b]",
+			tokens: []TokenizerState{TokenizerStateQuote, TokenizerStateOpenBracket, TokenizerStateSymbol, TokenizerStateSymbol, TokenizerStateCloseBracket},
+			src:    []string{"'", "[", "a", "b", "]"},
+		},
+		{
+			name:   "quasiquote with bracket",
+			in:     "`[,a ,@b]",
+			tokens: []TokenizerState{TokenizerStateQuasiquote, TokenizerStateOpenBracket, TokenizerStateUnquote, TokenizerStateSymbol, TokenizerStateUnquoteSplicing, TokenizerStateSymbol, TokenizerStateCloseBracket},
+			src:    []string{"`", "[", ",", "a", ",@", "b", "]"},
+		},
+		{
+			name:   "nested empty list",
+			in:     "[[]]",
+			tokens: []TokenizerState{TokenizerStateOpenBracket, TokenizerStateEmptyList, TokenizerStateCloseBracket},
+			src:    []string{"[", "[]", "]"},
+		},
+		{
+			name:   "bracket with paren inside",
+			in:     "[(a)]",
+			tokens: []TokenizerState{TokenizerStateOpenBracket, TokenizerStateOpenParen, TokenizerStateSymbol, TokenizerStateCloseParen, TokenizerStateCloseBracket},
+			src:    []string{"[", "(", "a", ")", "]"},
+		},
+	}
+
+	for _, tc := range tcs {
+		c.Run(tc.name, func(c *qt.C) {
+			p := NewTokenizer(strings.NewReader(tc.in), false)
+			var tokens []TokenizerState
+			var srcs []string
+			for {
+				tok, err := p.Next()
+				if err != nil {
+					c.Assert(err, qt.ErrorIs, io.EOF)
+					break
+				}
+				tokens = append(tokens, tok.Type())
+				srcs = append(srcs, tok.String())
+			}
+			c.Assert(tokens, qt.DeepEquals, tc.tokens)
+			c.Assert(srcs, qt.DeepEquals, tc.src)
+		})
+	}
+}

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -232,6 +232,12 @@ const (
 	TokenizerStateOpenParen
 	// TokenizerStateCloseParen represents ) (close parenthesis).
 	TokenizerStateCloseParen
+	// TokenizerStateOpenBracket represents [ (open square bracket).
+	// R7RS §2.1: Square brackets are equivalent to parentheses but must match.
+	TokenizerStateOpenBracket
+	// TokenizerStateCloseBracket represents ] (close square bracket).
+	// R7RS §2.1: Square brackets are equivalent to parentheses but must match.
+	TokenizerStateCloseBracket
 	// TokenizerStateCons represents . (dot for improper lists).
 	TokenizerStateCons
 
@@ -472,6 +478,21 @@ func (p *Tokenizer) read() {
 		return
 	case p.curr() == ')':
 		p.state = TokenizerStateCloseParen
+		p.next()
+		p.term()
+		return
+	case p.curr() == '[':
+		// R7RS §2.1: [ and ] are equivalent to ( and ) but must match
+		p.state = TokenizerStateOpenBracket
+		p.next()
+		if p.curr() == ']' {
+			p.state = TokenizerStateEmptyList
+			p.next()
+		}
+		p.term()
+		return
+	case p.curr() == ']':
+		p.state = TokenizerStateCloseBracket
 		p.next()
 		p.term()
 		return


### PR DESCRIPTION
## Summary

- Add `[` and `]` as synonyms for `(` and `)` per R7RS §2.1
- Enforce bracket matching: `(` must close with `)`, `[` must close with `]`
- Clear error messages for mismatched delimiters

## Test plan

- [x] Tokenizer tests for `[`, `]`, `[]`, and mixed sequences
- [x] Parser tests for valid bracket lists and improper lists
- [x] Parser tests for mismatch detection (`(a]`, `[a)`, etc.)
- [x] Datum label tests with bracket-delimited lists
- [x] Full test suite passes (`make test`)
- [x] Lint passes (`make lint`)

🤖 Generated with [Claude Code](https://claude.ai/code)