### PR TITLE
refactor: replace any with concrete types in FreeIdResolution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,8 +4,9 @@ TODO
 Code Cleanup
 ------------
 ### FreeIdResolution
-- [ ] Try and find a more specific type for the interface, instead of 'any'.
-- [ ] **Location:** `internal/match/syntax_adapter.go` and `machine/compile_syntax_rules.go`
+- [x] Try and find a more specific type for the interface, instead of 'any'.
+- [x] **Location:** `internal/match/syntax_adapter.go` and `machine/compile_syntax_rules.go`
+- [x] **Resolution:** Replaced `any` with `*environment.GlobalIndex` in `FreeIdResolution.Global` and `globalBindingProvider.GetGlobal()`, and `*environment.Binding` in `BindingChecker.GetBinding()` and `envBindingChecker.GetBinding()`. Import is safe: `match` → `environment` (no cycle). `SyntaxSymbol.ResolvedBinding any` stays `any` to avoid `syntax` ↔ `environment` cycle.
 
 ### Scope Matching Optimization
 - [ ] **Location:** `internal/syntax/` and `internal/match/`

--- a/internal/match/literal_match_test.go
+++ b/internal/match/literal_match_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 
@@ -272,10 +273,10 @@ func (p mockLocalScopes) GetLocalScopes() []*syntax.Scope { return p.scopes }
 
 // mockGlobalBinding implements globalBindingProvider for testing.
 type mockGlobalBinding struct {
-	binding any
+	binding *environment.GlobalIndex
 }
 
