### PR TITLE
fix: close file descriptors after loading Scheme files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -161,22 +161,28 @@ func main() {
 			if !opts.Quiet {
 				log.Printf("reading file %q", filename)
 			}
-			fd, err := os.Open(filename)
+			descriptor, err := os.Open(filename)
 			if err != nil {
 				Failf(err, "Cannot open file %s", filename)
 			}
-			isLastFile := i == len(opts.File)-1
-			if opts.Interactive || !isLastFile {
-				// Load file silently (all files in interactive mode, or non-last files in batch mode)
-				if err := runtime.Load(ctx, env, fd, filename); err != nil {
-					Failf(err)
+			func(fn string, fd *os.File) {
+				defer func() {
+					_ = fd.Close()
+				}()
+				isLastFile := i == len(opts.File)-1
+				if opts.Interactive || !isLastFile {
+					// Load file silently (all files in interactive mode, or non-last files in batch mode)
+					err = runtime.Load(ctx, env, fd, fn)
+					if err != nil {
+						Failf(err)
+					}
+				} else {
+					// Run last file (print results) and exit in non-interactive mode
+					fin = bufio.NewReader(fd)
+					runFile(ctx, env, fin, fn)
+					return
 				}
-			} else {
-				// Run last file (print results) and exit in non-interactive mode
-				fin = bufio.NewReader(fd)
-				runFile(ctx, env, fin, filename)
-				return
-			}
+			}(filename, descriptor)
 		}
 	}
 	// interactive REPL using the repl package


### PR DESCRIPTION
## Summary

- Add explicit `fd.Close()` calls after reading files with the `-f` flag
- Fixes resource leak where file descriptors were left open

This addresses Copilot feedback on PR #96.

## Test plan

- [x] `go build` succeeds
- [x] Quick REPL test: `echo '(+ 1 2)' | ./dist/scheme`
- [x] File execution test: `./dist/scheme -q -f test.scm`

🤖 Generated with [Claude Code](https://claude.ai/code)