### PR TITLE
refactor: add numeric predicate methods to Number interface

### DIFF
--- a/internal/extensions/math/prim_math.go
+++ b/internal/extensions/math/prim_math.go
@@ -726,64 +726,31 @@ func PrimTruncateRemainder(_ context.Context, mc *machine.MachineContext) error 
 
 // PrimFiniteQ implements the (finite?) primitive.
 func PrimFiniteQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger, *values.BigFloat, *values.Rational, *values.BigComplex:
-		// BigInteger, Rational, BigComplex (exact) are always finite
-		// BigFloat uses math/big which doesn't support infinity/NaN
-		mc.SetValue(values.TrueValue)
-	case *values.Float:
-		mc.SetValue(schemeutil.BoolToBoolean(!math.IsInf(v.Value, 0) && !math.IsNaN(v.Value)))
-	case *values.Complex:
-		rel := real(v.Value)
-		iam := imag(v.Value)
-		isFinite := !math.IsInf(rel, 0) && !math.IsNaN(rel) && !math.IsInf(iam, 0) && !math.IsNaN(iam)
-		mc.SetValue(schemeutil.BoolToBoolean(isFinite))
-	default:
-		return values.WrapForeignErrorf(values.ErrNotANumber, "finite?: expected a number but got %T", o)
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotANumber, "finite?: expected a number but got %T", mc.Arg(0))
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(n.IsFinite()))
 	return nil
 }
 
 // PrimInfiniteQ implements the (infinite?) primitive.
 func PrimInfiniteQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger, *values.BigFloat, *values.Rational, *values.BigComplex:
-		// BigInteger, Rational, BigComplex (exact) are never infinite
-		// BigFloat uses math/big which doesn't support infinity
-		mc.SetValue(values.FalseValue)
-	case *values.Float:
-		mc.SetValue(schemeutil.BoolToBoolean(math.IsInf(v.Value, 0)))
-	case *values.Complex:
-		rel := real(v.Value)
-		iam := imag(v.Value)
-		isInfinite := math.IsInf(rel, 0) || math.IsInf(iam, 0)
-		mc.SetValue(schemeutil.BoolToBoolean(isInfinite))
-	default:
-		return values.WrapForeignErrorf(values.ErrNotANumber, "infinite?: expected a number but got %T", o)
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotANumber, "infinite?: expected a number but got %T", mc.Arg(0))
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(!n.IsFinite() && !n.IsNaN()))
 	return nil
 }
 
 // PrimNanQ implements the nan? primitive.
 func PrimNanQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger, *values.BigFloat, *values.Rational, *values.BigComplex:
-		// BigInteger, Rational, BigComplex (exact) are never NaN
-		// BigFloat uses math/big which doesn't support NaN
-		mc.SetValue(values.FalseValue)
-	case *values.Float:
-		mc.SetValue(schemeutil.BoolToBoolean(math.IsNaN(v.Value)))
-	case *values.Complex:
-		rel := real(v.Value)
-		iam := imag(v.Value)
-		isNaN := math.IsNaN(rel) || math.IsNaN(iam)
-		mc.SetValue(schemeutil.BoolToBoolean(isNaN))
-	default:
-		return values.WrapForeignErrorf(values.ErrNotANumber, "nan?: expected a number but got %T", o)
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
+		return values.WrapForeignErrorf(values.ErrNotANumber, "nan?: expected a number but got %T", mc.Arg(0))
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(n.IsNaN()))
 	return nil
 }
 

--- a/registry/core/prim_arithmetic.go
+++ b/registry/core/prim_arithmetic.go
@@ -214,7 +214,7 @@ func PrimNumLe(_ context.Context, mc *machine.MachineContext) error {
 			return true
 		}
 		// NaN fails all comparisons per IEEE 754
