### PR TITLE
refactor: replace manual boolean patterns with BoolToBoolean

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,8 +49,8 @@ Code Cleanup
 ### Use BoolToBoolean Helper
 - [ ] **Location:** `internal/schemeutil/predicate.go` provides `BoolToBoolean(bool) *Boolean`
 - [ ] **Goal:** Replace manual `if b { TrueValue } else { FalseValue }` patterns
-- [ ] **Status:** 56 uses adopted across 15 files; ~35 manual patterns remain in 7 files
-- [ ] **Remaining files:** `prim_gointerop.go` (12), `prim_predicates.go` (10), `prim_threads.go` (6), `prim_exceptions.go` (3), `prim_all.go` (3), `prim_syntax.go` (1)
+- [ ] **Status:** 72 uses adopted across 20 files; ~22 manual patterns remain (compound conditionals and non-predicate sites)
+- [ ] **Remaining files:** `prim_gointerop.go` (7), `prim_threads.go` (2), `prim_exceptions.go` (2), `prim_all.go` (1)
 
 ---
 

--- a/internal/extensions/all/prim_all.go
+++ b/internal/extensions/all/prim_all.go
@@ -55,11 +55,7 @@ func PrimMakeRecordType(ctx context.Context, mc *machine.MachineContext) error {
 func PrimIsRecordType(_ context.Context, mc *machine.MachineContext) error {
 	obj := mc.Arg(0)
 	_, ok := obj.(*values.RecordType)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -67,11 +63,7 @@ func PrimIsRecordType(_ context.Context, mc *machine.MachineContext) error {
 func PrimIsRecord(_ context.Context, mc *machine.MachineContext) error {
 	obj := mc.Arg(0)
 	_, ok := obj.(*values.Record)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 

--- a/internal/extensions/exceptions/prim_exceptions.go
+++ b/internal/extensions/exceptions/prim_exceptions.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/aalpar/wile/internal/schemeutil"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
 )
@@ -298,11 +299,7 @@ func PrimError(ctx context.Context, mc *machine.MachineContext) error {
 func PrimErrorObjectQ(_ context.Context, mc *machine.MachineContext) error {
 	obj := mc.Arg(0)
 	_, ok := obj.(*values.NativeError)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 

--- a/internal/extensions/gointerop/prim_gointerop.go
+++ b/internal/extensions/gointerop/prim_gointerop.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/aalpar/wile/internal/schemeutil"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
 )
@@ -57,11 +58,7 @@ func PrimMakeChannel(_ context.Context, mc *machine.MachineContext) error {
 func PrimChannelQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.Channel)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -246,11 +243,7 @@ func PrimMakeWaitGroup(_ context.Context, mc *machine.MachineContext) error {
 func PrimWaitGroupQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.WaitGroup)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -335,11 +328,7 @@ func PrimMakeRWMutex(_ context.Context, mc *machine.MachineContext) error {
 func PrimRWMutexQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.RWMutex)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -450,11 +439,7 @@ func PrimMakeOnce(_ context.Context, mc *machine.MachineContext) error {
 func PrimOnceQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.Once)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -530,11 +515,7 @@ func PrimMakeAtomic(_ context.Context, mc *machine.MachineContext) error {
 func PrimAtomicQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.AtomicBox)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 

--- a/internal/extensions/threads/prim_threads.go
+++ b/internal/extensions/threads/prim_threads.go
@@ -106,11 +106,7 @@ func PrimCurrentThread(_ context.Context, mc *machine.MachineContext) error {
 func PrimThreadQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.Thread)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -335,11 +331,7 @@ func PrimThreadJoin(_ context.Context, mc *machine.MachineContext) error {
 func PrimMutexQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.Mutex)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -537,11 +529,7 @@ func PrimMutexUnlock(_ context.Context, mc *machine.MachineContext) error {
 func PrimConditionVariableQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.ConditionVariable)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 
@@ -644,11 +632,7 @@ func PrimCurrentTime(_ context.Context, mc *machine.MachineContext) error {
 func PrimTimeQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	_, ok := o.(*values.Time)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 

--- a/registry/core/prim_syntax.go
+++ b/registry/core/prim_syntax.go
@@ -34,11 +34,7 @@ func PrimIdentifierQ(_ context.Context, mc *machine.MachineContext) error {
 	obj := mc.Arg(0)
 
 	_, ok := obj.(*syntax.SyntaxSymbol)
-	if ok {
-		mc.SetValue(values.TrueValue)
-	} else {
-		mc.SetValue(values.FalseValue)
-	}
+	mc.SetValue(schemeutil.BoolToBoolean(ok))
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Replace 13 manual `if ok { TrueValue } else { FalseValue }` type-predicate patterns with `schemeutil.BoolToBoolean(ok)` across 5 files
- Add `schemeutil` import to `prim_gointerop.go` and `prim_exceptions.go`
- Update TODO.md to reflect current adoption status (72 uses across 20 files)

## Changes
| File | Sites replaced |
|------|---------------|
| `prim_gointerop.go` | 5 (`PrimChannelQ`, `PrimWaitGroupQ`, `PrimRWMutexQ`, `PrimOnceQ`, `PrimAtomicQ`) |
| `prim_threads.go` | 4 (`PrimThreadQ`, `PrimMutexQ`, `PrimConditionVariableQ`, `PrimTimeQ`) |
| `prim_exceptions.go` | 1 (`PrimErrorObjectQ`) |
| `prim_all.go` | 2 (`PrimIsRecordType`, `PrimIsRecord`) |
| `prim_syntax.go` | 1 (`PrimIdentifierQ`) |

Net: -50 lines (17 insertions, 67 deletions).

## Test Plan
- [x] `go_diagnostics` passes on all 5 files
- [x] `go test` passes for `exceptions` and `registry/core` packages
- [x] `make lint` passes with 0 issues