### PR TITLE
refactor: fix remaining pair accessor sites in syntax_adapter

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,6 +32,12 @@ Code Cleanup
 - [x] **Scope:** Audit compiler and primitive implementations
 - [x] **Status:** Replaced `*values.Pair` with `values.Tuple` in list-processing primitives (prim_lists.go, helpers/list.go, helpers/numeric.go, helpers/char.go, machine/operations.go). Deleted dead code in internal/schemeutil/collections.go.
 
+### Replace Direct Pair Index Access with Accessor Methods
+- [x] **Goal:** Convert all direct `[0]`/`[1]` index access on `*Pair` to `Car()`/`Cdr()`/`SetCar()`/`SetCdr()`, and `&Pair{x, y}` literals to `NewCons(x, y)`
+- [x] **Benefit:** Encapsulates Pair representation; only `pair.go` methods use raw indexing
+- [x] **Scope:** values/, machine/, internal/match/ (pair.go's own method implementations excluded)
+- [x] **Status:** All production code outside pair.go now uses accessor methods and NewCons
+
 ---
 
 ### Use values.Number Interface

--- a/internal/match/syntax_adapter.go
+++ b/internal/match/syntax_adapter.go
@@ -512,11 +512,11 @@ func (p *SyntaxMatcher) capturedValueToSyntax(
 
 	switch v := val.(type) {
 	case *values.Pair:
-		car, err := p.capturedValueToSyntax(v[0], introScope, useSiteCtx, origin)
+		car, err := p.capturedValueToSyntax(v.Car(), introScope, useSiteCtx, origin)
 		if err != nil {
 			return nil, err
 		}
-		cdr, err := p.capturedValueToSyntax(v[1], introScope, useSiteCtx, origin)
+		cdr, err := p.capturedValueToSyntax(v.Cdr(), introScope, useSiteCtx, origin)
 		if err != nil {
 			return nil, err
 		}
@@ -791,14 +791,14 @@ func valueToSyntax(val values.Value, templateStx syntax.SyntaxValue) syntax.Synt
 	switch v := val.(type) {
 	case *values.Pair:
 		// Recursively wrap car and cdr
-		car := valueToSyntax(v[0], templateStx)
+		car := valueToSyntax(v.Car(), templateStx)
 
 		// nil cdr: improper construction; EmptyList: proper list terminator
 		var cdr syntax.SyntaxValue
-		if v[1] == nil || values.IsEmptyList(v[1]) {
+		if v.Cdr() == nil || values.IsEmptyList(v.Cdr()) {
 			cdr = syntax.NewSyntaxEmptyList(srcCtx)
 		} else {
-			cdr = valueToSyntax(v[1], templateStx)
+			cdr = valueToSyntax(v.Cdr(), templateStx)
 		}
 
 		return syntax.NewSyntaxCons(car, cdr, srcCtx)


### PR DESCRIPTION
## Summary
- Convert 5 remaining `v[0]`/`v[1]` index accesses to `v.Car()`/`v.Cdr()` in `capturedValueToSyntax` and `valueToSyntax`
- Update TODO.md with completed entry for the pair accessor refactoring

## Context
Follows up on the pair accessor refactoring (commits `4cc9dbb` and `b182fe5` already on master). These sites in `syntax_adapter.go` were missed in the initial pass.

## Test plan
- [x] `go_diagnostics` — 0 errors
- [x] `go test ./...` — all pass
- [x] `make lint` — 0 issues