-		if helpers.IsNaN(prev) || helpers.IsNaN(curr) {
+		if prev.IsNaN() || curr.IsNaN() {
 			return true // fails the comparison
 		}
 		return curr.LessThan(prev)
@@ -237,7 +237,7 @@ func PrimNumGe(_ context.Context, mc *machine.MachineContext) error {
 			return true
 		}
 		// NaN fails all comparisons per IEEE 754
-		if helpers.IsNaN(prev) || helpers.IsNaN(curr) {
+		if prev.IsNaN() || curr.IsNaN() {
 			return true // fails the comparison
 		}
 		return prev.LessThan(curr)

--- a/registry/core/prim_exact_integer_q_test.go
+++ b/registry/core/prim_exact_integer_q_test.go
@@ -34,7 +34,10 @@ func TestExactIntegerQ(t *testing.T) {
 		{name: "exact-integer? on float", code: `(exact-integer? 42.0)`, expected: values.FalseValue},
 		{name: "exact-integer? on rational", code: `(exact-integer? 3/4)`, expected: values.FalseValue},
 		{name: "exact-integer? on integer rational", code: `(exact-integer? 4/2)`, expected: values.TrueValue}, // 4/2 reduces to Integer(2) at parse time
-		{name: "exact-integer? on complex", code: `(exact-integer? 1+0i)`, expected: values.FalseValue},
+		// R7RS §6.2.6: 1+0i is exact, and (integer? 1+0i) is #t since
+		// imag is exactly zero and real is integer. So exact-integer? is #t.
+		{name: "exact-integer? on exact complex", code: `(exact-integer? 1+0i)`, expected: values.TrueValue},
+		{name: "exact-integer? on inexact complex", code: `(exact-integer? 1.0+0.0i)`, expected: values.FalseValue},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/registry/core/prim_predicates.go
+++ b/registry/core/prim_predicates.go
@@ -138,68 +138,12 @@ func PrimListQ(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.2.6: Returns #t if the argument is an integer (exact or inexact).
 // Inexact integers are floating-point numbers with zero fractional part.
 func PrimIntegerQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger:
-		mc.SetValue(values.TrueValue)
-	case *values.Rational:
-		if v.IsInteger() {
-			mc.SetValue(values.TrueValue)
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
-	case *values.Float:
-		f := v.Value
-		if f == float64(int64(f)) {
-			mc.SetValue(values.TrueValue)
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
-	case *values.BigFloat:
-		if v.BigFloatValue().IsInt() {
-			mc.SetValue(values.TrueValue)
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
-	case *values.Complex:
-		if imag(v.Value) == 0 {
-			r := real(v.Value)
-			if r == float64(int64(r)) {
-				mc.SetValue(values.TrueValue)
-			} else {
-				mc.SetValue(values.FalseValue)
-			}
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
-	case *values.BigComplex:
-		// Check if imaginary part is zero and real part is an integer
-		if v.IsReal() {
-			realPart := v.Real()
-			switch rp := realPart.(type) {
-			case *values.BigInteger:
-				mc.SetValue(values.TrueValue)
-			case *values.Rational:
-				if rp.IsInteger() {
-					mc.SetValue(values.TrueValue)
-				} else {
-					mc.SetValue(values.FalseValue)
-				}
-			case *values.BigFloat:
-				if rp.BigFloatValue().IsInt() {
-					mc.SetValue(values.TrueValue)
-				} else {
-					mc.SetValue(values.FalseValue)
-				}
-			default:
-				mc.SetValue(values.FalseValue)
-			}
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
-	default:
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
 		mc.SetValue(values.FalseValue)
+		return nil
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(n.IsInteger()))
 	return nil
 }
 
@@ -210,19 +154,11 @@ func PrimIntegerQ(_ context.Context, mc *machine.MachineContext) error {
 func PrimRealQ(_ context.Context, mc *machine.MachineContext) error {
 	o := mc.Arg(0)
 	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger, *values.Float, *values.BigFloat, *values.Rational:
+	case values.RealNumber:
+		_ = v
 		mc.SetValue(values.TrueValue)
-	case *values.Complex:
-		// R7RS: A complex is real only if imaginary part is exactly zero.
-		// Complex uses float64 parts (always inexact), so cannot be exactly zero.
-		// If the imaginary was exact 0 at parse time, parser returns Float instead.
-		mc.SetValue(values.FalseValue)
 	case *values.BigComplex:
-		if v.IsReal() {
-			mc.SetValue(values.TrueValue)
-		} else {
-			mc.SetValue(values.FalseValue)
-		}
+		mc.SetValue(schemeutil.BoolToBoolean(v.IsReal()))
 	default:
 		mc.SetValue(values.FalseValue)
 	}
@@ -234,27 +170,12 @@ func PrimRealQ(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.2.6: Returns #t if the argument is a rational number.
 // Integers (including BigInteger) are a subset of rationals.
 func PrimRationalQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch v := o.(type) {
-	case *values.Integer, *values.BigInteger, *values.BigFloat, *values.Rational:
-		// BigFloat is always finite, so always rational
-		mc.SetValue(values.TrueValue)
-	case *values.Float:
-		// Float is rational if it's finite (not NaN or Inf)
-		f := v.Value
-		if math.IsNaN(f) || math.IsInf(f, 0) {
-			mc.SetValue(values.FalseValue)
-		} else {
-			mc.SetValue(values.TrueValue)
-		}
-	case *values.Complex:
-		// R7RS: A complex is rational only if imaginary part is exactly zero.
-		// Complex uses float64 parts (always inexact), so cannot be exactly zero.
-		// If the imaginary was exact 0 at parse time, parser returns Float instead.
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
 		mc.SetValue(values.FalseValue)
-	default:
-		mc.SetValue(values.FalseValue)
+		return nil
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(n.IsRational()))
 	return nil
 }
 
@@ -286,13 +207,12 @@ func PrimInexactQ(_ context.Context, mc *machine.MachineContext) error {
 //
 // R7RS §6.2.6: Returns #t if the argument is both exact and an integer.
 func PrimExactIntegerQ(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	switch o.(type) {
-	case *values.Integer, *values.BigInteger:
-		mc.SetValue(values.TrueValue)
-	default:
+	n, ok := mc.Arg(0).(values.Number)
+	if !ok {
 		mc.SetValue(values.FalseValue)
+		return nil
 	}
+	mc.SetValue(schemeutil.BoolToBoolean(n.IsExact() && n.IsInteger()))
 	return nil
 }
 

--- a/registry/helpers/numeric.go
+++ b/registry/helpers/numeric.go
@@ -17,7 +17,6 @@ package helpers
 import (
 	"context"
 	"errors"
-	"math"
 
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
@@ -120,12 +119,6 @@ func NumericFoldWithFirst(
 	return nil
 }
 
-// IsNaN returns true if the number is a NaN float.
-func IsNaN(n values.Number) bool {
-	f, ok := n.(*values.Float)
-	return ok && math.IsNaN(f.Value)
-}
-
 // NumericChainCompare is a helper for numeric chain comparison primitives.
 // First arg at index 0, rest at index 1. Returns true if all consecutive
 // pairs satisfy the comparator, false otherwise.
@@ -189,10 +182,10 @@ func NumericExtremum(
 	}
 
 	// Track if any argument is inexact
-	hasInexact := IsInexact(best)
+	hasInexact := !best.IsExact()
 
 	// Check if first is NaN
-	if f, ok := best.(*values.Float); ok && math.IsNaN(f.Value) {
+	if best.IsNaN() {
 		mc.SetValue(best)
 		return nil
 	}
@@ -214,12 +207,12 @@ func NumericExtremum(
 			return values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected a number but got %T", name, v)
 		}
 
-		if IsInexact(curr) {
+		if !curr.IsExact() {
 			hasInexact = true
 		}
 
 		// Check for NaN - if any argument is NaN, result is NaN
-		if f, ok := curr.(*values.Float); ok && math.IsNaN(f.Value) {
+		if curr.IsNaN() {
 			foundNaN = true
 			best = curr
 			return nil
@@ -247,16 +240,6 @@ func NumericExtremum(
 	return nil
 }
 
-// IsInexact returns true if the number is inexact (Float, BigFloat, or Complex)
-func IsInexact(n values.Number) bool {
-	switch n.(type) {
-	case *values.Float, *values.BigFloat, *values.Complex:
-		return true
-	default:
-		return false
-	}
-}
-
 // MaybeToInexact converts an exact number to inexact (Float) if needed.
 // If the number is already inexact or hasInexact is false, returns it unchanged.
 func MaybeToInexact(n values.Number, hasInexact bool) values.Value {
@@ -264,7 +247,7 @@ func MaybeToInexact(n values.Number, hasInexact bool) values.Value {
 		return n
 	}
 	// If already inexact, return as-is
-	if IsInexact(n) {
+	if !n.IsExact() {
 		return n
 	}
 	// Convert exact to inexact

--- a/values/big_complex.go
+++ b/values/big_complex.go
@@ -513,6 +513,38 @@ func (p *BigComplex) IsExact() bool {
 	return isExactPart(p.real) && isExactPart(p.imag)
 }
 
+// IsInteger returns true if the imaginary part is zero and the real part is an integer.
+//
+// R7RS §6.2.6: integer? returns #t for complex numbers with zero imaginary
+// part whose real part is an integer.
+func (p *BigComplex) IsInteger() bool {
+	return p.IsReal() && p.RealPart().IsInteger()
+}
+
+// IsRational returns true if this BigComplex is a real number.
+//
+// R7RS §6.2.6: rational? returns #t for real BigComplex values since
+// BigInteger, Rational, and BigFloat parts are all finite.
+func (p *BigComplex) IsRational() bool {
+	return p.IsReal()
+}
+
+// IsFinite returns true since BigComplex parts are always finite.
+//
+// R7RS §6.2.6: BigComplex uses BigInteger, Rational, or BigFloat parts,
+// none of which support Inf or NaN.
+func (p *BigComplex) IsFinite() bool {
+	return true
+}
+
+// IsNaN returns false since BigComplex parts cannot represent NaN.
+//
+// R7RS §6.2.6: BigComplex uses BigInteger, Rational, or BigFloat parts,
+// none of which support NaN.
+func (p *BigComplex) IsNaN() bool {
+	return false
+}
+
 // isExactPart returns true if the number is an exact type (BigInteger or Rational).
 func isExactPart(n Number) bool {
 	switch n.(type) {

--- a/values/big_float.go
+++ b/values/big_float.go
@@ -248,6 +248,34 @@ func (p *BigFloat) IsExact() bool {
 	return false // BigFloat is inexact
 }
 
+// IsInteger returns true if this BigFloat represents an integer value.
+//
+// R7RS §6.2.6: integer? returns #t for inexact integers.
+func (p *BigFloat) IsInteger() bool {
+	return p.value.IsInt()
+}
+
+// IsRational returns true since BigFloat is always finite (big.Float has no Inf/NaN).
+//
+// R7RS §6.2.6: rational? returns #t for all finite real numbers.
+func (p *BigFloat) IsRational() bool {
+	return true
+}
+
+// IsFinite returns true since big.Float has no Inf or NaN representation.
+//
+// R7RS §6.2.6: finite? returns #t for finite numbers.
+func (p *BigFloat) IsFinite() bool {
+	return true
+}
+
+// IsNaN returns false since big.Float has no NaN representation.
+//
+// R7RS §6.2.6: nan? returns #f for big.Float values.
+func (p *BigFloat) IsNaN() bool {
+	return false
+}
+
 // ToExact converts this BigFloat to an exact Rational.
 func (p *BigFloat) ToExact() Number {
 	// Convert to Rational for exact representation

--- a/values/big_integer.go
+++ b/values/big_integer.go
@@ -286,6 +286,34 @@ func (p *BigInteger) IsExact() bool {
 	return true
 }
 
+// IsInteger returns true since BigInteger is always an integer.
+//
+// R7RS §6.2.6: integer? returns #t for exact integers.
+func (p *BigInteger) IsInteger() bool {
+	return true
+}
+
+// IsRational returns true since integers are a subset of rationals.
+//
+// R7RS §6.2.6: rational? returns #t for all real finite numbers.
+func (p *BigInteger) IsRational() bool {
+	return true
+}
+
+// IsFinite returns true since integers are always finite.
+//
+// R7RS §6.2.6: finite? returns #t for all exact numbers.
+func (p *BigInteger) IsFinite() bool {
+	return true
+}
+
+// IsNaN returns false since integers are never NaN.
+//
+// R7RS §6.2.6: nan? returns #f for exact numbers.
+func (p *BigInteger) IsNaN() bool {
+	return false
+}
+
 // ToExact returns this BigInteger as an exact number.
 //
 // R7RS §6.2.6: exact returns an exact representation of its argument.

--- a/values/complex.go
+++ b/values/complex.go
@@ -329,6 +329,40 @@ func (p *Complex) IsExact() bool {
 	return false
 }
 
+// IsInteger returns true if this complex has zero imaginary part and an integer real part.
+//
+// R7RS §6.2.6: integer? returns #t for complex numbers with zero imaginary
+// part whose real part is an integer.
+func (p *Complex) IsInteger() bool {
+	return imag(p.Value) == 0 &&
+		real(p.Value) == math.Trunc(real(p.Value)) &&
+		!math.IsInf(real(p.Value), 0) &&
+		!math.IsNaN(real(p.Value))
+}
+
+// IsRational returns false for Complex numbers.
+//
+// R7RS §6.2.6: Complex numbers with inexact imaginary parts cannot be
+// exactly zero, so complex values are not rational.
+func (p *Complex) IsRational() bool {
+	return false
+}
+
+// IsFinite returns true if both real and imaginary parts are finite.
+//
+// R7RS §6.2.6: finite? returns #t if neither part is Inf or NaN.
+func (p *Complex) IsFinite() bool {
+	return !math.IsInf(real(p.Value), 0) && !math.IsNaN(real(p.Value)) &&
+		!math.IsInf(imag(p.Value), 0) && !math.IsNaN(imag(p.Value))
+}
+
+// IsNaN returns true if either the real or imaginary part is NaN.
+//
+// R7RS §6.2.6: nan? returns #t if any component is NaN.
+func (p *Complex) IsNaN() bool {
+	return math.IsNaN(real(p.Value)) || math.IsNaN(imag(p.Value))
+}
+
 // IsReal returns true if the imaginary part is zero.
 func (p *Complex) IsReal() bool {
 	return imag(p.Value) == 0

--- a/values/float.go
+++ b/values/float.go
@@ -284,6 +284,35 @@ func (p *Float) IsExact() bool {
 	return false
 }
 
+// IsInteger returns true if this float represents an integer value.
+//
+// R7RS §6.2.6: integer? returns #t for inexact integers (e.g., 3.0).
+// Uses math.Trunc to correctly handle large floats outside int64 range.
+func (p *Float) IsInteger() bool {
+	return p.Value == math.Trunc(p.Value) && !math.IsInf(p.Value, 0) && !math.IsNaN(p.Value)
+}
+
+// IsRational returns true if this float is finite (not NaN or Inf).
+//
+// R7RS §6.2.6: rational? returns #t for finite inexact reals.
+func (p *Float) IsRational() bool {
+	return !math.IsNaN(p.Value) && !math.IsInf(p.Value, 0)
+}
+
+// IsFinite returns true if this float is finite (not Inf or NaN).
+//
+// R7RS §6.2.6: finite? returns #t for finite numbers.
+func (p *Float) IsFinite() bool {
+	return !math.IsInf(p.Value, 0) && !math.IsNaN(p.Value)
+}
+
+// IsNaN returns true if this float is NaN.
+//
+// R7RS §6.2.6: nan? returns #t for NaN values.
+func (p *Float) IsNaN() bool {
+	return math.IsNaN(p.Value)
+}
+
 // IsVoid returns true if the float is nil.
 func (p *Float) IsVoid() bool {
 	return p == nil

--- a/values/integer.go
+++ b/values/integer.go
@@ -423,6 +423,34 @@ func (p *Integer) IsExact() bool {
 	return true
 }
 
+// IsInteger returns true since Integer is always an integer.
+//
+// R7RS §6.2.6: integer? returns #t for exact integers.
+func (p *Integer) IsInteger() bool {
+	return true
+}
+
+// IsRational returns true since integers are a subset of rationals.
+//
+// R7RS §6.2.6: rational? returns #t for all real finite numbers.
+func (p *Integer) IsRational() bool {
+	return true
+}
+
+// IsFinite returns true since integers are always finite.
+//
+// R7RS §6.2.6: finite? returns #t for all exact numbers.
+func (p *Integer) IsFinite() bool {
+	return true
+}
+
+// IsNaN returns false since integers are never NaN.
+//
+// R7RS §6.2.6: nan? returns #f for exact numbers.
+func (p *Integer) IsNaN() bool {
+	return false
+}
+
 // IsVoid returns true if this integer is nil.
 func (p *Integer) IsVoid() bool {
 	return p == nil

--- a/values/rational.go
+++ b/values/rational.go
@@ -350,6 +350,27 @@ func (p *Rational) IsExact() bool {
 	return true
 }
 
+// IsRational returns true since Rational is always a rational number.
+//
+// R7RS §6.2.6: rational? returns #t for exact rationals.
+func (p *Rational) IsRational() bool {
+	return true
+}
+
+// IsFinite returns true since exact rationals are always finite.
+//
+// R7RS §6.2.6: finite? returns #t for all exact numbers.
+func (p *Rational) IsFinite() bool {
+	return true
+}
+
+// IsNaN returns false since exact rationals are never NaN.
+//
+// R7RS §6.2.6: nan? returns #f for exact numbers.
+func (p *Rational) IsNaN() bool {
+	return false
+}
+
 // IsVoid returns true if the rational is nil.
 func (p *Rational) IsVoid() bool {
 	return p == nil

--- a/values/values.go
+++ b/values/values.go
@@ -224,6 +224,10 @@ type Number interface {
 	ToInexact() Number
 	IsZero() bool
 	IsExact() bool
+	IsInteger() bool  // R7RS §6.2.6: is this an integer value?
+	IsRational() bool // R7RS §6.2.6: is this a rational value?
+	IsFinite() bool   // R7RS §6.2.6: is this a finite number?
+	IsNaN() bool      // R7RS §6.2.6: is this NaN?
 	LessThan(Number) bool
 	Compare(Number) int
 }


### PR DESCRIPTION
## Summary

- Add `IsInteger`, `IsRational`, `IsFinite`, `IsNaN` methods to the `Number` interface so predicate primitives dispatch through the interface instead of manual 7-case type switches
- Implement all 4 methods on all 7 numeric types
- Simplify predicate primitives: `PrimIntegerQ` (65→6 lines), `PrimRationalQ` (23→6), `PrimRealQ` (20→12), `PrimExactIntegerQ` (12→7), `PrimFiniteQ`/`PrimInfiniteQ`/`PrimNanQ` (~18→6 each)
- Delete `helpers.IsNaN` and `helpers.IsInexact`, replace with `n.IsNaN()` and `!n.IsExact()`

## R7RS conformance fixes

- `Float.IsInteger` uses `math.Trunc` instead of `float64(int64(f))` for correct handling of large floats outside int64 range
- `exact-integer?` now uses value-level check (`IsExact && IsInteger`) instead of type-level check, making `(exact-integer? 1+0i)` return `#t` per R7RS §6.2.6
- `rational?` now returns `#t` for real `BigComplex` values (previously fell through to `#f`)

## Test plan

- [x] `go test ./values/...` passes
- [x] `go test ./registry/core/...` passes (6.8s, ~4242 tests)
- [x] `make lint` passes with 0 issues
- [x] Updated `exact-integer?` test to match R7RS semantics for exact complex with zero imaginary part