-func (p mockGlobalBinding) GetGlobal() any { return p.binding }
+func (p mockGlobalBinding) GetGlobal() *environment.GlobalIndex { return p.binding }
 
 // mockHasLocalBinding implements hasLocalBindingProvider for testing.
 type mockHasLocalBinding struct {
@@ -316,7 +317,7 @@ func TestApplyHygieneToSymbol(t *testing.T) {
 	})
 
 	c.Run("free identifier with global binding", func(c *qt.C) {
-		globalIdx := 42 // some mock global binding
+		globalIdx := environment.NewGlobalIndex(values.NewSymbol("baz"))
 		freeIds := map[string]any{
 			"baz": mockGlobalBinding{binding: globalIdx},
 		}
@@ -356,7 +357,7 @@ func TestApplyHygieneToSymbol(t *testing.T) {
 	})
 
 	c.Run("global binding with existing scopes clears them", func(c *qt.C) {
-		globalIdx := 99
+		globalIdx := environment.NewGlobalIndex(values.NewSymbol("baz"))
 		freeIds := map[string]any{
 			"baz": mockGlobalBinding{binding: globalIdx},
 		}

--- a/internal/match/syntax_adapter.go
+++ b/internal/match/syntax_adapter.go
@@ -37,6 +37,7 @@ package match
 import (
 	"context"
 
+	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 )
@@ -50,7 +51,7 @@ type localScopesProvider interface {
 // globalBindingProvider is an interface for getting global bindings from a free ID resolution.
 // Implemented by machine.FreeIdResolution to avoid circular imports.
 type globalBindingProvider interface {
-	GetGlobal() any
+	GetGlobal() *environment.GlobalIndex
 }
 
 // hasLocalBindingProvider is an interface for checking if a local binding was found
@@ -71,10 +72,10 @@ type BindingChecker interface {
 	HasBinding(sym string, scopes []*syntax.Scope) bool
 
 	// GetBinding returns the binding for sym with the given scopes.
-	// Returns nil if no binding exists. The returned value is opaque but
-	// can be compared for equality to check if two identifiers have the
-	// same binding (per R7RS §4.3.2).
-	GetBinding(sym string, scopes []*syntax.Scope) any
+	// Returns nil if no binding exists. Bindings can be compared for
+	// pointer equality to check if two identifiers have the same
+	// binding (per R7RS §4.3.2).
+	GetBinding(sym string, scopes []*syntax.Scope) *environment.Binding
 }
 
 // SyntaxMatcher adapts the core Matcher to work with syntax objects and hygiene.

--- a/internal/match/syntax_adapter_test.go
+++ b/internal/match/syntax_adapter_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 
@@ -698,7 +699,7 @@ func TestExpandWithOrigin_PreservesPatternVars(t *testing.T) {
 
 // mockBindingChecker implements BindingChecker for testing.
 type mockBindingChecker struct {
-	bindings map[string]any // sym -> binding (nil means no binding)
+	bindings map[string]*environment.Binding // sym -> binding (nil means no binding)
 }
 
 func (p *mockBindingChecker) HasBinding(sym string, scopes []*syntax.Scope) bool {
@@ -706,7 +707,7 @@ func (p *mockBindingChecker) HasBinding(sym string, scopes []*syntax.Scope) bool
 	return ok && binding != nil
 }
 
-func (p *mockBindingChecker) GetBinding(sym string, scopes []*syntax.Scope) any {
+func (p *mockBindingChecker) GetBinding(sym string, scopes []*syntax.Scope) *environment.Binding {
 	return p.bindings[sym]
 }
 
@@ -721,14 +722,14 @@ func TestLiteralScopesMatchWithChecker_BothHaveSameBinding(t *testing.T) {
 	patternSym := syntax.NewSyntaxSymbol("=>", srcCtx)
 
 	// Both symbols resolve to the same binding (simulating imported auxiliary syntax)
-	sharedBinding := &struct{ name string }{name: "arrow-binding"}
+	sharedBinding := environment.NewBinding(values.NewSymbol("=>"), environment.BindingTypeVariable)
 
 	literalSyntax := map[string]*syntax.SyntaxSymbol{
 		"=>": patternSym,
 	}
 	matcher := NewSyntaxMatcherWithLiterals(nil, nil, nil, "...", literalSyntax)
 	matcher.bindingChecker = &mockBindingChecker{
-		bindings: map[string]any{
+		bindings: map[string]*environment.Binding{
 			"=>": sharedBinding, // Same binding for both
 		},
 	}
@@ -753,8 +754,8 @@ func TestLiteralScopesMatchWithChecker_DifferentBindings(t *testing.T) {
 	patternSym := syntax.NewSyntaxSymbol("=>", patternSrcCtx)
 
 	// Input has a different binding (let-bound) than pattern (global)
-	inputBinding := &struct{ name string }{name: "let-binding"}
-	patternBinding := &struct{ name string }{name: "global-binding"}
+	inputBinding := environment.NewBinding(values.NewSymbol("=>"), environment.BindingTypeVariable)
+	patternBinding := environment.NewBinding(values.NewSymbol("=>"), environment.BindingTypePrimitive)
 
 	literalSyntax := map[string]*syntax.SyntaxSymbol{
 		"=>": patternSym,
@@ -787,7 +788,7 @@ func TestLiteralScopesMatchWithChecker_BothUnbound(t *testing.T) {
 	}
 	matcher := NewSyntaxMatcherWithLiterals(nil, nil, nil, "...", literalSyntax)
 	matcher.bindingChecker = &mockBindingChecker{
-		bindings: map[string]any{}, // No bindings
+		bindings: map[string]*environment.Binding{}, // No bindings
 	}
 
 	// Should match because both are unbound (nil == nil)
@@ -797,8 +798,8 @@ func TestLiteralScopesMatchWithChecker_BothUnbound(t *testing.T) {
 
 // mockBindingCheckerWithScopes returns different bindings for input vs pattern.
 type mockBindingCheckerWithScopes struct {
-	inputBinding   any
-	patternBinding any
+	inputBinding   *environment.Binding
+	patternBinding *environment.Binding
 }
 
 func (p *mockBindingCheckerWithScopes) HasBinding(sym string, scopes []*syntax.Scope) bool {
@@ -809,7 +810,7 @@ func (p *mockBindingCheckerWithScopes) HasBinding(sym string, scopes []*syntax.S
 	return p.patternBinding != nil
 }
 
-func (p *mockBindingCheckerWithScopes) GetBinding(sym string, scopes []*syntax.Scope) any {
+func (p *mockBindingCheckerWithScopes) GetBinding(sym string, scopes []*syntax.Scope) *environment.Binding {
 	// Determine if this is input (has scopes) or pattern (no scopes)
 	if len(scopes) > 0 {
 		return p.inputBinding

--- a/machine/compile_syntax_rules.go
+++ b/machine/compile_syntax_rules.go
@@ -50,7 +50,7 @@ import (
 type FreeIdResolution struct {
 	// Global is set if the free identifier refers to a global binding.
 	// This enables cross-library macro hygiene by pre-resolving the binding.
-	Global any
+	Global *environment.GlobalIndex
 	// LocalScopes is set if the free identifier refers to a local binding.
 	// These are the scopes of the binding at macro definition time.
 	// During expansion, the free identifier gets these scopes, ensuring
@@ -73,9 +73,8 @@ func (p *FreeIdResolution) GetLocalScopes() []*syntax.Scope {
 }
 
 // GetGlobal returns the global binding's index, or nil if this is a local binding.
-// Returns any to avoid circular import with environment package in match.
 // Implements the globalBindingProvider interface for match package hygiene.
-func (p *FreeIdResolution) GetGlobal() any {
+func (p *FreeIdResolution) GetGlobal() *environment.GlobalIndex {
 	if p == nil {
 		return nil
 	}

--- a/machine/operation_syntax_rules_transform.go
+++ b/machine/operation_syntax_rules_transform.go
@@ -77,13 +77,12 @@ func (p *envBindingChecker) HasBinding(sym string, scopes []*syntax.Scope) bool 
 // This is used for R7RS §4.3.2 auxiliary syntax hygiene: we compare the
 // actual bindings (not just whether they exist) to determine if a literal
 // matches. Two identifiers match only if they have the same binding.
-func (p *envBindingChecker) GetBinding(sym string, scopes []*syntax.Scope) any {
+func (p *envBindingChecker) GetBinding(sym string, scopes []*syntax.Scope) *environment.Binding {
 	if p.env == nil {
 		return nil
 	}
 	s := values.NewSymbol(sym)
-	binding := p.env.GetBindingWithScopes(s, scopes)
-	return binding
+	return p.env.GetBindingWithScopes(s, scopes)
 }
 
 // OperationSyntaxRulesTransform is a VM operation that performs macro expansion.


### PR DESCRIPTION
## Summary

- Replace untyped `any` with `*environment.GlobalIndex` in `FreeIdResolution.Global` and `globalBindingProvider.GetGlobal()`
- Replace untyped `any` with `*environment.Binding` in `BindingChecker.GetBinding()` and `envBindingChecker.GetBinding()`
- Update test mocks to use concrete types instead of `int` literals and anonymous structs
- Mark `FreeIdResolution` TODO item as complete

The `match` → `environment` import is safe (no cycle). `SyntaxSymbol.ResolvedBinding` stays `any` to avoid a `syntax` ↔ `environment` circular import.

## Test plan
- [x] `go_diagnostics` reports no errors on all changed files
- [x] `go test ./machine/... ./internal/match/...` passes
- [x] `make lint` passes with 0 issues