### PR TITLE
fix: use errors.Is for all sentinel error comparisons

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -16,6 +16,7 @@ package wile
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/aalpar/wile/environment"
@@ -215,7 +216,7 @@ func (p *Engine) Call(ctx context.Context, proc Value, args ...Value) (Value, er
 
 	err = sub.Run()
 	if err != nil {
-		if err != machine.ErrMachineHalt {
+		if !errors.Is(err, machine.ErrMachineHalt) {
 			return nil, err
 		}
 	}
@@ -295,7 +296,7 @@ func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame,
 			mc := machine.NewMachineContext(ctx, cont)
 			err = mc.Run()
 			if err != nil {
-				if err != machine.ErrMachineHalt {
+				if !errors.Is(err, machine.ErrMachineHalt) {
 					return err
 				}
 			}

--- a/error.go
+++ b/error.go
@@ -14,7 +14,10 @@
 
 package wile
 
-import "io"
+import (
+	"errors"
+	"io"
+)
 
 // Error represents a Wile engine error.
 type Error struct {
@@ -35,5 +38,5 @@ func (p *Error) Unwrap() error {
 
 // isEOF checks if an error represents end of input.
 func isEOF(err error) bool {
-	return err == io.EOF
+	return errors.Is(err, io.EOF)
 }

--- a/internal/bootstrap/environment_tiny.go
+++ b/internal/bootstrap/environment_tiny.go
@@ -29,6 +29,7 @@ package bootstrap
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 
@@ -200,7 +201,7 @@ func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame,
 
 		for {
 			stx, err := p.ReadSyntax(ctx)
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/internal/extensions/io/prim_read_write.go
+++ b/internal/extensions/io/prim_read_write.go
@@ -926,11 +926,11 @@ func PrimReadBytevectorBang(_ context.Context, mc *machine.MachineContext) error
 	buf := make([]byte, end-start)
 	n, err := p.Read(buf)
 
-	if err == io.EOF && n == 0 {
+	if errors.Is(err, io.EOF) && n == 0 {
 		mc.SetValue(values.EOFObject)
 		return nil
 	}
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return values.WrapForeignReadErrorf(err, "read-bytevector!: error reading from port")
 	}
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -167,7 +167,7 @@ func (p *Parser) ReadSyntax(_ context.Context) (syntax.SyntaxValue, error) {
 		// Advance to the next token for the next ReadSyntax() call
 		p.cur, p.err = p.toks.Next()
 		// EOF is fine - it means there's nothing more to read
-		if p.err != nil && p.err != io.EOF {
+		if p.err != nil && !errors.Is(p.err, io.EOF) {
 			p.toks = nil
 			return nil, p.err
 		}
@@ -176,14 +176,14 @@ func (p *Parser) ReadSyntax(_ context.Context) (syntax.SyntaxValue, error) {
 		}
 		switch d := q.(type) {
 		case *syntax.SyntaxComment, *syntax.SyntaxDatumComment:
-			if p.err == io.EOF {
+			if errors.Is(p.err, io.EOF) {
 				return nil, p.err
 			}
 			continue
 		case *syntax.SyntaxDirective:
 			// R7RS §2.1: Process fold-case directives
 			p.processFoldCaseDirective(d)
-			if p.err == io.EOF {
+			if errors.Is(p.err, io.EOF) {
 				return nil, p.err
 			}
 			continue

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -152,7 +152,7 @@ func (p *REPL) Run(ctx context.Context) error {
 				rl.SetPrompt(p.prompt)
 				continue
 			}
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				// Ctrl-D: exit
 				fmt.Fprintln(p.out)
 				return nil
@@ -234,7 +234,7 @@ func (p *REPL) RunSimple(ctx context.Context) error {
 
 		line, err := reader.ReadLine()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				fmt.Fprintln(p.out)
 				return nil
 			}

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -860,11 +860,11 @@ func (p *Tokenizer) readExactness(state TokenizerState) {
 
 func (p *Tokenizer) readBoolean(key string, state TokenizerState) {
 	k := p.scanCaseInsensitive([]byte(key))
-	if p.err != nil && p.err != io.EOF {
+	if p.err != nil && !errors.Is(p.err, io.EOF) {
 		// #t is a valid boolean
 		return
 	}
-	if (k == 0 || k == len(key)-1) && (isDelimiter(p.curr()) || p.err == io.EOF) {
+	if (k == 0 || k == len(key)-1) && (isDelimiter(p.curr()) || errors.Is(p.err, io.EOF)) {
 		p.state = state
 		return
 	}
@@ -2059,7 +2059,7 @@ func (p *Tokenizer) term() {
 
 // isEOF returns true if the tokenizer has reached end of input.
 func (p *Tokenizer) isEOF() bool {
-	return p.err == io.EOF
+	return errors.Is(p.err, io.EOF)
 }
 
 // span returns the accumulated source text for the current token.


### PR DESCRIPTION
## Summary

Replace direct `==` and `!=` comparisons against sentinel errors (`io.EOF`, `machine.ErrMachineHalt`) with `errors.Is()` across all production code. Direct comparison silently fails when errors are wrapped — `errors.Is` traverses the error chain correctly.

## Changes

- **error.go**: `isEOF` helper now uses `errors.Is(err, io.EOF)`
- **engine.go**: `ErrMachineHalt` checks in `Call` and `loadBootstrapMacros` use `errors.Is`
- **internal/parser/parser.go**: 3 `io.EOF` checks in `ReadSyntax` loop
- **internal/tokenizer/tokenizer.go**: 3 `io.EOF` checks in `readBoolean` and `isEOF`
- **internal/repl/repl.go**: 2 `io.EOF` checks in `Run` and `RunSimple`
- **internal/bootstrap/environment_tiny.go**: 1 `io.EOF` check in `loadBootstrapMacros`
- **internal/extensions/io/prim_read_write.go**: 2 `io.EOF` checks in `read-bytevector!`

Total: 14 comparisons fixed across 7 files.

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./...` — all tests pass
- [x] `make lint` — 0 issues
- [x] Grep for remaining `err ==`/`err !=` sentinel patterns confirms only test files and doc comments remain