### PR TITLE
feat: add runtime package and schelog example

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	gruntime "runtime"
+	goruntime "runtime"
 	"strings"
 	"syscall"
 
@@ -33,15 +33,17 @@ import (
 	"github.com/aalpar/wile/internal/repl"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
+	"github.com/aalpar/wile/runtime"
 
 	"github.com/jessevdk/go-flags"
 )
 
 type Options struct {
-	File        string `short:"f" long:"file" description:"Scheme file to run"`
-	LibraryPath string `short:"L" long:"library-path" description:"Library search path (colon-separated, prepended to SCHEME_LIBRARY_PATH)"`
-	Version     bool   `short:"V" long:"version" description:"Print version information and exit"`
-	Quiet       bool   `short:"q" long:"quiet" description:"Suppress informational messages"`
+	File        []string `short:"f" long:"file" description:"Scheme file(s) to load (can be repeated)"`
+	Interactive bool     `short:"i" long:"interactive" description:"Enter REPL after loading file(s)"`
+	LibraryPath string   `short:"L" long:"library-path" description:"Library search path (colon-separated, prepended to SCHEME_LIBRARY_PATH)"`
+	Version     bool     `short:"V" long:"version" description:"Print version information and exit"`
+	Quiet       bool     `short:"q" long:"quiet" description:"Suppress informational messages"`
 }
 
 var (
@@ -96,10 +98,10 @@ func setupSignals(quiet bool) {
 		for range sigChan {
 			// Allocate a buffer and write all goroutine stacks to it
 			stacktrace := make([]byte, 1<<20)
-			length := gruntime.Stack(stacktrace, true) // `true` means dump all goroutines
+			length := goruntime.Stack(stacktrace, true) // `true` means dump all goroutines
 			for length >= len(stacktrace) {
 				stacktrace = make([]byte, len(stacktrace)*2)
-				length = gruntime.Stack(stacktrace, true)
+				length = goruntime.Stack(stacktrace, true)
 			}
 			fmt.Fprintln(os.Stderr, "=== GOROUTINE STACK DUMP ===")
 			fmt.Fprintln(os.Stderr, string(stacktrace[:length]))
@@ -115,7 +117,6 @@ func setupSignals(quiet bool) {
 
 func main() {
 	var fin io.RuneReader
-	var fd *os.File
 
 	parser := flags.NewParser(&opts, flags.Default)
 	parser.Name = "scheme"
@@ -136,8 +137,8 @@ func main() {
 	}
 
 	// Handle positional argument as file if --file not specified
-	if opts.File == "" && len(args) > 0 {
-		opts.File = args[0]
+	if len(opts.File) == 0 && len(args) > 0 {
+		opts.File = append(opts.File, args[0])
 	}
 
 	env, err0 := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
@@ -154,19 +155,29 @@ func main() {
 	machine.LibraryEnvFactory = bootstrap.NewLibraryEnvironmentFrame
 	// read evaluate loop
 	ctx := context.Background()
-	// include file if any
-	if opts.File != "" {
-		var err1 error
-		if !opts.Quiet {
-			log.Printf("reading file %q", opts.File)
+	// Load files if any
+	if len(opts.File) > 0 {
+		for i, filename := range opts.File {
+			if !opts.Quiet {
+				log.Printf("reading file %q", filename)
+			}
+			fd, err := os.Open(filename)
+			if err != nil {
+				Failf(err, "Cannot open file %s", filename)
+			}
+			isLastFile := i == len(opts.File)-1
+			if opts.Interactive || !isLastFile {
+				// Load file silently (all files in interactive mode, or non-last files in batch mode)
+				if err := runtime.Load(ctx, env, fd, filename); err != nil {
+					Failf(err)
+				}
+			} else {
+				// Run last file (print results) and exit in non-interactive mode
+				fin = bufio.NewReader(fd)
+				runFile(ctx, env, fin, filename)
+				return
+			}
 		}
-		fd, err1 = os.Open(opts.File)
-		if err1 != nil {
-			Failf(err1, "Cannot open file %s", opts.File)
-		}
-		fin = bufio.NewReader(fd)
-		runFile(ctx, env, fin, opts.File)
-		return
 	}
 	// interactive REPL using the repl package
 	setupSignals(opts.Quiet)
@@ -212,11 +223,11 @@ func runFile(ctx context.Context, env *environment.EnvironmentFrame, fin io.Rune
 	}
 
 	// Compile and run the single wrapped expression
-	tpl, err2 := repl.Compile(env, programStx)
+	tpl, err2 := runtime.Compile(env, programStx)
 	if err2 != nil {
 		Failf(err2, "Cannot compile expression")
 	}
-	mv, err2 := repl.Run(ctx, tpl, env)
+	mv, err2 := runtime.Run(ctx, tpl, env)
 	// Print result for:
 	// - Normal completion (err2 == nil) - when inTail=false at top-level
 	// - ErrMachineHalt - when inTail=true at top-level (RestoreContinuation returns ErrMachineHalt)

--- a/examples/logic/schelog/README.md
+++ b/examples/logic/schelog/README.md
@@ -1,0 +1,126 @@
+# Schelog: Prolog in Scheme
+
+Schelog is an embedding of Prolog-style logic programming in Scheme, created by
+Dorai Sitaram. This directory contains the **unmodified** schelog.scm library
+and all example files from the upstream repository, demonstrating Wile's full
+compatibility with Schelog.
+
+## Compatibility
+
+Wile runs Schelog without any modifications to the original source code. All
+upstream examples pass, including the famous Zebra puzzle. Run the validation
+suite to verify:
+
+```bash
+./examples/logic/schelog/run-all-tests.sh
+```
+
+Expected output:
+```
+=== Schelog Validation Suite for Wile ===
+...
+=== Test Summary ===
+Passed: 16
+Failed: 0
+
+All tests passed! Wile is fully compatible with Schelog.
+```
+
+## Usage
+
+### Interactive Exploration
+
+Start a REPL with schelog loaded:
+
+```bash
+./dist/scheme -i -f examples/logic/schelog/schelog.scm
+```
+
+Then try:
+
+```scheme
+> (%which (x) (%member x '(a b c)))
+((x a))
+> (%more)
+((x b))
+> (%more)
+((x c))
+> (%more)
+#f
+```
+
+### Running the Demo
+
+```bash
+./dist/scheme -i -f examples/logic/schelog/schelog.scm -f examples/logic/schelog/demo.scm
+```
+
+### Running Examples
+
+Load schelog first, then any example file:
+
+```bash
+# Map coloring
+./dist/scheme -i -f examples/logic/schelog/schelog.scm -f examples/logic/schelog/mapcol.scm
+
+# Zebra puzzle (requires puzzle.scm helper)
+./dist/scheme -i -f examples/logic/schelog/schelog.scm \
+              -f examples/logic/schelog/puzzle.scm \
+              -f examples/logic/schelog/houses.scm
+```
+
+Then query interactively:
+
+```scheme
+> (set! *schelog-use-occurs-check?* #t)  ; Required for Zebra puzzle
+> (solve-puzzle %houses)
+((solution= ((japan owns the zebra) (norway drinks water))))
+```
+
+### Multiple Files
+
+The `-f` flag can be repeated to load multiple files in order:
+
+```bash
+./dist/scheme -i -f lib1.scm -f lib2.scm -f main.scm
+```
+
+All files except the last are loaded silently. In interactive mode (`-i`), the
+REPL starts after all files are loaded.
+
+## Key Concepts
+
+- **Logic variables**: Created with `%let`, represent unknowns to be unified
+- **Relations**: Defined with `%rel`, similar to Prolog predicates
+- **Queries**: `%which` finds solutions, `%more` backtracks for alternatives
+- **Unification**: `%=` unifies terms, `%is` evaluates arithmetic
+- **Control**: `%and`, `%or`, `%not`, `!` (cut)
+- **Sets**: `%bag-of`, `%set-of` collect all solutions
+- **Occurs check**: `*schelog-use-occurs-check?*` enables for complex unification
+
+## Files
+
+### Core Library
+- `schelog.scm` - Complete schelog library (unmodified from upstream)
+
+### Examples (from upstream)
+- `toys.scm` - Basic predicates: append, reverse, factorial, length
+- `holland.scm` - Simple facts database
+- `england.scm` - Royal family relationships
+- `england2.scm` - Alternative Scheme-style syntax
+- `bible.scm` - Biblical genealogy with set predicates
+- `mapcol.scm` - Map coloring (4-color theorem)
+- `games.scm` - Logic puzzle from Sterling & Shapiro
+- `puzzle.scm` - Generic puzzle solver
+- `houses.scm` - Zebra puzzle (Einstein's riddle)
+
+### Wile-specific
+- `demo.scm` - Interactive demonstration
+- `run-all-tests.sh` - Validation suite
+- `README.md` - This file
+
+## Resources
+
+- [Schelog Documentation](https://ds26gte.github.io/schelog/)
+- [GitHub Repository](https://github.com/ds26gte/schelog)
+- [Wile Scheme](https://github.com/aalpar/wile) - Pure Go Scheme with hygienic macros

--- a/examples/logic/schelog/bible.scm
+++ b/examples/logic/schelog/bible.scm
@@ -1,0 +1,119 @@
+;The following is the "Biblical" database from "The Art of
+;Prolog", Sterling & Shapiro, ch. 1.
+
+;(%father X Y) :- X is the father of Y.
+
+(define %father
+  (%rel ()
+    (('terach 'abraham)) (('terach 'nachor)) (('terach 'haran))
+    (('abraham 'isaac)) (('haran 'lot)) (('haran 'milcah))
+    (('haran 'yiscah))))
+
+;(%mother X Y) :- X is the mother of Y.
+
+(define %mother
+  (%rel () (('sarah 'isaac))))
+
+(define %male
+  (%rel ()
+    (('terach)) (('abraham)) (('isaac)) (('lot)) (('haran)) (('nachor))))
+
+(define %female
+  (%rel ()
+    (('sarah)) (('milcah)) (('yiscah))))
+
+;AoP, ch. 17.  Finding all the children of a particular
+;father.  (%children F CC) :- CC is the list of children
+;whose father is F.  First approach: %children-1 uses an
+;auxiliary predicate %children-aux, which uses an
+;accumulator.
+
+(define %children-1
+
+  (letrec ((children-aux
+	     (%rel (x a cc c)
+	       ((x a cc)
+                 (%father x c) (%not (%member c a)) !
+                 (children-aux x (cons c a) cc))
+	       ((x cc cc)))))
+
+    (%rel (x cc)
+      ((x cc) (children-aux x '() cc)))))
+
+(define terachs-kids-test
+  ;find all the children of Terach.  Returns
+  ;cc = (abraham nachor haran)
+  (lambda ()
+    (%which (cc)
+      (%children-1 'terach cc))))
+
+(define dad-kids-test
+  ;find a father and all his children.  Returns
+  ;f = terach, cc = (haran nachor abraham).
+  ;(%more) fails, showing flaw in %children-1.
+  ;see AoP, ch. 17, p. 267
+  (lambda ()
+    (%which (f cc)
+      (%children-1 f cc))))
+
+(define terachs-kids-test-2
+  ;find all the kids of Terach, using %set-of.
+  ;returns kk = (abraham nachor haran)
+  (lambda ()
+    (%let (k)
+      (%which (kk)
+        (%set-of k (%father 'terach k) kk)))))
+
+;This is a better definition of the %children predicate.
+;Uses set predicate %bag-of
+
+(define %children
+  (%rel (x kids c)
+    ((kids) (%set-of c (%father x c) kids))))
+
+(define dad-kids-test-2
+  ;find each dad-kids combo.
+  ;1st soln: dad = terach, kids = (abraham nachor haran)
+  ;(%more) gives additional solutions.
+  (lambda ()
+    (%let (x)
+      (%which (dad kids)
+        (%set-of x (%free-vars (dad)
+                     (%father dad x))
+          kids)))))
+
+(define dad-kids-test-3
+  ;looks like dad-kids-test-2, but dad is now
+  ;existentially quantified.  returns a set of
+  ;kids (i.e., anything with a father)
+  (lambda ()
+    (%let (x)
+      (%which (dad kids)
+        (%set-of x (%father dad x)
+          kids)))))
+
+(define dad-kids-test-4
+  ;find the set of dad-kids.
+  ;since dad is existentially quantified,
+  ;this gives the wrong answer: it gives
+  ;one set containing all the kids
+  (lambda ()
+    (%let (dad kids x)
+      (%which (dad-kids)
+	(%set-of (list dad kids)
+	  (%set-of x (%father dad x) kids)
+	  dad-kids)))))
+
+(define dad-kids-test-5
+  ;the correct solution.  dad is
+  ;identified as a free var.
+  ;returns a set of dad-kids, one for
+  ;each dad
+  (lambda ()
+    (%let (dad kids x)
+      (%which (dad-kids)
+	(%set-of (list dad kids)
+	  (%set-of x (%free-vars (dad)
+                       (%father dad x))
+            kids)
+	  dad-kids)))))

--- a/examples/logic/schelog/demo.scm
+++ b/examples/logic/schelog/demo.scm
@@ -1,0 +1,130 @@
+;;; demo.scm - Schelog demonstration
+;;;
+;;; Demonstrates: Prolog-style logic programming in Scheme
+;;;               Relations, unification, backtracking, cut
+;;;
+;;; Usage:
+;;;   cd <wile-root>
+;;;   ./dist/scheme -i -f examples/logic/schelog/schelog.scm -f examples/logic/schelog/demo.scm
+;;;
+;;; For interactive exploration:
+;;;   ./dist/scheme -i -f examples/logic/schelog/schelog.scm
+;;;   > (%which (x) (%member x '(a b c)))
+;;;   > (%more)
+
+(display "=== Schelog: Prolog in Scheme ===\n\n")
+
+;; -----------------------------------------------------------------------
+;; Example 1: Family relationships
+;; -----------------------------------------------------------------------
+
+(display "--- Family relationships ---\n")
+
+;; Define parent facts
+(define %parent
+  (%rel ()
+    [('tom 'bob)]
+    [('tom 'liz)]
+    [('bob 'ann)]
+    [('bob 'pat)]
+    [('pat 'jim)]))
+
+;; Define grandparent rule
+(define %grandparent
+  (%rel (x y z)
+    [(x y) (%parent x z) (%parent z y)]))
+
+;; Query: Who are Tom's children?
+(display "Tom's children: ")
+(display (%which (child) (%parent 'tom child)))
+(newline)
+
+;; Query: Who are Bob's grandchildren?
+(display "Bob's grandchildren: ")
+(let ((result (%which (gc) (%grandparent 'bob gc))))
+  (display result)
+  (newline))
+
+;; -----------------------------------------------------------------------
+;; Example 2: List membership
+;; -----------------------------------------------------------------------
+
+(display "\n--- List membership ---\n")
+
+;; %member is built into schelog, let's use it
+(display "Is 'b' in '(a b c)? ")
+(display (if (%which () (%member 'b '(a b c))) "yes" "no"))
+(newline)
+
+(display "Is 'x' in '(a b c)? ")
+(display (if (%which () (%member 'x '(a b c))) "yes" "no"))
+(newline)
+
+;; Find all members
+(display "Members of '(1 2 3): ")
+(let loop ((result (%which (x) (%member x '(1 2 3)))))
+  (when result
+    (display (cdr (car result)))
+    (display " ")
+    (loop (%more))))
+(newline)
+
+;; -----------------------------------------------------------------------
+;; Example 3: Append relation
+;; -----------------------------------------------------------------------
+
+(display "\n--- Append relation ---\n")
+
+;; %append is built into schelog
+(display "Append '(a b) and '(c d): ")
+(display (%which (z) (%append '(a b) '(c d) z)))
+(newline)
+
+;; Use append to split a list
+(display "Split '(1 2 3) into two parts:\n")
+(let loop ((result (%which (x y) (%append x y '(1 2 3)))))
+  (when result
+    (display "  ")
+    (display result)
+    (newline)
+    (loop (%more))))
+
+;; -----------------------------------------------------------------------
+;; Example 4: Arithmetic
+;; -----------------------------------------------------------------------
+
+(display "\n--- Arithmetic constraints ---\n")
+
+;; Find X where X + 3 = 7
+(display "X + 3 = 7, X = ")
+(%let (x)
+  (%which () (%is x (- 7 3)))
+  (display (schelog:deref* x)))
+(newline)
+
+;; -----------------------------------------------------------------------
+;; Example 5: Negation as failure
+;; -----------------------------------------------------------------------
+
+(display "\n--- Negation as failure ---\n")
+
+(define %likes
+  (%rel ()
+    [('mary 'food)]
+    [('mary 'wine)]
+    [('john 'wine)]
+    [('john 'mary)]))
+
+(display "Mary likes food? ")
+(display (if (%which () (%likes 'mary 'food)) "yes" "no"))
+(newline)
+
+(display "John likes food? ")
+(display (if (%which () (%likes 'john 'food)) "yes" "no"))
+(newline)
+
+(display "John does NOT like food? ")
+(display (if (%which () (%not (%likes 'john 'food))) "yes" "no"))
+(newline)
+
+(display "\nSchelog — Prolog's power with Scheme's elegance.\n")

--- a/examples/logic/schelog/england.scm
+++ b/examples/logic/schelog/england.scm
@@ -1,0 +1,52 @@
+;The following is a simple database about a certain family in England.
+;Should be a piece of cake, but given here so that you can hone
+;your ability to read the syntax.
+
+;This file is written using `%rel' for a more Prolog-like syntax.
+;The file england2.scm uses a Scheme-like syntax.
+
+(define %male
+  (%rel ()
+    (('philip)) (('charles)) (('andrew)) (('edward))
+    (('mark)) (('william)) (('harry)) (('peter))))
+
+(define %female
+  (%rel ()
+    (('elizabeth)) (('anne)) (('diana)) (('sarah)) (('zara))))
+
+(define %husband-of
+  (%rel ()
+    (('philip 'elizabeth)) (('charles 'diana))
+    (('mark 'anne)) (('andrew 'sarah))))
+
+(define %wife-of
+  (%rel (w h)
+    ((w h) (%husband-of h w))))
+
+(define %married-to
+  (%rel (x y)
+    ((x y) (%husband-of x y))
+    ((x y) (%wife-of x y))))
+
+(define %father-of
+  (%rel ()
+   (('philip 'charles)) (('philip 'anne)) (('philip 'andrew))
+   (('philip 'edward)) (('charles 'william)) (('charles 'harry))
+   (('mark 'peter)) (('mark 'zara))))
+
+(define %mother-of
+  (%rel (m c f)
+    ((m c) (%wife-of m f) (%father-of f c))))
+
+(define %child-of
+  (%rel (c p)
+    ((c p) (%father-of p c))
+    ((c p) (%mother-of p c))))
+
+(define %parent-of
+  (%rel (p c)
+    ((p c) (%child-of c p))))
+
+(define %brother-of
+  (%rel (b x f)
+    ((b x) (%male b) (%father-of f b) (%father-of f x) (%/= b x))))

--- a/examples/logic/schelog/england2.scm
+++ b/examples/logic/schelog/england2.scm
@@ -1,0 +1,74 @@
+;The following is a simple database about a certain family in England.
+;Should be a piece of cake, but given here so that you can hone
+;your ability to read the syntax.
+
+;This file is written using goal combinations like %or, %and
+;like you would use Scheme procedures.  For a more Prolog-like
+;syntax of the same program, see england.scm.
+
+(define %male
+  (lambda (x)
+    (%or (%= x 'philip)
+	 (%= x 'charles)
+	 (%= x 'andrew)
+	 (%= x 'edward)
+	 (%= x 'mark)
+	 (%= x 'william)
+	 (%= x 'harry)
+	 (%= x 'peter))))
+
+(define %female
+  (lambda (x)
+    (%or (%= x 'elizabeth)
+	 (%= x 'anne)
+	 (%= x 'diana)
+	 (%= x 'sarah)
+	 (%= x 'zara))))
+
+(define %husband-of
+  (lambda (h w)
+    (%or (%and (%= h 'philip) (%= w 'elizabeth))
+	 (%and (%= h 'charles) (%= w 'diana))
+	 (%and (%= h 'mark) (%= w 'anne))
+	 (%and (%= h 'andrew) (%= w 'sarah)))))
+
+(define %wife-of
+  (lambda (w h)
+    (%husband-of h w)))
+
+(define %married-to
+  (lambda (x y)
+    (%or (%husband-of x y) (%wife-of x y))))
+
+(define %father-of
+  (lambda (x y)
+    (%or (%and (%= x 'philip) (%= y 'charles))
+	 (%and (%= x 'philip) (%= y 'anne))
+	 (%and (%= x 'philip) (%= y 'andrew))
+	 (%and (%= x 'philip) (%= y 'edward))
+	 (%and (%= x 'charles) (%= y 'william))
+	 (%and (%= x 'charles) (%= y 'harry))
+	 (%and (%= x 'mark) (%= y 'peter))
+	 (%and (%= x 'mark) (%= y 'zara)))))
+
+(define %mother-of
+  (lambda (m c)
+    (%let (f)
+      (%and (%wife-of m f) (%father-of f c)))))
+
+(define %child-of
+  (lambda (c p)
+    (%or (%father-of p c) (%mother-of p c))))
+
+(define %parent-of
+  (lambda (p c)
+    (%child-of c p)))
+
+(define %brother-of
+  (lambda (b x)
+    (%let (f)
+      (%and (%male b)
+	    (%father-of f b)
+	    (%father-of f x)
+	    (%/= b x)))))
+

--- a/examples/logic/schelog/games.scm
+++ b/examples/logic/schelog/games.scm
@@ -1,0 +1,83 @@
+;;This example is from Sterling & Shapiro, p. 214.
+;;
+;;The problem reads: Three friends came first, second and
+;;third in a competition.  Each had a different name, liked a
+;;different sport, and had a different nationality.  Michael
+;;likes basketball, and did better than the American.  Simon,
+;;the Israeli, did better than the tennis player.  The
+;;cricket player came first.  Who's the Australian?  What
+;;sport does Richard play?
+
+(define person
+  ;;a structure-builder for persons
+  (lambda (name country sport)
+    (list 'person name country sport)))
+
+(define %games
+  (%rel (clues queries solution the-men
+	 n1 n2 n3 c1 c2 c3 s1 s2 s3)
+    ((clues queries solution)
+     (%= the-men
+       (list (person n1 c1 s1) (person n2 c2 s2) (person n3 c3 s3)))
+     (%games-clues the-men clues)
+     (%games-queries the-men queries solution))))
+    
+(define %games-clues
+  (%rel (the-men clue1-man1 clue1-man2 clue2-man1 clue2-man2 clue3-man)
+    ((the-men
+       (list
+	 (%did-better clue1-man1 clue1-man2 the-men)
+	 (%name clue1-man1 'michael)
+	 (%sport clue1-man1 'basketball)
+	 (%country clue1-man2 'usa)
+
+	 (%did-better clue2-man1 clue2-man2 the-men)
+	 (%name clue2-man1 'simon)
+	 (%country clue2-man1 'israel)
+	 (%sport clue2-man2 'tennis)
+
+	 (%first the-men clue3-man)
+	 (%sport clue3-man 'cricket))))))
+
+(define %games-queries
+  (%rel (the-men man1 man2 aussies-name dicks-sport)
+    ((the-men
+       (list
+	 (%member man1 the-men)
+	 (%country man1 'australia)
+	 (%name man1 aussies-name)
+
+	 (%member man2 the-men)
+	 (%name man2 'richard)
+	 (%sport man2 dicks-sport))
+       (list
+	 (list aussies-name 'is 'the 'australian)
+	 (list 'richard 'plays dicks-sport))))))
+	 
+(define %did-better
+  (%rel (a b c)
+    ((a b (list a b c)))
+    ((a c (list a b c)))
+    ((b c (list a b c)))))
+
+(define %name
+  (%rel (name country sport)
+    (((person name country sport) name))))
+
+(define %country
+  (%rel (name country sport)
+    (((person name country sport) country))))
+
+(define %sport
+  (%rel (name country sport)
+    (((person name country sport) sport))))
+
+(define %first
+  (%rel (car cdr)
+    (((cons car cdr) car))))
+
+;;With the above as the database, and also loading the file
+;;puzzle.scm containing the puzzle solver, we merely need to
+;;ask (solve-puzzle %games) to get the solution, which is
+;;
+;;((michael is the australian) (richard plays tennis))

--- a/examples/logic/schelog/holland.scm
+++ b/examples/logic/schelog/holland.scm
@@ -1,0 +1,36 @@
+;This is a very trivial program.  In Prolog, it would be:
+;
+;    city(amsterdam).
+;    city(brussels).
+;    country(holland).
+;    country(belgium).
+
+(define %city
+  (lambda (x)
+    (%or (%= x 'amsterdam)
+	 (%= x 'brussels))))
+
+(define %country
+  (lambda (x)
+    (%or (%= x 'holland)
+	 (%= x 'belgium))))
+
+;For a more Prolog-style syntax, you can rewrite the same thing,
+;using the `%rel' macro, as the following:
+
+'(define %city
+  (%rel ()
+    (('amsterdam))
+    (('brussels))))
+
+'(define %country
+  (%rel ()
+    (('holland))
+    (('belgium))))
+
+;Typical easy queries:
+;
+; (%which (x) (%city x)) succeeds twice
+; (%which (x) (%country x)) succeeds twice
+; (%which () (%city 'amsterdam)) succeeds
+; (%which () (%country 'amsterdam)) fails

--- a/examples/logic/schelog/houses.scm
+++ b/examples/logic/schelog/houses.scm
@@ -1,0 +1,148 @@
+;Exercise 14.1 (iv) from Sterling & Shapiro, p. 217-8  
+
+;There are 5 houses, each of a different color and inhabited
+;by a man of a different nationality, with a different pet,
+;drink and cigarette choice.
+;
+;1. The Englishman lives in the red house
+;2. The Spaniard owns the dog
+;3. Coffee is drunk in the green house
+;4. The Ukrainian drinks tea
+;5. The green house is to the immediate right of the ivory house
+;6. The Winston smoker owns snails
+;7. Kools are smoked in the yellow house
+;8. Milk is drunk in the middle house
+;9. The Norwegian lives in the first house on the left
+;10. The Chesterfield smoker lives next to the man with the fox
+;11. Kools are smoked in the house adjacent to the horse's place
+;12. The Lucky Strike smoker drinks orange juice
+;13. The Japanese smokes Parliaments
+;14. The Norwegian lives next to the blue house
+
+;Who owns the zebra?  Who drinks water?
+
+(define house
+  (lambda (hue nation pet drink cigarette)
+    (list 'house hue nation pet drink cigarette)))
+
+(define %hue (%rel (h) (((house h (_) (_) (_) (_)) h))))
+(define %nation (%rel (n) (((house (_) n (_) (_) (_)) n))))
+(define %pet (%rel (p) (((house (_) (_) p (_) (_)) p))))
+(define %drink (%rel (d) (((house (_) (_) (_) d (_)) d))))
+(define %cigarette (%rel (c) (((house (_) (_) (_) (_) c) c))))
+
+(define %adjacent
+  (%rel (a b)
+    ((a b (list a b (_) (_) (_))))
+    ((a b (list (_) a b (_) (_))))
+    ((a b (list (_) (_) a b (_))))
+    ((a b (list (_) (_) (_) a b)))))
+
+(define %middle
+  (%rel (a)
+    ((a (list (_) (_) a (_) (_))))))
+
+(define %houses
+  (%rel (row-of-houses clues queries solution
+	 h1 h2 h3 h4 h5 n1 n2 n3 n4 n5 p1 p2 p3 p4 p5
+	 d1 d2 d3 d4 d5 c1 c2 c3 c4 c5)
+    ((clues queries solution)
+     (%= row-of-houses
+       (list
+	 (house h1 n1 p1 d1 c1)
+	 (house h2 n2 p2 d2 c2)
+	 (house h3 n3 p3 d3 c3)
+	 (house h4 n4 p4 d4 c4)
+	 (house h5 n5 p5 d5 c5)))
+     (%houses-clues row-of-houses clues)
+     (%houses-queries row-of-houses queries solution))))
+
+(define %houses-clues
+  (%rel (row-of-houses abode1 abode2 abode3 abode4 abode5 abode6 abode7
+	 abode8 abode9 abode10 abode11 abode12 abode13 abode14 abode15)
+    ((row-of-houses
+       (list
+	 (%member abode1 row-of-houses)
+	 (%nation abode1 'english)
+	 (%hue abode1 'red)
+
+	 (%member abode2 row-of-houses)
+	 (%nation abode2 'spain)
+	 (%pet abode2 'dog)
+
+	 (%member abode3 row-of-houses)
+	 (%drink abode3 'coffee)
+	 (%hue abode3 'green)
+
+	 (%member abode4 row-of-houses)
+	 (%nation abode4 'ukraine)
+	 (%drink abode4 'tea)
+
+	 (%member abode5 row-of-houses)
+	 (%adjacent abode5 abode3 row-of-houses)
+	 (%hue abode5 'ivory)
+
+	 (%member abode6 row-of-houses)
+	 (%cigarette abode6 'winston)
+	 (%pet abode6 'snail)
+
+	 (%member abode7 row-of-houses)
+	 (%cigarette abode7 'kool)
+	 (%hue abode7 'yellow)
+
+	 (%= (list (_) (_) abode8 (_) (_)) row-of-houses)
+	 (%drink abode8 'milk)
+
+	 (%= (list abode9 (_) (_) (_) (_)) row-of-houses)
+	 (%nation abode9 'norway)
+
+	 (%member abode10 row-of-houses)
+	 (%member abode11 row-of-houses)
+	 (%or (%adjacent abode10 abode11 row-of-houses)
+	   (%adjacent abode11 abode10 row-of-houses))
+	 (%cigarette abode10 'chesterfield)
+	 (%pet abode11 'fox)
+
+	 (%member abode12 row-of-houses)
+	 (%or (%adjacent abode7 abode12 row-of-houses) 
+	   (%adjacent abode12 abode7 row-of-houses))
+	 (%pet abode12 'horse)
+
+	 (%member abode13 row-of-houses)
+	 (%cigarette abode13 'lucky-strike)
+	 (%drink abode13 'oj)
+
+	 (%member abode14 row-of-houses)
+	 (%nation abode14 'japan)
+	 (%cigarette abode14 'parliament)
+
+	 (%member abode15 row-of-houses)
+	 (%or (%adjacent abode9 abode15 row-of-houses) 
+	   (%adjacent abode15 abode9 row-of-houses))
+	 (%hue abode15 'blue))))))
+
+(define %houses-queries
+  (%rel (row-of-houses abode1 abode2 zebra-owner water-drinker)
+    ((row-of-houses
+       (list
+	 (%member abode1 row-of-houses)
+	 (%pet abode1 'zebra)
+	 (%nation abode1 zebra-owner)
+
+	 (%member abode2 row-of-houses)
+	 (%drink abode2 'water)
+	 (%nation abode2 water-drinker))
+
+       (list (list zebra-owner 'owns 'the 'zebra)
+	 (list water-drinker 'drinks 'water))))))
+
+;Load puzzle.scm and type (solve-puzzle %houses)
+
+;Note: This program, as written, requires
+;the occurs check.  Make sure the global
+;*schelog-use-occurs-check?* is set to #t before
+;calling solve-puzzle.  If not, you will get into
+;an infinite loop.
+
+;Note 2: Perhaps there is a way to rewrite the 
+;program so that it doesn't rely on the occurs check.

--- a/examples/logic/schelog/mapcol.scm
+++ b/examples/logic/schelog/mapcol.scm
@@ -1,0 +1,79 @@
+;map coloring, example from Sterling & Shapiro, p. 212
+
+;(%member x y) holds if x is in y
+
+(define %member
+  (%rel (X Xs Y Ys)
+    ((X (cons X Xs)))
+    ((X (cons Y Ys)) (%member X Ys))))
+
+;(%members x y) holds if x is a subset of y
+
+(define %members
+  (%rel (X Xs Ys)
+    (((cons X Xs) Ys) (%member X Ys) (%members Xs Ys))
+    (('() Ys))))
+
+;(%select x y z) holds if z is y with one less occurrence of x
+
+(define %select
+  (%rel (X Xs Y Ys Zs)
+    ((X (cons X Xs) Xs))
+    ((X (cons Y Ys) (cons Y Zs))
+     (%select X Ys Zs))))
+
+;region is a structure-builder
+
+(define region
+  (lambda (name color neighbors)
+    (list 'region name color neighbors)))
+
+(define %color-map
+  (%rel (Region Regions Colors)
+    (((cons Region Regions) Colors)
+     (%color-region Region Colors) (%color-map Regions Colors))
+    (('() Colors))))
+
+(define %color-region
+  (%rel (Name Color Neighbors Colors Colors1)
+    (((region Name Color Neighbors) Colors)
+     (%select Color Colors Colors1)
+     (%members Neighbors Colors1))))
+
+(define %test-color
+  (%rel (Name Map Colors)
+    ((Name Map)
+     (%map Name Map)
+     (%colors Colors)
+     (%color-map Map Colors))))
+
+(define %map
+  (%rel (A B C D E F G H I L P S)
+    (('test (list
+	      (region 'a A (list B C D))
+	      (region 'b B (list A C E))
+	      (region 'c C (list A B D E F))
+	      (region 'd D (list A C F))
+	      (region 'e E (list B C F))
+	      (region 'f F (list C D E)))))
+    (('western-europe
+       (list
+	 (region 'portugal P (list E))
+	 (region 'spain E (list F P))
+	 (region 'france F (list E I S B G L))
+	 (region 'belgium B (list F H L G))
+	 (region 'holland H (list B G))
+	 (region 'germany G (list F A S H B L))
+	 (region 'luxembourg L (list F B G))
+	 (region 'italy I (list F A S))
+	 (region 'switzerland S (list F I A G))
+	 (region 'austria A (list I S G)))))))
+
+(define %colors
+  (%rel ()
+    (('(red yellow blue white)))))
+
+;ask (%which (M) (%test-color 'test M)) or
+;ask (%which (M) (%test-color 'western-europe M)) for the
+;respective (non-unique) colorings.
+

--- a/examples/logic/schelog/puzzle.scm
+++ b/examples/logic/schelog/puzzle.scm
@@ -1,0 +1,41 @@
+;This is the puzzle solver described in Sterling & Shapiro, p. 214
+
+;As S & S say, it is a "trivial" piece of code
+;that successively solves each clue and query, which are expressed
+;as Prolog goals and are executed with the meta-variable facility.
+
+;The code in "real" Prolog, for comparison, is:
+;
+;  solve_puzzle(Clues, Queries, Solution) 
+;                 :- solve(Clues), solve(Queries).
+;
+;  solve([Clue|Clues]) :- Clue, solve(Clues).
+;  solve([]).
+
+(define %solve-puzzle
+  (%rel (clues queries solution)
+    ((clues queries solution)
+      (%solve clues)
+      (%solve queries))))
+
+(define %solve
+  (%rel (clue clues)
+    (((cons clue clues))
+      clue 
+      (%solve clues))
+    (('()))))
+
+;evaluate (solve-puzzle %puzzle) to get the solution to
+;%puzzle.  Here %puzzle is a relation that is defined to
+;hold for the three arguments clues, queries and solution=,
+;iff they satisfy the constraints imposed by the puzzle.
+;solve-puzzle finds an (the?) instantiation for the solution=
+;variable.
+
+(define solve-puzzle
+  (lambda (%puzzle)
+    (%let (clues queries)
+      (%which (solution=)
+	(%and
+	  (%puzzle clues queries solution=)
+	  (%solve-puzzle clues queries solution=))))))

--- a/examples/logic/schelog/run-all-tests.scm
+++ b/examples/logic/schelog/run-all-tests.scm
@@ -1,0 +1,185 @@
+;;; run-all-tests.scm - Comprehensive Schelog validation suite for Wile
+;;;
+;;; This file tests all schelog examples to validate Wile's compatibility
+;;; with the Schelog logic programming library.
+;;;
+;;; Usage:
+;;;   cd <wile-root>
+;;;   ./dist/scheme -f examples/logic/schelog/run-all-tests.scm
+;;;
+;;; Expected output: All tests should pass with no errors.
+
+;; Load schelog and all example files
+(include "examples/logic/schelog/schelog.scm")
+(include "examples/logic/schelog/toys.scm")
+(include "examples/logic/schelog/puzzle.scm")
+(include "examples/logic/schelog/mapcol.scm")
+(include "examples/logic/schelog/england.scm")
+(include "examples/logic/schelog/bible.scm")
+(include "examples/logic/schelog/games.scm")
+(include "examples/logic/schelog/holland.scm")
+(include "examples/logic/schelog/houses.scm")
+
+(define tests-passed 0)
+(define tests-failed 0)
+
+(define (test name expected actual)
+  (if (equal? expected actual)
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "  PASS: ")
+        (display name)
+        (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "  FAIL: ")
+        (display name)
+        (display " - expected ")
+        (display expected)
+        (display ", got ")
+        (display actual)
+        (newline))))
+
+(define (test-not-false name result)
+  (if result
+      (begin
+        (set! tests-passed (+ tests-passed 1))
+        (display "  PASS: ")
+        (display name)
+        (newline))
+      (begin
+        (set! tests-failed (+ tests-failed 1))
+        (display "  FAIL: ")
+        (display name)
+        (display " - expected truthy result, got #f")
+        (newline))))
+
+(display "=== Schelog Validation Suite for Wile ===\n\n")
+
+;; ---------------------------------------------------------------------------
+;; toys.scm tests
+;; ---------------------------------------------------------------------------
+(display "--- toys.scm ---\n")
+
+(test "%length '(a b c)"
+      '((n 3))
+      (%which (n) (%length '(a b c) n)))
+
+(test "%append '(1 2) '(3 4)"
+      '((z (1 2 3 4)))
+      (%which (z) (%append '(1 2) '(3 4) z)))
+
+(test "%reverse '(a b c d)"
+      '((y (d c b a)))
+      (%which (y) (%reverse '(a b c d) y)))
+
+(test "%fact 5"
+      '((n 120))
+      (%which (n) (%fact 5 n)))
+
+(test "%fact 0"
+      '((n 1))
+      (%which (n) (%fact 0 n)))
+
+;; ---------------------------------------------------------------------------
+;; holland.scm tests
+;; ---------------------------------------------------------------------------
+(display "\n--- holland.scm ---\n")
+
+(test-not-false "%city amsterdam" (%which () (%city 'amsterdam)))
+(test-not-false "%city brussels" (%which () (%city 'brussels)))
+(test "%country amsterdam" #f (%which () (%country 'amsterdam)))
+(test-not-false "%country holland" (%which () (%country 'holland)))
+
+;; ---------------------------------------------------------------------------
+;; england.scm tests
+;; ---------------------------------------------------------------------------
+(display "\n--- england.scm ---\n")
+
+(test-not-false "%male philip" (%which () (%male 'philip)))
+(test-not-false "%female elizabeth" (%which () (%female 'elizabeth)))
+(test-not-false "%father-of philip charles" (%which () (%father-of 'philip 'charles)))
+(test-not-false "%mother-of elizabeth charles" (%which () (%mother-of 'elizabeth 'charles)))
+
+;; Count Philip's children
+(let ((count 0))
+  (let loop ((result (%which (c) (%father-of 'philip c))))
+    (when result
+      (set! count (+ count 1))
+      (loop (%more))))
+  (test "Philip has 4 children" 4 count))
+
+;; ---------------------------------------------------------------------------
+;; bible.scm tests
+;; ---------------------------------------------------------------------------
+(display "\n--- bible.scm ---\n")
+
+(let ((result (terachs-kids-test)))
+  (test-not-false "terachs-kids-test returns result" result)
+  (when result
+    (let ((kids (cdr (car result))))
+      (test "Terach has 3 kids" 3 (length kids)))))
+
+(let ((result (terachs-kids-test-2)))
+  (test-not-false "terachs-kids-test-2 (with %set-of)" result))
+
+;; ---------------------------------------------------------------------------
+;; mapcol.scm tests
+;; ---------------------------------------------------------------------------
+(display "\n--- mapcol.scm ---\n")
+
+(test-not-false "test map coloring" (%which (M) (%test-color 'test M)))
+(test-not-false "western-europe map coloring" (%which (M) (%test-color 'western-europe M)))
+
+;; ---------------------------------------------------------------------------
+;; games.scm tests
+;; ---------------------------------------------------------------------------
+(display "\n--- games.scm ---\n")
+
+(let ((result (solve-puzzle %games)))
+  (test-not-false "games puzzle has solution" result)
+  (when result
+    (let ((solution (schelog:deref* (cdr (car result)))))
+      (test "games puzzle answer 1"
+            '(michael is the australian)
+            (schelog:deref* (car solution)))
+      (test "games puzzle answer 2"
+            '(richard plays tennis)
+            (schelog:deref* (cadr solution))))))
+
+;; ---------------------------------------------------------------------------
+;; houses.scm tests (Zebra puzzle)
+;; ---------------------------------------------------------------------------
+(display "\n--- houses.scm (Zebra puzzle) ---\n")
+
+;; Enable occurs check for this puzzle
+(set! *schelog-use-occurs-check?* #t)
+
+(let ((result (solve-puzzle %houses)))
+  (test-not-false "zebra puzzle has solution" result)
+  (when result
+    (let ((solution (schelog:deref* (cdr (car result)))))
+      (test "zebra puzzle: japan owns zebra"
+            '(japan owns the zebra)
+            (schelog:deref* (car solution)))
+      (test "zebra puzzle: norway drinks water"
+            '(norway drinks water)
+            (schelog:deref* (cadr solution))))))
+
+;; ---------------------------------------------------------------------------
+;; Summary
+;; ---------------------------------------------------------------------------
+(newline)
+(display "=== Test Summary ===\n")
+(display "Passed: ")
+(display tests-passed)
+(newline)
+(display "Failed: ")
+(display tests-failed)
+(newline)
+
+(if (= tests-failed 0)
+    (display "\nAll tests passed! Wile is fully compatible with Schelog.\n")
+    (begin
+      (display "\nSome tests failed. See above for details.\n")
+      (exit 1)))

--- a/examples/logic/schelog/run-all-tests.sh
+++ b/examples/logic/schelog/run-all-tests.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Schelog Validation Suite for Wile
+#
+# This script runs all schelog examples to validate Wile's compatibility
+# with the Schelog logic programming library by Dorai Sitaram.
+#
+# Usage:
+#   cd <wile-root>
+#   ./examples/logic/schelog/run-all-tests.sh
+#
+# Expected output: All tests should pass with no errors.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WILE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCHEME="$WILE_ROOT/dist/scheme"
+SCHELOG_DIR="$SCRIPT_DIR"
+
+echo "=== Schelog Validation Suite for Wile ==="
+echo ""
+echo "Wile binary: $SCHEME"
+echo "Schelog dir: $SCHELOG_DIR"
+echo ""
+
+# Check that scheme binary exists
+if [ ! -x "$SCHEME" ]; then
+    echo "ERROR: Scheme binary not found at $SCHEME"
+    echo "Run 'make build' or 'go build -o dist/scheme ./cmd' first"
+    exit 1
+fi
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+run_test() {
+    local name="$1"
+    local files="$2"
+    local code="$3"
+
+    echo "Testing: $name"
+
+    # Build the command
+    local cmd="$SCHEME -q"
+    for f in $files; do
+        cmd="$cmd -i -f $SCHELOG_DIR/$f"
+    done
+
+    # Run the test
+    if output=$(echo "$code" | $cmd 2>&1); then
+        echo "  PASS"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo "  FAIL: $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+run_test_with_output() {
+    local name="$1"
+    local files="$2"
+    local code="$3"
+    local expected="$4"
+
+    echo "Testing: $name"
+
+    # Build the command
+    local cmd="$SCHEME -q"
+    for f in $files; do
+        cmd="$cmd -i -f $SCHELOG_DIR/$f"
+    done
+
+    # Run the test and capture output
+    if output=$(echo "$code" | $cmd 2>&1); then
+        if echo "$output" | grep -q "$expected"; then
+            echo "  PASS"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+            return 0
+        else
+            echo "  FAIL: expected '$expected' in output"
+            echo "  Got: $output"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            return 1
+        fi
+    else
+        echo "  FAIL: $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+echo "--- toys.scm ---"
+run_test_with_output "toys: %length" "schelog.scm toys.scm" \
+    '(display (%which (n) (%length (quote (a b c)) n)))' \
+    "((n 3))"
+
+run_test_with_output "toys: %append" "schelog.scm toys.scm" \
+    '(display (%which (z) (%append (quote (1 2)) (quote (3 4)) z)))' \
+    "((z (1 2 3 4)))"
+
+run_test_with_output "toys: %reverse" "schelog.scm toys.scm" \
+    '(display (%which (y) (%reverse (quote (a b c d)) y)))' \
+    "((y (d c b a)))"
+
+run_test_with_output "toys: %fact 5" "schelog.scm toys.scm" \
+    '(display (%which (n) (%fact 5 n)))' \
+    "((n 120))"
+
+echo ""
+echo "--- holland.scm ---"
+run_test_with_output "holland: city amsterdam" "schelog.scm holland.scm" \
+    '(display (if (%which () (%city (quote amsterdam))) "yes" "no"))' \
+    "yes"
+
+run_test_with_output "holland: country amsterdam (should be no)" "schelog.scm holland.scm" \
+    '(display (if (%which () (%country (quote amsterdam))) "yes" "no"))' \
+    "no"
+
+echo ""
+echo "--- england.scm ---"
+run_test_with_output "england: Philip is male" "schelog.scm england.scm" \
+    '(display (if (%which () (%male (quote philip))) "yes" "no"))' \
+    "yes"
+
+run_test_with_output "england: Philip father of Charles" "schelog.scm england.scm" \
+    '(display (if (%which () (%father-of (quote philip) (quote charles))) "yes" "no"))' \
+    "yes"
+
+echo ""
+echo "--- mapcol.scm ---"
+run_test_with_output "mapcol: test map" "schelog.scm mapcol.scm" \
+    '(display (if (%which (M) (%test-color (quote test) M)) "solved" "failed"))' \
+    "solved"
+
+run_test_with_output "mapcol: western-europe" "schelog.scm mapcol.scm" \
+    '(display (if (%which (M) (%test-color (quote western-europe) M)) "solved" "failed"))' \
+    "solved"
+
+echo ""
+echo "--- bible.scm ---"
+run_test_with_output "bible: terachs-kids-test" "schelog.scm bible.scm" \
+    '(display (if (terachs-kids-test) "found" "not found"))' \
+    "found"
+
+echo ""
+echo "--- games.scm ---"
+run_test_with_output "games: puzzle solution" "schelog.scm puzzle.scm games.scm" \
+    '(let ((r (solve-puzzle %games))) (display (if r "solved" "failed")))' \
+    "solved"
+
+run_test_with_output "games: michael is australian" "schelog.scm puzzle.scm games.scm" \
+    '(let ((r (solve-puzzle %games))) (display (schelog:deref* (car (cdr (car r))))))' \
+    "(michael is the australian)"
+
+echo ""
+echo "--- houses.scm (Zebra puzzle) ---"
+run_test_with_output "houses: zebra puzzle solved" "schelog.scm puzzle.scm houses.scm" \
+    '(begin (set! *schelog-use-occurs-check?* #t) (let ((r (solve-puzzle %houses))) (display (if r "solved" "failed"))))' \
+    "solved"
+
+run_test_with_output "houses: japan owns zebra" "schelog.scm puzzle.scm houses.scm" \
+    '(begin (set! *schelog-use-occurs-check?* #t) (let ((r (solve-puzzle %houses))) (display (schelog:deref* (car (car (cdr (car r))))))))' \
+    "(japan owns the zebra)"
+
+run_test_with_output "houses: norway drinks water" "schelog.scm puzzle.scm houses.scm" \
+    '(begin (set! *schelog-use-occurs-check?* #t) (let ((r (solve-puzzle %houses))) (display (schelog:deref* (cadr (car (cdr (car r))))))))' \
+    "(norway drinks water)"
+
+echo ""
+echo "=== Test Summary ==="
+echo "Passed: $TESTS_PASSED"
+echo "Failed: $TESTS_FAILED"
+echo ""
+
+if [ $TESTS_FAILED -eq 0 ]; then
+    echo "All tests passed! Wile is fully compatible with Schelog."
+    exit 0
+else
+    echo "Some tests failed. See above for details."
+    exit 1
+fi

--- a/examples/logic/schelog/schelog.scm
+++ b/examples/logic/schelog/schelog.scm
@@ -1,0 +1,729 @@
+;Schelog
+;An embedding of Prolog in Scheme
+;Dorai Sitaram
+;last modified 2018-06-09
+
+;logic variables and their manipulation
+
+(define schelog:*ref* "ref")
+
+(define schelog:*unbound* '_)
+
+(define schelog:make-ref
+  ;;makes a fresh unbound ref;
+  ;;unbound refs point to themselves
+  (lambda opt
+    (vector schelog:*ref*
+      (if (null? opt) schelog:*unbound*
+	(car opt)))))
+
+(define _ schelog:make-ref)
+
+(define schelog:ref?
+  (lambda (r)
+    (and (vector? r)
+	 (eq? (vector-ref r 0) schelog:*ref*))))
+
+(define schelog:deref
+  (lambda (r)
+    (vector-ref r 1)))
+
+(define schelog:set-ref!
+  (lambda (r v)
+    (vector-set! r 1 v)))
+
+(define schelog:unbound-ref?
+  (lambda (r)
+    (eq? (schelog:deref r) schelog:*unbound*)))
+
+(define schelog:unbind-ref!
+  (lambda (r)
+    (schelog:set-ref! r schelog:*unbound*)))
+
+;frozen logic vars
+
+(define schelog:*frozen* "frozen")
+
+(define schelog:freeze-ref
+  (lambda (r)
+    (schelog:make-ref (vector schelog:*frozen* r))))
+
+(define schelog:thaw-frozen-ref
+  (lambda (r)
+    (vector-ref (schelog:deref r) 1)))
+
+(define schelog:frozen-ref?
+  (lambda (r)
+    (let ((r2 (schelog:deref r)))
+      (and (vector? r2)
+	   (eq? (vector-ref r2 0) schelog:*frozen*)))))
+
+;deref a structure completely (except the frozen ones, i.e.)
+
+(define schelog:deref*
+  (lambda (s)
+    (cond ((schelog:ref? s)
+	   (if (schelog:frozen-ref? s) s
+	     (schelog:deref* (schelog:deref s))))
+	  ((pair? s) (cons (schelog:deref* (car s))
+                       (schelog:deref* (cdr s))))
+	  ((vector? s)
+	   (list->vector (map schelog:deref* (vector->list s))))
+	  (else s))))
+
+;%let introduces new logic variables
+
+(define-syntax %let
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (x* (cadr so-d))
+             (e* (cddr so-d)))
+        `(let ,(map (lambda (x) `(,x (schelog:make-ref))) x*)
+           ,@e*)))))
+
+;the unify predicate
+
+(define *schelog-use-occurs-check?* #f)
+
+(define schelog:occurs-in?
+  (lambda (var term)
+    (and *schelog-use-occurs-check?*
+         (let loop ((term term))
+           (cond ((eqv? var term) #t)
+                 ((schelog:ref? term)
+                  (cond ((schelog:unbound-ref? term) #f)
+                        ((schelog:frozen-ref? term) #f)
+                        (else (loop (schelog:deref term)))))
+                 ((pair? term)
+                  (or (loop (car term)) (loop (cdr term))))
+                 ((vector? term)
+                  (loop (vector->list term)))
+                 (else #f))))))
+
+(define schelog:unify
+  (lambda (t1 t2)
+    (lambda (fk)
+      (let ((unwind-trail
+              (lambda (s)
+                (for-each schelog:unbind-ref! s)
+                (fk 'unwind-trail)))
+            (cleanup-n-fail
+              (lambda (s)
+                (for-each schelog:unbind-ref! s)
+                (fk 'fail))))
+        (letrec ((unify1
+                   (lambda (t1 t2 s)
+                     ;(printf "unify1 ~s ~s~%" t1 t2)
+                     (cond ((eqv? t1 t2) s)
+                           ((schelog:ref? t1)
+                            (cond ((schelog:unbound-ref? t1)
+                                   (cond ((schelog:occurs-in? t1 t2)
+                                          (cleanup-n-fail s))
+                                         (else
+                                           (schelog:set-ref! t1 t2)
+                                           (cons t1 s))))
+                                  ((schelog:frozen-ref? t1)
+                                   (cond ((schelog:ref? t2)
+                                          (cond ((schelog:unbound-ref? t2)
+                                                 ;(printf "t2 is unbound~%")
+                                                 (unify1 t2 t1 s))
+                                                ((schelog:frozen-ref? t2)
+                                                 (cleanup-n-fail s))
+                                                (else
+                                                  (unify1 t1 (schelog:deref t2) s))))
+                                         (else (cleanup-n-fail s))))
+                                  (else
+                                    ;(printf "derefing t1~%")
+                                    (unify1 (schelog:deref t1) t2 s))))
+                           ((schelog:ref? t2) (unify1 t2 t1 s))
+                           ((and (pair? t1) (pair? t2))
+                            (unify1 (cdr t1) (cdr t2)
+                                    (unify1 (car t1) (car t2) s)))
+                           ((and (string? t1) (string? t2))
+                            (if (string=? t1 t2) s
+                              (cleanup-n-fail s)))
+                           ((and (vector? t1) (vector? t2))
+                            (unify1 (vector->list t1)
+                                    (vector->list t2) s))
+                           (else
+                             (cleanup-n-fail s))))))
+          (let ((s (unify1 t1 t2 '())))
+            (lambda (msg)
+              ((if (eq? msg 'unwind-trail)
+                   unwind-trail
+                 cleanup-n-fail) s))))))))
+
+(define %= schelog:unify)
+
+;disjunction
+
+(define schelog:make-failure-continuation
+  (lambda (fk)
+    (lambda (msg)
+      (if (not (eq? msg 'unwind-trail))
+          (fk 'fail)
+        #f))))
+
+(define schelog:call-with-failure-continuation
+  (lambda (f)
+    (call-with-current-continuation
+      (lambda (fk)
+        (f (schelog:make-failure-continuation fk))))))
+
+(define-syntax %or
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (gg (cdr so-d)))
+        `(lambda (__fk)
+           (call-with-current-continuation
+             (lambda (__sk)
+               ,@(map (lambda (g)
+                        `(schelog:call-with-failure-continuation
+                           (lambda (__fk)
+                             (__sk ((schelog:deref* ,g) __fk)))))
+                      gg)
+               (__fk 'fail))))))))
+
+;conjunction
+
+(define-syntax %and
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (gg (cdr so-d)))
+        `(lambda (__fk)
+           (let* ,(map (lambda (g) `(__fk ((schelog:deref* ,g) __fk))) gg)
+             __fk))))))
+
+;cut
+
+(define-syntax %cut-delimiter
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (g (cadr so-d)))
+        `(lambda (__fk)
+           (let ((! (lambda (__fk2) (__fk2 'unwind-trail) __fk)))
+             ((schelog:deref* ,g) __fk)))))))
+
+;Prolog-like sugar
+
+(define-syntax %rel
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (vv (cadr so-d))
+             (cc (cddr so-d)))
+        `(lambda __fmls
+           (lambda (__fk)
+             (call-with-current-continuation
+               (lambda (__sk)
+                 (let ((! (lambda (fk1) (fk1 'unwind-trail) __fk)))
+                   (%let ,vv
+                         ,@(map (lambda (c)
+                                  `(schelog:call-with-failure-continuation
+                                     (lambda (__fk)
+                                       (let* ((__fk ((%= __fmls (list ,@(car c)))
+                                                     __fk))
+                                              ,@(map (lambda (sg)
+                                                       `(__fk ((schelog:deref* ,sg)
+                                                               __fk)))
+                                                     (cdr c)))
+                                         (__sk __fk)))))
+                                cc)
+                         (__fk 'fail)))))))))))
+
+;the fail and true preds
+
+(define %fail
+  (lambda (fk) (fk 'fail)))
+
+(define %true
+  (lambda (fk) fk))
+
+;for structures ("functors"), use Scheme's list and vector
+;functions and anything that's built using them.
+
+;arithmetic
+
+(define-syntax %is
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (v (cadr so-d))
+             (e (caddr so-d)))
+        (letrec ((%is-help (lambda (e fk)
+                             (cond ((pair? e)
+                                    (cond ((eq? (car e) 'quote) e)
+                                          (else
+                                            (map (lambda (e1)
+                                                   (%is-help e1 fk)) e))))
+                                   (else
+                                     `(if (and (schelog:ref? ,e)
+                                               (schelog:unbound-ref? ,e))
+                                        (,fk 'fail) (schelog:deref* ,e)))))))
+          `(lambda (__fk)
+             ((%= ,v ,(%is-help e '__fk)) __fk)))))))
+
+;defining arithmetic comparison operators
+
+(define schelog:make-binary-arithmetic-relation
+  (lambda (f)
+    (lambda (x y)
+      (%is #t (f x y)))))
+
+(define %=:= (schelog:make-binary-arithmetic-relation =))
+(define %> (schelog:make-binary-arithmetic-relation >))
+(define %>= (schelog:make-binary-arithmetic-relation >=))
+(define %< (schelog:make-binary-arithmetic-relation <))
+(define %<= (schelog:make-binary-arithmetic-relation <=))
+(define %=/= (schelog:make-binary-arithmetic-relation
+               (lambda (m n) (not (= m n)))))
+
+;type predicates
+
+(define schelog:constant?
+  (lambda (x)
+    (cond ((schelog:ref? x)
+	   (cond ((schelog:unbound-ref? x) #f)
+		 ((schelog:frozen-ref? x) #t)
+		 (else (schelog:constant? (schelog:deref x)))))
+	  ((pair? x) #f)
+	  ((vector? x) #f)
+	  (else #t))))
+
+(define schelog:compound?
+  (lambda (x)
+    (cond ((schelog:ref? x) (cond ((schelog:unbound-ref? x) #f)
+			  ((schelog:frozen-ref? x) #f)
+			  (else (schelog:compound? (schelog:deref x)))))
+	  ((pair? x) #t)
+	  ((vector? x) #t)
+	  (else #f))))
+
+(define %constant
+  (lambda (x)
+    (lambda (fk)
+      (if (schelog:constant? x) fk (fk 'fail)))))
+
+(define %compound
+  (lambda (x)
+    (lambda (fk)
+      (if (schelog:compound? x) fk (fk 'fail)))))
+
+;metalogical type predicates
+
+(define schelog:var?
+  (lambda (x)
+    (cond ((schelog:ref? x)
+	   (cond ((schelog:unbound-ref? x) #t)
+		 ((schelog:frozen-ref? x) #f)
+		 (else (schelog:var? (schelog:deref x)))))
+	  ((pair? x) (or (schelog:var? (car x)) (schelog:var? (cdr x))))
+	  ((vector? x) (schelog:var? (vector->list x)))
+	  (else #f))))
+
+(define %var
+  (lambda (x)
+    (lambda (fk) (if (schelog:var? x) fk (fk 'fail)))))
+
+(define %nonvar
+  (lambda (x)
+    (lambda (fk) (if (schelog:var? x) (fk 'fail) fk))))
+
+; negation of unify
+
+(define schelog:make-negation ;basically inlined cut-fail
+  (lambda (p)
+    (lambda args
+      (lambda (fk)
+	(if (call-with-current-continuation
+	      (lambda (k)
+		((apply p args)
+                 (schelog:make-failure-continuation (lambda (d) (k #f))))))
+	    (fk 'fail)
+	    fk)))))
+
+(define %/=
+  (schelog:make-negation %=))
+
+;identical
+
+(define schelog:ident?
+  (lambda (x y)
+    (cond ((schelog:ref? x)
+	   (cond ((schelog:unbound-ref? x)
+		  (cond ((schelog:ref? y)
+			 (cond ((schelog:unbound-ref? y) (eq? x y))
+			       ((schelog:frozen-ref? y) #f)
+			       (else (schelog:ident? x (schelog:deref y)))))
+			(else #f)))
+		 ((schelog:frozen-ref? x)
+		  (cond ((schelog:ref? y)
+			 (cond ((schelog:unbound-ref? y) #f)
+			       ((schelog:frozen-ref? y) (eq? x y))
+			       (else (schelog:ident? x (schelog:deref y)))))
+			(else #f)))
+		 (else (schelog:ident? (schelog:deref x) y))))
+	  ((pair? x)
+	   (cond ((schelog:ref? y)
+		  (cond ((schelog:unbound-ref? y) #f)
+			((schelog:frozen-ref? y) #f)
+			(else (schelog:ident? x (schelog:deref y)))))
+		 ((pair? y)
+		  (and (schelog:ident? (car x) (car y))
+		       (schelog:ident? (cdr x) (cdr y))))
+		 (else #f)))
+	  ((vector? x)
+	   (cond ((schelog:ref? y)
+		  (cond ((schelog:unbound-ref? y) #f)
+			((schelog:frozen-ref? y) #f)
+			(else (schelog:ident? x (schelog:deref y)))))
+		 ((vector? y)
+		  (schelog:ident? (vector->list x)
+		    (vector->list y)))
+		 (else #f)))
+	  (else
+	    (cond ((schelog:ref? y)
+		   (cond ((schelog:unbound-ref? y) #f)
+			 ((schelog:frozen-ref? y) #f)
+			 (else (schelog:ident? x (schelog:deref y)))))
+		  ((pair? y) #f)
+		  ((vector? y) #f)
+		  (else (eqv? x y)))))))
+
+(define %==
+  (lambda (x y)
+    (lambda (fk) (if (schelog:ident? x y) fk (fk 'fail)))))
+
+(define %/==
+  (lambda (x y)
+    (lambda (fk) (if (schelog:ident? x y) (fk 'fail) fk))))
+
+;variables as objects
+
+(define schelog:freeze
+  (lambda (s)
+    (let ((dict '()))
+      (let loop ((s s))
+	(cond ((schelog:ref? s)
+	       (cond ((or (schelog:unbound-ref? s) (schelog:frozen-ref? s))
+		      (let ((x (assq s dict)))
+			(if x (cdr x)
+			    (let ((y (schelog:freeze-ref s)))
+			      (set! dict (cons (cons s y) dict))
+			      y))))
+		     ;((schelog:frozen-ref? s) s) ;?
+		     (else (loop (schelog:deref s)))))
+	      ((pair? s) (cons (loop (car s)) (loop (cdr s))))
+	      ((vector? s)
+	       (list->vector (map loop (vector->list s))))
+	      (else s))))))
+
+(define schelog:melt
+  (lambda (f)
+    (cond ((schelog:ref? f)
+	   (cond ((schelog:unbound-ref? f) f)
+		 ((schelog:frozen-ref? f) (schelog:thaw-frozen-ref f))
+		 (else (schelog:melt (schelog:deref f)))))
+	  ((pair? f)
+	   (cons (schelog:melt (car f)) (schelog:melt (cdr f))))
+	  ((vector? f)
+	   (list->vector (map schelog:melt (vector->list f))))
+	  (else f))))
+
+(define schelog:melt-new
+  (lambda (f)
+    (let ((dict '()))
+      (let loop ((f f))
+	(cond ((schelog:ref? f)
+	       (cond ((schelog:unbound-ref? f) f)
+		     ((schelog:frozen-ref? f)
+		      (let ((x (assq f dict)))
+			(if x (cdr x)
+			    (let ((y (schelog:make-ref)))
+			      (set! dict (cons (cons f y) dict))
+			      y))))
+		     (else (loop (schelog:deref f)))))
+	      ((pair? f) (cons (loop (car f)) (loop (cdr f))))
+	      ((vector? f)
+	       (list->vector (map loop (vector->list f))))
+	      (else f))))))
+
+(define schelog:copy
+  (lambda (s)
+    (schelog:melt-new (schelog:freeze s))))
+
+(define %freeze
+  (lambda (s f)
+    (lambda (fk)
+      ((%= (schelog:freeze s) f) fk))))
+
+(define %melt
+  (lambda (f s)
+    (lambda (fk)
+      ((%= (schelog:melt f) s) fk))))
+
+(define %melt-new
+  (lambda (f s)
+    (lambda (fk)
+      ((%= (schelog:melt-new f) s) fk))))
+
+(define %copy
+  (lambda (s c)
+    (lambda (fk)
+      ((%= (schelog:copy s) c) fk))))
+
+;negation as failure
+
+(define %not
+  (lambda (g)
+    (%cut-delimiter
+      (%or (%and g ! %fail)
+           %true))))
+
+;assert, asserta
+
+(define %empty-rel
+  (lambda args
+    %fail))
+
+(define-syntax %assert
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (rel-name (cadr so-d))
+             (vv (caddr so-d))
+             (cc (cdddr so-d)))
+    `(set! ,rel-name
+           (let ((__old-rel ,rel-name)
+                 (__new-addition (%rel ,vv ,@cc)))
+             (lambda __fmls
+               (%or (apply __old-rel __fmls)
+                    (apply __new-addition __fmls)))))))))
+
+(define-syntax %assert-a
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (rel-name (cadr so-d))
+             (vv (caddr so-d))
+             (cc (cdddr so-d)))
+        `(set! ,rel-name
+           (let ((__old-rel ,rel-name)
+                 (__new-addition (%rel ,vv ,@cc)))
+             (lambda __fmls
+               (%or (apply __new-addition __fmls)
+                    (apply __old-rel __fmls)))))))))
+
+;set predicates
+
+(define schelog:set-cons
+  (lambda (e s)
+    (if (member e s) s (cons e s))))
+
+(define-syntax %free-vars
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (vv (cadr so-d))
+             (g (caddr so-d)))
+        `(cons 'schelog:goal-with-free-vars
+               (cons (list ,@vv) ,g))))))
+
+(define schelog:goal-with-free-vars?
+  (lambda (x)
+    (and (pair? x) (eq? (car x) 'schelog:goal-with-free-vars))))
+
+(define schelog:make-bag-of
+  (lambda (kons)
+    (lambda (lv goal bag)
+      (let ((fvv '()))
+        (if (schelog:goal-with-free-vars? goal)
+          (begin (set! fvv (cadr goal))
+            (set! goal (cddr goal)))
+          #f)
+        (schelog:make-bag-of-aux kons fvv lv goal bag)))))
+
+(define schelog:make-bag-of-aux
+  (lambda (kons fvv lv goal bag)
+    (lambda (fk)
+      (call-with-current-continuation
+        (lambda (sk)
+          (let ((lv2 (cons fvv lv)))
+            (let* ((acc '())
+                    (fk-final
+                     (schelog:make-failure-continuation
+                      (lambda (d)
+                        ;;(set! acc (reverse! acc))
+                        (sk ((schelog:separate-bags fvv bag acc) fk)))))
+                    (fk-retry (goal fk-final)))
+              (set! acc (kons (schelog:deref* lv2) acc))
+              (fk-retry 'retry))))))))
+
+(define schelog:separate-bags
+  (lambda (fvv bag acc)
+    ;;(format #t "Accum: ~s~%" acc)
+    (let ((bags (let loop ((acc acc)
+                            (current-fvv #f) (current-bag '())
+                            (bags '()))
+                  (if (null? acc)
+                    (cons (cons current-fvv current-bag) bags)
+                    (let ((x (car acc)))
+                      (let ((x-fvv (car x)) (x-lv (cdr x)))
+                        (if (or (not current-fvv) (equal? x-fvv current-fvv))
+                          (loop (cdr acc) x-fvv (cons x-lv current-bag) bags)
+                          (loop (cdr acc) x-fvv (list x-lv)
+                            (cons (cons current-fvv current-bag) bags)))))))))
+      ;;(format #t "Bags: ~a~%" bags)
+      (if (null? bags) (%= bag '())
+        (let ((fvv-bag (cons fvv bag)))
+          (let loop ((bags bags))
+            (if (null? bags) %fail
+              (%or (%= fvv-bag (car bags))
+                (loop (cdr bags))))))))))
+
+(define %bag-of (schelog:make-bag-of cons))
+(define %set-of (schelog:make-bag-of schelog:set-cons))
+
+;%bag-of-1, %set-of-1 hold if there's at least one solution
+
+(define %bag-of-1
+  (lambda (x g b)
+    (%and (%bag-of x g b)
+      (%= b (cons (_) (_))))))
+
+(define %set-of-1
+  (lambda (x g s)
+    (%and (%set-of x g s)
+      (%= s (cons (_) (_))))))
+
+;user interface
+
+;(%which (v ...) query) returns #f if query fails and instantiations
+;of v ... if query succeeds.  In the latter case, type (%more) to
+;retry query for more instantiations.
+
+(define schelog:*more-k* 'forward)
+(define schelog:*more-fk* 'forward)
+
+(define-syntax %which
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (vv (cadr so-d))
+             (g (caddr so-d)))
+        `(%let ,vv
+               (call-with-current-continuation
+                 (lambda (__qk)
+                   (set! schelog:*more-k* __qk)
+                   (set! schelog:*more-fk*
+                     ((schelog:deref* ,g)
+                      (schelog:make-failure-continuation
+                      (lambda (d)
+                        (set! schelog:*more-fk* #f)
+                        (schelog:*more-k* #f)))))
+                   (schelog:*more-k*
+                     (map (lambda (nam val) (list nam (schelog:deref* val)))
+                          ',vv
+                          (list ,@vv))))))))))
+
+(define %more
+  (lambda ()
+    (call-with-current-continuation
+      (lambda (k)
+	(set! schelog:*more-k* k)
+	(if schelog:*more-fk* (schelog:*more-fk* 'more)
+	  #f)))))
+
+;end of embedding code.  The following are
+;some utilities, written in Schelog
+
+(define %member
+  (lambda (x y)
+    (%let (xs z zs)
+      (%or
+	(%= y (cons x xs))
+	(%and (%= y (cons z zs))
+	  (%member x zs))))))
+
+(define %if-then-else
+  (lambda (p q r)
+    (%cut-delimiter
+      (%or
+	(%and p ! q)
+	r))))
+
+;the above could also have been written in a more
+;Prolog-like fashion, viz.
+
+'(define %member
+  (%rel (x xs y ys)
+    ((x (cons x xs)))
+    ((x (cons y ys)) (%member x ys))))
+
+'(define %if-then-else
+  (%rel (p q r)
+    ((p q r) p ! q)
+    ((p q r) r)))
+
+(define %append
+  (%rel (x xs ys zs)
+    (('() ys ys))
+    (((cons x xs) ys (cons x zs))
+      (%append xs ys zs))))
+
+(define %repeat
+  ;;failure-driven loop
+  (%rel ()
+    (())
+    (() (%repeat))))
+
+; deprecated names -- retained here for backward-compatibility
+
+(define == %=)
+(define %notunify %/=)
+
+(define-syntax %cut
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (e (cdr so-d)))
+        `(%cut-delimiter ,@e)))))
+
+(define-syntax rel
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (e (cdr so-d)))
+        `(%rel ,@e)))))
+
+(define %eq %=:=)
+(define %gt %>)
+(define %ge %>=)
+(define %lt %<)
+(define %le %<=)
+(define %ne %=/=)
+(define %ident %==)
+(define %notident %/==)
+
+(define-syntax %exists
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (vv (cadr so-d))
+             (g (caddr so-d)))
+        g))))
+
+(define-syntax which
+  (lambda (so)
+    (datum->syntax so
+      (let* ((so-d (syntax->datum so))
+             (e (cdr so-d)))
+        `(%which ,@e)))))
+
+(define more %more)
+
+;end of file

--- a/examples/logic/schelog/toys.scm
+++ b/examples/logic/schelog/toys.scm
@@ -1,0 +1,84 @@
+;A list of trivial programs in Prolog, just so you can get used
+;to schelog syntax.
+
+;(%length l n) holds if length(l) = n
+
+(define %length
+  (%rel (h t n m)
+    (('() 0))
+    (((cons h t) n) (%length t m) (%is n (+ m 1)))))
+
+;(%delete x y z) holds if z is y with all x's removed
+
+(define %delete
+  (%rel (x y z w)
+    ((x '() '()))
+    ((x (cons x w) y) (%delete x w y))
+    ((x (cons z w) (cons z y)) (%not (%= x z)) (%delete x w y))))
+
+;(%remdup x y) holds if y is x without duplicates
+
+(define %remdup
+  (%rel (x y z w)
+    (('() '()))
+    (((cons x y) (cons x z)) (%delete x y w) (%remdup w z))))
+
+;(%count x n) holds if n is the number of elements in x without
+;counting duplicates
+
+'(define %count
+  (%rel (x n y)
+    ((x n) (%remdup x y) (%length y n))))
+
+;same thing
+
+(define %count
+  (letrec ((countaux
+	     (%rel (m n m+1 x y z)
+	       (('() m m))
+	       (((cons x y) m n)
+		(%delete x y z) (%is m+1 (+ m 1)) (countaux z m+1 n)))))
+    (%rel (x n)
+      ((x n) (countaux x 0 n)))))
+
+;(%append x y z) holds if z is the concatenation of x and y
+
+(define %append
+  (%rel (x y z w)
+    (('() x x))
+    (((cons x y) z (cons x w)) (%append y z w))))
+
+;(%reverse x y) holds if the y is the reversal of x
+
+'(define %reverse
+  (%rel (x y z yy)
+    (('() '()))
+    (((cons x y) z) (%reverse y yy) (%append yy (list x) z))))
+
+;same thing, but tailcall optimizing
+
+(define %reverse
+  (letrec ((revaux
+	     (%rel (x y z w)
+	       (('() y y))
+	       (((cons x y) z w) (revaux y (cons x z) w)))))
+    (%rel (x y)
+      ((x y) (revaux x '() y)))))
+
+;(%fact n m) holds if m = n!
+
+'(define %fact
+  (%rel (n n! n-1 n-1!)
+    ((0 1))
+    ((n n!) (%is n-1 (- n 1)) (%fact n-1 n-1!) (%is n! (* n n-1!)))))
+
+;same thing, but tailcall optimizing
+
+(define %fact
+  (letrec ((factaux
+	     (%rel (n! m x m-1 xx)
+	       ((0 n! n!))
+	       ((m x n!) (%is m-1 (- m 1)) (%is xx (* x m))
+		(factaux m-1 xx n!)))))
+    (%rel (n n!)
+      ((n n!) (factaux n 1 n!)))))

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
+	wileruntime "github.com/aalpar/wile/runtime"
 
 	"github.com/ergochat/readline"
 )
@@ -354,33 +355,25 @@ func (p *lineReader) ReadLine() (string, error) {
 }
 
 // Compile expands and compiles a syntax expression into a native template.
-// This is a standalone function that can be used outside of a REPL context.
+//
+// Deprecated: Use [github.com/aalpar/wile/runtime.Compile] instead.
+// This function delegates to the runtime package.
 func Compile(env *environment.EnvironmentFrame, expr syntax.SyntaxValue) (*machine.NativeTemplate, error) {
-	tpl := machine.NewNativeTemplate(0, 0, false)
-
-	ectx := machine.NewExpandTimeCallContext()
-	stx1, err := machine.NewExpanderTimeContinuation(env).ExpandExpression(ectx, expr)
-	if err != nil {
-		return nil, fmt.Errorf("expansion error: %w", err)
-	}
-
-	// Use inTail=false for top-level expressions
-	cctx := machine.NewCompileTimeCallContext(false, true, env)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, stx1)
-	if err != nil {
-		return nil, fmt.Errorf("compilation error: %w", err)
-	}
-	return tpl, nil
+	return wileruntime.Compile(env, expr)
 }
 
 // Run executes a compiled template and returns the result values.
-// This is a standalone function that can be used outside of a REPL context.
+//
+// Deprecated: Use [github.com/aalpar/wile/runtime.Run] instead.
+// This function delegates to the runtime package.
 func Run(ctx context.Context, tpl *machine.NativeTemplate, env *environment.EnvironmentFrame) (machine.MultipleValues, error) {
-	cont := machine.NewMachineContinuation(nil, tpl, env)
-	mc := machine.NewMachineContext(ctx, cont)
-	err := mc.RunWithEscapeHandling()
-	if err != nil {
-		return nil, err
-	}
-	return mc.GetValues(), nil
+	return wileruntime.Run(ctx, tpl, env)
+}
+
+// Load reads and evaluates Scheme expressions from a reader into the environment.
+//
+// Deprecated: Use [github.com/aalpar/wile/runtime.Load] instead.
+// This function delegates to the runtime package.
+func Load(ctx context.Context, env *environment.EnvironmentFrame, r io.Reader, filename string) error {
+	return wileruntime.Load(ctx, env, r, filename)
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package runtime provides the core API for embedding Wile Scheme in Go applications.
+//
+// This package exposes the essential functions for compiling and executing Scheme code:
+//
+//   - [Compile] transforms syntax into executable templates
+//   - [Run] executes compiled templates
+//   - [Load] reads and evaluates Scheme code from an io.Reader
+//
+// # Basic Usage
+//
+// To evaluate Scheme code from a string:
+//
+//	env, _ := bootstrap.NewTopLevelEnvironmentFrameTiny(ctx)
+//	reader := strings.NewReader(`(+ 1 2)`)
+//	err := runtime.Load(ctx, env, reader, "example.scm")
+//
+// # Creating Environments
+//
+// Use [github.com/aalpar/wile/internal/bootstrap.NewTopLevelEnvironmentFrameTiny]
+// to create a top-level environment with all standard bindings.
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/aalpar/wile/environment"
+	"github.com/aalpar/wile/internal/parser"
+	"github.com/aalpar/wile/internal/syntax"
+	"github.com/aalpar/wile/machine"
+)
+
+// Compile expands and compiles a syntax expression into an executable template.
+//
+// The returned [machine.NativeTemplate] can be executed multiple times with [Run].
+// This is useful when the same code needs to be evaluated repeatedly.
+func Compile(env *environment.EnvironmentFrame, expr syntax.SyntaxValue) (*machine.NativeTemplate, error) {
+	tpl := machine.NewNativeTemplate(0, 0, false)
+
+	ectx := machine.NewExpandTimeCallContext()
+	expanded, err := machine.NewExpanderTimeContinuation(env).ExpandExpression(ectx, expr)
+	if err != nil {
+		return nil, fmt.Errorf("expansion error: %w", err)
+	}
+
+	// Use inTail=false for top-level expressions
+	cctx := machine.NewCompileTimeCallContext(false, true, env)
+	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	if err != nil {
+		return nil, fmt.Errorf("compilation error: %w", err)
+	}
+
+	return tpl, nil
+}
+
+// Run executes a compiled template and returns the result values.
+//
+// The template is executed in the context of the given environment. Any definitions
+// or side effects will modify the environment.
+func Run(ctx context.Context, tpl *machine.NativeTemplate, env *environment.EnvironmentFrame) (machine.MultipleValues, error) {
+	cont := machine.NewMachineContinuation(nil, tpl, env)
+	mc := machine.NewMachineContext(ctx, cont)
+	err := mc.RunWithEscapeHandling()
+	if err != nil {
+		return nil, err
+	}
+	return mc.GetValues(), nil
+}
+
+// Load reads and evaluates Scheme expressions from a reader into the environment.
+//
+// All expressions are read, wrapped in a (begin ...) form, compiled, and executed.
+// This is the primary way to load Scheme libraries or configuration files.
+//
+// The filename parameter is used for error messages and source location tracking.
+// Pass an empty string if the source has no associated filename.
+func Load(ctx context.Context, env *environment.EnvironmentFrame, r io.Reader, filename string) error {
+	p := parser.NewParserWithFile(env, true, bufio.NewReader(r), filename)
+
+	// Collect all expressions from the reader
+	var exprs []syntax.SyntaxValue
+	for {
+		stx, err := p.ReadSyntax(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("parse error in %s: %w", filename, err)
+		}
+		exprs = append(exprs, stx)
+	}
+
+	// Nothing to do if empty
+	if len(exprs) == 0 {
+		return nil
+	}
+
+	// Wrap in (begin ...) if multiple expressions
+	var programStx syntax.SyntaxValue
+	if len(exprs) == 1 {
+		programStx = exprs[0]
+	} else {
+		sctx := syntax.NewZeroValueSourceContext()
+		beginSym := syntax.NewSyntaxSymbol("begin", sctx)
+		allExprs := make([]syntax.SyntaxValue, 0, len(exprs)+1)
+		allExprs = append(allExprs, beginSym)
+		allExprs = append(allExprs, exprs...)
+		programStx = syntax.SyntaxList(sctx, allExprs...)
+	}
+
+	// Compile and run
+	tpl, err := Compile(env, programStx)
+	if err != nil {
+		return fmt.Errorf("compile error in %s: %w", filename, err)
+	}
+
+	_, err = Run(ctx, tpl, env)
+	if err != nil && !errors.Is(err, machine.ErrMachineHalt) {
+		return fmt.Errorf("runtime error in %s: %w", filename, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR adds a public `runtime` package for embedding and demonstrates Wile's capabilities with the Schelog logic programming library.

## Changes

### New `runtime` Package

Moves core execution functions out of `internal/repl` to make them available to external embedders:

```go
import "github.com/aalpar/wile/runtime"

// Load Scheme code from any io.Reader
err := runtime.Load(ctx, env, file, "mylib.scm")

// Or compile and run separately
tpl, _ := runtime.Compile(env, syntaxExpr)
result, _ := runtime.Run(ctx, tpl, env)
```

### CLI Enhancements

- **`-i`/`--interactive`**: Enter REPL after loading files
- **`-f` repeatable**: Load multiple files in order

```bash
# Load library, then enter REPL
./dist/scheme -i -f lib.scm

# Load multiple files
./dist/scheme -i -f schelog.scm -f puzzle.scm -f houses.scm
```

### Schelog Example

Complete working example of [Schelog](https://github.com/ds26gte/schelog) (Prolog-in-Scheme):

- **Unmodified** `schelog.scm` from upstream
- All 9 upstream examples included
- Validation suite with 16 passing tests
- Includes the famous Zebra puzzle

```bash
./examples/logic/schelog/run-all-tests.sh
# Passed: 16, Failed: 0
```

## Why This Matters

1. **Embedding API**: The `runtime` package provides the clean public API that embedders need
2. **Proof of capability**: Schelog exercises procedural macros (`define-syntax` + `lambda`), `call/cc`, occurs-check, and complex backtracking
3. **Use case validation**: Logic programming in Go without CGo is a key Wile use case

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] Schelog validation suite passes (16/16 tests)
- [x] Manual testing of `-i` and multiple `-f` flags

🤖 Generated with [Claude Code](https://claude.ai/code)