### PR TITLE
test: add character, string, record, and promise primitive tests

### DIFF
--- a/internal/extensions/all/prim_all_test.go
+++ b/internal/extensions/all/prim_all_test.go
@@ -1,0 +1,704 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package all_test
+
+import (
+	"testing"
+
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// =============================================================================
+// Record Primitives — Low-Level API
+// =============================================================================
+
+func TestMakeRecordType(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"returns record type", `(record-type? (make-record-type 'point '(x y)))`, values.TrueValue},
+		{"not a record", `(record? (make-record-type 'point '(x y)))`, values.FalseValue},
+		{"empty fields", `(record-type? (make-record-type 'empty '()))`, values.TrueValue},
+		{"single field", `(record-type? (make-record-type 'wrapper '(value)))`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"name not symbol", `(make-record-type "point" '(x y))`},
+		{"field not symbol", `(make-record-type 'point '(x "y"))`},
+		{"wrong arity zero", `(make-record-type)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestRecordTypeQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"true for record type", `(record-type? (make-record-type 'foo '(a)))`, values.TrueValue},
+		{"false for integer", `(record-type? 42)`, values.FalseValue},
+		{"false for string", `(record-type? "hello")`, values.FalseValue},
+		{"false for list", `(record-type? '(1 2))`, values.FalseValue},
+		{"false for boolean", `(record-type? #t)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestRecordQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"true for record instance", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y))))
+			  (record? (ctor 1 2)))`, values.TrueValue},
+		{"false for record type", `(record? (make-record-type 'foo '(a)))`, values.FalseValue},
+		{"false for integer", `(record? 42)`, values.FalseValue},
+		{"false for string", `(record? "hello")`, values.FalseValue},
+		{"false for pair", `(record? '(1 . 2))`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestRecordTypeAccessor(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	// record-type returns the RecordType of a record instance
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"returns record type", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (p (ctor 1 2)))
+			  (record-type? (record-type p)))`, values.TrueValue},
+		{"same identity as original", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (p (ctor 1 2)))
+			  (eq? rt (record-type p)))`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a record", `(record-type 42)`},
+		{"record type not a record", `(record-type (make-record-type 'foo '()))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestRecordConstructor(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"construct and verify is record", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y))))
+			  (record? (ctor 10 20)))`, values.TrueValue},
+		{"partial constructor", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x)))
+			       (p (ctor 10))
+			       (get-x (record-accessor rt 'x))
+			       (get-y (record-accessor rt 'y)))
+			  (get-x p))`, values.NewInteger(10)},
+		{"partial constructor default field is false", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x)))
+			       (p (ctor 10))
+			       (get-y (record-accessor rt 'y)))
+			  (get-y p))`, values.FalseValue},
+		{"empty constructor", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '()))
+			       (p (ctor))
+			       (get-x (record-accessor rt 'x)))
+			  (get-x p))`, values.FalseValue},
+		{"constructor field ordering", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(y x)))
+			       (p (ctor 20 10))
+			       (get-x (record-accessor rt 'x))
+			       (get-y (record-accessor rt 'y)))
+			  (+ (get-x p) (get-y p)))`, values.NewInteger(30)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a record type", `(record-constructor 42 '(x))`},
+		{"unknown field", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-constructor rt '(z)))`},
+		{"field tags not symbols", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-constructor rt '("x")))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestRecordPredicate(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"true for own type", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (pred (record-predicate rt)))
+			  (pred (ctor 1 2)))`, values.TrueValue},
+		{"false for different record type", `
+			(let* ((rt1 (make-record-type 'point '(x y)))
+			       (rt2 (make-record-type 'color '(r g b)))
+			       (ctor2 (record-constructor rt2 '(r g b)))
+			       (pred1 (record-predicate rt1)))
+			  (pred1 (ctor2 255 0 0)))`, values.FalseValue},
+		{"false for non-record", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (pred (record-predicate rt)))
+			  (pred 42))`, values.FalseValue},
+		{"false for string", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (pred (record-predicate rt)))
+			  (pred "hello"))`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a record type", `(record-predicate 42)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestRecordAccessor(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"access first field", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (get-x (record-accessor rt 'x)))
+			  (get-x (ctor 10 20)))`, values.NewInteger(10)},
+		{"access second field", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (get-y (record-accessor rt 'y)))
+			  (get-y (ctor 10 20)))`, values.NewInteger(20)},
+		{"access string field", `
+			(let* ((rt (make-record-type 'person '(name age)))
+			       (ctor (record-constructor rt '(name age)))
+			       (get-name (record-accessor rt 'name)))
+			  (get-name (ctor "Alice" 30)))`, values.NewString("Alice")},
+		{"access boolean field", `
+			(let* ((rt (make-record-type 'flag '(value)))
+			       (ctor (record-constructor rt '(value)))
+			       (get-val (record-accessor rt 'value)))
+			  (get-val (ctor #t)))`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a record type", `(record-accessor 42 'x)`},
+		{"field tag not symbol", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-accessor rt "x"))`},
+		{"unknown field", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-accessor rt 'z))`},
+		{"accessor on wrong record type", `
+			(let* ((rt1 (make-record-type 'point '(x y)))
+			       (rt2 (make-record-type 'color '(r g b)))
+			       (ctor2 (record-constructor rt2 '(r g b)))
+			       (get-x (record-accessor rt1 'x)))
+			  (get-x (ctor2 255 0 0)))`},
+		{"accessor on non-record", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (get-x (record-accessor rt 'x)))
+			  (get-x 42))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestRecordModifier(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"modify and read back", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (get-x (record-accessor rt 'x))
+			       (set-x! (record-modifier rt 'x))
+			       (p (ctor 10 20)))
+			  (set-x! p 99)
+			  (get-x p))`, values.NewInteger(99)},
+		{"modify second field", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (get-y (record-accessor rt 'y))
+			       (set-y! (record-modifier rt 'y))
+			       (p (ctor 10 20)))
+			  (set-y! p 99)
+			  (get-y p))`, values.NewInteger(99)},
+		{"modify preserves other fields", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (ctor (record-constructor rt '(x y)))
+			       (get-x (record-accessor rt 'x))
+			       (set-y! (record-modifier rt 'y))
+			       (p (ctor 10 20)))
+			  (set-y! p 99)
+			  (get-x p))`, values.NewInteger(10)},
+		{"modify type change", `
+			(let* ((rt (make-record-type 'box '(value)))
+			       (ctor (record-constructor rt '(value)))
+			       (get-val (record-accessor rt 'value))
+			       (set-val! (record-modifier rt 'value))
+			       (b (ctor 42)))
+			  (set-val! b "hello")
+			  (get-val b))`, values.NewString("hello")},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a record type", `(record-modifier 42 'x)`},
+		{"field tag not symbol", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-modifier rt "x"))`},
+		{"unknown field", `
+			(let ((rt (make-record-type 'point '(x y))))
+			  (record-modifier rt 'z))`},
+		{"modifier on wrong record type", `
+			(let* ((rt1 (make-record-type 'point '(x y)))
+			       (rt2 (make-record-type 'color '(r g b)))
+			       (ctor2 (record-constructor rt2 '(r g b)))
+			       (set-x! (record-modifier rt1 'x)))
+			  (set-x! (ctor2 255 0 0) 42))`},
+		{"modifier on non-record", `
+			(let* ((rt (make-record-type 'point '(x y)))
+			       (set-x! (record-modifier rt 'x)))
+			  (set-x! 42 99))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+// =============================================================================
+// Records — High-Level define-record-type Macro
+// =============================================================================
+
+func TestDefineRecordType(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"construct and access", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x)
+			    (y point-y))
+			  (let ((p (make-point 3 4)))
+			    (+ (point-x p) (point-y p))))`, values.NewInteger(7)},
+		{"predicate true", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x)
+			    (y point-y))
+			  (point? (make-point 1 2)))`, values.TrueValue},
+		{"predicate false for non-record", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x)
+			    (y point-y))
+			  (point? 42))`, values.FalseValue},
+		{"predicate false for different record type", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x)
+			    (y point-y))
+			  (define-record-type <color>
+			    (make-color r g b)
+			    color?
+			    (r color-r)
+			    (g color-g)
+			    (b color-b))
+			  (point? (make-color 255 0 0)))`, values.FalseValue},
+		{"mutable field", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x point-set-x!)
+			    (y point-y point-set-y!))
+			  (let ((p (make-point 3 4)))
+			    (point-set-x! p 10)
+			    (point-x p)))`, values.NewInteger(10)},
+		{"mutation preserves other fields", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x point-set-x!)
+			    (y point-y))
+			  (let ((p (make-point 3 4)))
+			    (point-set-x! p 10)
+			    (point-y p)))`, values.NewInteger(4)},
+		{"mixed mutable and immutable fields", `
+			(begin
+			  (define-record-type <entry>
+			    (make-entry key value)
+			    entry?
+			    (key entry-key)
+			    (value entry-value entry-set-value!))
+			  (let ((e (make-entry 'name "Alice")))
+			    (entry-set-value! e "Bob")
+			    (entry-value e)))`, values.NewString("Bob")},
+		{"record with single field", `
+			(begin
+			  (define-record-type <wrapper>
+			    (make-wrapper val)
+			    wrapper?
+			    (val wrapper-val))
+			  (wrapper-val (make-wrapper 42)))`, values.NewInteger(42)},
+		{"nested records", `
+			(begin
+			  (define-record-type <point>
+			    (make-point x y)
+			    point?
+			    (x point-x)
+			    (y point-y))
+			  (define-record-type <line>
+			    (make-line start end)
+			    line?
+			    (start line-start)
+			    (end line-end))
+			  (let ((l (make-line (make-point 0 0) (make-point 3 4))))
+			    (point-x (line-end l))))`, values.NewInteger(3)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+// =============================================================================
+// Promise Primitives
+// =============================================================================
+
+func TestPromiseQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"delay creates promise", `(promise? (delay 1))`, values.TrueValue},
+		{"make-promise creates promise", `(promise? (make-promise 42))`, values.TrueValue},
+		{"make-promise on promise", `(promise? (make-promise (delay 1)))`, values.TrueValue},
+		{"integer not promise", `(promise? 1)`, values.FalseValue},
+		{"string not promise", `(promise? "hello")`, values.FalseValue},
+		{"list not promise", `(promise? '(1 2 3))`, values.FalseValue},
+		{"boolean not promise", `(promise? #f)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestMakePromise(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"wraps value", `(force (make-promise 42))`, values.NewInteger(42)},
+		{"wraps computed value", `(force (make-promise (+ 1 2)))`, values.NewInteger(3)},
+		{"wraps string", `(force (make-promise "hello"))`, values.NewString("hello")},
+		{"passes promise through", `(force (make-promise (delay 99)))`, values.NewInteger(99)},
+		{"make-promise is idempotent on promises", `
+			(let ((p (delay 42)))
+			  (eq? p (make-promise p)))`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestForce(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"force delayed value", `(force (delay 42))`, values.NewInteger(42)},
+		{"force delayed arithmetic", `(force (delay (+ 1 2)))`, values.NewInteger(3)},
+		{"force non-promise passthrough", `(force 5)`, values.NewInteger(5)},
+		{"force string passthrough", `(force "hello")`, values.NewString("hello")},
+		{"force memoizes result", `
+			(let ((count 0))
+			  (let ((p (delay (begin (set! count (+ count 1)) count))))
+			    (force p)
+			    (force p)
+			    (force p)
+			    count))`, values.NewInteger(1)},
+		{"force nested delay", `(force (delay (delay 10)))`, values.NewInteger(10)},
+		{"force list result", `(force (delay (cons 1 (cons 2 '()))))`,
+			values.List(values.NewInteger(1), values.NewInteger(2))},
+		{"force boolean", `(force (delay #t))`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestDelayForce(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"simple delay-force", `(force (delay-force (make-promise 5)))`, values.NewInteger(5)},
+		{"delay-force with delay", `(force (delay-force (delay 10)))`, values.NewInteger(10)},
+		{"delay-force chain", `(force (delay-force (delay-force (make-promise 7))))`, values.NewInteger(7)},
+		{"delay-force recursive iteration", `
+			(begin
+			  (define (stream-count n limit)
+			    (if (>= n limit)
+			        (delay n)
+			        (delay-force (stream-count (+ n 1) limit))))
+			  (force (stream-count 0 100)))`, values.NewInteger(100)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestMakeLazyPromise(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	// %make-lazy-promise is the internal primitive used by the delay macro.
+	// It creates a promise from a thunk (zero-argument lambda).
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"creates promise from thunk", `(promise? (%make-lazy-promise (lambda () 42)))`, values.TrueValue},
+		{"force evaluates thunk", `(force (%make-lazy-promise (lambda () (+ 1 2))))`, values.NewInteger(3)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+// =============================================================================
+// R7RS Promise Semantics (§4.2.5 examples)
+// =============================================================================
+
+func TestR7RSPromiseSemantics(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		// R7RS §4.2.5: Memoization — forcing a promise multiple times
+		// returns the same result without re-evaluating.
+		{"memoization side effect counted once", `
+			(let ((count 0))
+			  (define p (delay (begin (set! count (+ count 1)) count)))
+			  (force p)
+			  (force p)
+			  count)`, values.NewInteger(1)},
+
+		// R7RS §4.2.5: force on a non-promise returns the value.
+		{"force on non-promise", `(force 42)`, values.NewInteger(42)},
+
+		// Delay-force enables safe recursive forcing (tail-call style).
+		{"delay-force tail recursion", `
+			(begin
+			  (define (loop n)
+			    (if (= n 0)
+			        (delay 'done)
+			        (delay-force (loop (- n 1)))))
+			  (force (loop 50)))`, values.NewSymbol("done")},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}

--- a/internal/extensions/all/prim_characters_test.go
+++ b/internal/extensions/all/prim_characters_test.go
@@ -1,0 +1,425 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package all_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aalpar/wile"
+	extall "github.com/aalpar/wile/internal/extensions/all"
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// newEngine creates a Wile engine with all standard extensions loaded.
+func newEngine(t *testing.T) *wile.Engine {
+	t.Helper()
+	engine, err := wile.NewEngine(
+		wile.WithExtension(extall.Extension),
+	)
+	qt.New(t).Assert(err, qt.IsNil)
+	return engine
+}
+
+// eval runs Scheme code and returns the result.
+func eval(t *testing.T, engine *wile.Engine, code string) wile.Value {
+	t.Helper()
+	result, err := engine.Eval(context.Background(), code)
+	qt.New(t).Assert(err, qt.IsNil)
+	return result
+}
+
+// evalExpectError runs Scheme code and expects an error.
+func evalExpectError(t *testing.T, engine *wile.Engine, code string) {
+	t.Helper()
+	_, err := engine.Eval(context.Background(), code)
+	qt.New(t).Assert(err, qt.IsNotNil)
+}
+
+// --- Case-insensitive comparison ---
+
+func TestCharCiEq(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"same case", `(char-ci=? #\a #\a)`, values.TrueValue},
+		{"different case", `(char-ci=? #\a #\A)`, values.TrueValue},
+		{"not equal", `(char-ci=? #\a #\b)`, values.FalseValue},
+		{"variadic three equal", `(char-ci=? #\A #\a #\A)`, values.TrueValue},
+		{"variadic not all equal", `(char-ci=? #\a #\A #\b)`, values.FalseValue},
+		{"non-alpha characters", `(char-ci=? #\1 #\1)`, values.TrueValue},
+		{"single arg vacuous true", `(char-ci=? #\a)`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	t.Run("wrong type", func(t *testing.T) {
+		evalExpectError(t, engine, `(char-ci=? #\a 42)`)
+	})
+}
+
+func TestCharCiLt(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"less than", `(char-ci<? #\a #\B)`, values.TrueValue},
+		{"equal not less", `(char-ci<? #\a #\A)`, values.FalseValue},
+		{"greater not less", `(char-ci<? #\b #\A)`, values.FalseValue},
+		{"variadic ascending", `(char-ci<? #\a #\B #\c)`, values.TrueValue},
+		{"variadic not strictly ascending", `(char-ci<? #\a #\B #\b)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharCiGt(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"greater than", `(char-ci>? #\b #\A)`, values.TrueValue},
+		{"equal not greater", `(char-ci>? #\a #\A)`, values.FalseValue},
+		{"variadic descending", `(char-ci>? #\c #\B #\a)`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharCiLe(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"less than", `(char-ci<=? #\a #\B)`, values.TrueValue},
+		{"equal", `(char-ci<=? #\a #\A)`, values.TrueValue},
+		{"greater", `(char-ci<=? #\b #\A)`, values.FalseValue},
+		{"variadic non-decreasing", `(char-ci<=? #\a #\A #\b)`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharCiGe(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"greater than", `(char-ci>=? #\b #\A)`, values.TrueValue},
+		{"equal", `(char-ci>=? #\a #\A)`, values.TrueValue},
+		{"less", `(char-ci>=? #\a #\B)`, values.FalseValue},
+		{"variadic non-increasing", `(char-ci>=? #\b #\A #\a)`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+// --- Classification predicates ---
+
+func TestCharAlphabeticQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"lowercase letter", `(char-alphabetic? #\a)`, values.TrueValue},
+		{"uppercase letter", `(char-alphabetic? #\Z)`, values.TrueValue},
+		{"digit", `(char-alphabetic? #\0)`, values.FalseValue},
+		{"space", `(char-alphabetic? #\space)`, values.FalseValue},
+		{"unicode greek alpha", "(char-alphabetic? #\\α)", values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"wrong type", `(char-alphabetic? "a")`},
+		{"wrong arity", `(char-alphabetic? #\a #\b)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestCharNumericQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"digit 5", `(char-numeric? #\5)`, values.TrueValue},
+		{"zero", `(char-numeric? #\0)`, values.TrueValue},
+		{"nine", `(char-numeric? #\9)`, values.TrueValue},
+		{"letter", `(char-numeric? #\a)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharWhitespaceQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"space", `(char-whitespace? #\space)`, values.TrueValue},
+		{"tab", `(char-whitespace? #\tab)`, values.TrueValue},
+		{"newline", `(char-whitespace? #\newline)`, values.TrueValue},
+		{"letter", `(char-whitespace? #\a)`, values.FalseValue},
+		{"digit", `(char-whitespace? #\0)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharUpperCaseQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"uppercase", `(char-upper-case? #\A)`, values.TrueValue},
+		{"lowercase", `(char-upper-case? #\a)`, values.FalseValue},
+		{"digit", `(char-upper-case? #\0)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestCharLowerCaseQ(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"lowercase", `(char-lower-case? #\a)`, values.TrueValue},
+		{"uppercase", `(char-lower-case? #\A)`, values.FalseValue},
+		{"digit", `(char-lower-case? #\0)`, values.FalseValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+// --- Case mapping ---
+
+func TestCharUpcase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"lowercase to uppercase", `(char-upcase #\a)`, values.NewCharacter('A')},
+		{"already uppercase", `(char-upcase #\A)`, values.NewCharacter('A')},
+		{"digit unchanged", `(char-upcase #\5)`, values.NewCharacter('5')},
+		{"space unchanged", `(char-upcase #\space)`, values.NewCharacter(' ')},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	t.Run("wrong type", func(t *testing.T) {
+		evalExpectError(t, engine, `(char-upcase "a")`)
+	})
+}
+
+func TestCharDowncase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"uppercase to lowercase", `(char-downcase #\A)`, values.NewCharacter('a')},
+		{"already lowercase", `(char-downcase #\a)`, values.NewCharacter('a')},
+		{"digit unchanged", `(char-downcase #\5)`, values.NewCharacter('5')},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestCharFoldcase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"uppercase folds to lowercase", `(char-foldcase #\A)`, values.NewCharacter('a')},
+		{"lowercase stays", `(char-foldcase #\a)`, values.NewCharacter('a')},
+		{"digit unchanged", `(char-foldcase #\5)`, values.NewCharacter('5')},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	// R7RS: (char-foldcase (char-foldcase c)) = (char-foldcase c)
+	t.Run("foldcase is idempotent", func(t *testing.T) {
+		result := eval(t, engine, `(char=? (char-foldcase (char-foldcase #\Z)) (char-foldcase #\Z))`)
+		c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+	})
+}
+
+// --- digit-value ---
+
+func TestDigitValue(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		// ASCII digits 0-9
+		{"ascii 0", `(digit-value #\0)`, values.NewInteger(0)},
+		{"ascii 1", `(digit-value #\1)`, values.NewInteger(1)},
+		{"ascii 2", `(digit-value #\2)`, values.NewInteger(2)},
+		{"ascii 3", `(digit-value #\3)`, values.NewInteger(3)},
+		{"ascii 4", `(digit-value #\4)`, values.NewInteger(4)},
+		{"ascii 5", `(digit-value #\5)`, values.NewInteger(5)},
+		{"ascii 6", `(digit-value #\6)`, values.NewInteger(6)},
+		{"ascii 7", `(digit-value #\7)`, values.NewInteger(7)},
+		{"ascii 8", `(digit-value #\8)`, values.NewInteger(8)},
+		{"ascii 9", `(digit-value #\9)`, values.NewInteger(9)},
+
+		// Non-digits return #f
+		{"letter", `(digit-value #\a)`, values.FalseValue},
+		{"space", `(digit-value #\space)`, values.FalseValue},
+
+		// Unicode decimal digit scripts
+		{"arabic-indic zero U+0660", "(digit-value #\\٠)", values.NewInteger(0)},
+		{"arabic-indic five U+0665", "(digit-value #\\٥)", values.NewInteger(5)},
+		{"devanagari zero U+0966", "(digit-value #\\०)", values.NewInteger(0)},
+		{"devanagari nine U+096F", "(digit-value #\\९)", values.NewInteger(9)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"wrong type", `(digit-value 5)`},
+		{"wrong arity", `(digit-value #\0 #\1)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}

--- a/internal/extensions/all/prim_strings_test.go
+++ b/internal/extensions/all/prim_strings_test.go
@@ -1,0 +1,480 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package all_test
+
+import (
+	"testing"
+
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// --- Case-insensitive comparison ---
+
+func TestStringCiEq(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"same case", `(string-ci=? "abc" "abc")`, values.TrueValue},
+		{"different case", `(string-ci=? "abc" "ABC")`, values.TrueValue},
+		{"mixed case", `(string-ci=? "Hello" "hELLO")`, values.TrueValue},
+		{"not equal", `(string-ci=? "abc" "abd")`, values.FalseValue},
+		{"different lengths", `(string-ci=? "abc" "ab")`, values.FalseValue},
+		{"empty strings", `(string-ci=? "" "")`, values.TrueValue},
+		{"variadic three equal", `(string-ci=? "abc" "ABC" "Abc")`, values.TrueValue},
+		{"variadic not all equal", `(string-ci=? "abc" "ABC" "abd")`, values.FalseValue},
+		{"single arg vacuous true", `(string-ci=? "abc")`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"wrong type", `(string-ci=? "abc" 42)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestStringCiLt(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"less than", `(string-ci<? "abc" "DEF")`, values.TrueValue},
+		{"equal not less", `(string-ci<? "abc" "ABC")`, values.FalseValue},
+		{"greater not less", `(string-ci<? "def" "ABC")`, values.FalseValue},
+		{"variadic ascending", `(string-ci<? "abc" "DEF" "ghi")`, values.TrueValue},
+		{"variadic not ascending", `(string-ci<? "abc" "DEF" "def")`, values.FalseValue},
+		{"prefix is less", `(string-ci<? "ab" "ABC")`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestStringCiGt(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"greater than", `(string-ci>? "def" "ABC")`, values.TrueValue},
+		{"equal not greater", `(string-ci>? "abc" "ABC")`, values.FalseValue},
+		{"variadic descending", `(string-ci>? "ghi" "DEF" "abc")`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestStringCiLe(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"less than", `(string-ci<=? "abc" "DEF")`, values.TrueValue},
+		{"equal", `(string-ci<=? "abc" "ABC")`, values.TrueValue},
+		{"greater", `(string-ci<=? "def" "ABC")`, values.FalseValue},
+		{"variadic non-decreasing", `(string-ci<=? "abc" "ABC" "def")`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+func TestStringCiGe(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"greater than", `(string-ci>=? "def" "ABC")`, values.TrueValue},
+		{"equal", `(string-ci>=? "abc" "ABC")`, values.TrueValue},
+		{"less", `(string-ci>=? "abc" "DEF")`, values.FalseValue},
+		{"variadic non-increasing", `(string-ci>=? "def" "ABC" "abc")`, values.TrueValue},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), qt.Equals, tc.want)
+		})
+	}
+}
+
+// --- Case mapping ---
+
+func TestStringUpcase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"lowercase", `(string-upcase "hello")`, values.NewString("HELLO")},
+		{"already upper", `(string-upcase "HELLO")`, values.NewString("HELLO")},
+		{"mixed", `(string-upcase "Hello World")`, values.NewString("HELLO WORLD")},
+		{"empty", `(string-upcase "")`, values.NewString("")},
+		{"digits unchanged", `(string-upcase "abc123")`, values.NewString("ABC123")},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	t.Run("wrong type", func(t *testing.T) {
+		evalExpectError(t, engine, `(string-upcase 42)`)
+	})
+}
+
+func TestStringDowncase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"uppercase", `(string-downcase "HELLO")`, values.NewString("hello")},
+		{"already lower", `(string-downcase "hello")`, values.NewString("hello")},
+		{"mixed", `(string-downcase "Hello World")`, values.NewString("hello world")},
+		{"empty", `(string-downcase "")`, values.NewString("")},
+		{"digits unchanged", `(string-downcase "ABC123")`, values.NewString("abc123")},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestStringFoldcase(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{"uppercase folds", `(string-foldcase "HELLO")`, values.NewString("hello")},
+		{"lowercase stays", `(string-foldcase "hello")`, values.NewString("hello")},
+		{"mixed folds", `(string-foldcase "Hello World")`, values.NewString("hello world")},
+		{"empty", `(string-foldcase "")`, values.NewString("")},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	// R7RS: (string-ci=? (string-foldcase s1) (string-foldcase s2)) = (string-ci=? s1 s2)
+	t.Run("foldcase is idempotent", func(t *testing.T) {
+		result := eval(t, engine, `(string=? (string-foldcase (string-foldcase "HeLLo"))
+		                                      (string-foldcase "HeLLo"))`)
+		c.Assert(result.Internal(), qt.Equals, values.TrueValue)
+	})
+}
+
+// --- string-copy! ---
+
+func TestStringCopyTo(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{
+			"basic copy",
+			`(let ((s (string-copy "aaaaa"))) (string-copy! s 0 "hello") s)`,
+			values.NewString("hello"),
+		},
+		{
+			"copy at offset",
+			`(let ((s (string-copy "aaaaa"))) (string-copy! s 2 "xy") s)`,
+			values.NewString("aaxy" + "a"),
+		},
+		{
+			"copy with start",
+			`(let ((s (string-copy "aaaaa"))) (string-copy! s 0 "hello" 1) s)`,
+			values.NewString("elloa"),
+		},
+		{
+			"copy with start and end",
+			`(let ((s (string-copy "aaaaa"))) (string-copy! s 1 "hello" 1 3) s)`,
+			values.NewString("aelaa"),
+		},
+		{
+			"copy zero-length range",
+			`(let ((s (string-copy "hello"))) (string-copy! s 0 "xyz" 1 1) s)`,
+			values.NewString("hello"),
+		},
+		{
+			"copy entire source",
+			`(let ((s (string-copy "xxxxx"))) (string-copy! s 0 "abcde") s)`,
+			values.NewString("abcde"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"destination out of bounds", `(let ((s (string-copy "abc"))) (string-copy! s 2 "hello"))`},
+		{"negative at", `(let ((s (string-copy "abc"))) (string-copy! s -1 "x"))`},
+		{"invalid source range", `(let ((s (string-copy "abc"))) (string-copy! s 0 "hello" 3 1))`},
+		{"wrong type dest", `(string-copy! 42 0 "abc")`},
+		{"wrong type source", `(let ((s (string-copy "abc"))) (string-copy! s 0 42))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+// --- string-fill! ---
+
+func TestStringFill(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{
+			"fill entire string",
+			`(let ((s (string-copy "hello"))) (string-fill! s #\x) s)`,
+			values.NewString("xxxxx"),
+		},
+		{
+			"fill with start",
+			`(let ((s (string-copy "hello"))) (string-fill! s #\x 2) s)`,
+			values.NewString("hexxx"),
+		},
+		{
+			"fill with start and end",
+			`(let ((s (string-copy "hello"))) (string-fill! s #\x 1 3) s)`,
+			values.NewString("hxxlo"),
+		},
+		{
+			"fill zero-length range",
+			`(let ((s (string-copy "hello"))) (string-fill! s #\x 2 2) s)`,
+			values.NewString("hello"),
+		},
+		{
+			"fill empty string",
+			`(let ((s (string-copy ""))) (string-fill! s #\x) s)`,
+			values.NewString(""),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"invalid range", `(let ((s (string-copy "hello"))) (string-fill! s #\x 3 1))`},
+		{"out of bounds", `(let ((s (string-copy "abc"))) (string-fill! s #\x 0 5))`},
+		{"wrong type string", `(string-fill! 42 #\x)`},
+		{"wrong type char", `(let ((s (string-copy "abc"))) (string-fill! s "x"))`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+// --- string-map ---
+
+func TestStringMap(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{
+			"upcase via map",
+			`(string-map char-upcase "hello")`,
+			values.NewString("HELLO"),
+		},
+		{
+			"identity",
+			`(string-map (lambda (c) c) "hello")`,
+			values.NewString("hello"),
+		},
+		{
+			"empty string",
+			`(string-map char-upcase "")`,
+			values.NewString(""),
+		},
+		{
+			"two strings min length",
+			// With two strings of different lengths, operates on min length.
+			// This lambda takes two chars and returns the first.
+			`(string-map (lambda (a b) a) "abcde" "xyz")`,
+			values.NewString("abc"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a procedure", `(string-map 42 "hello")`},
+		{"not a string", `(string-map char-upcase 42)`},
+		{"no strings", `(string-map char-upcase)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+// --- string-for-each ---
+
+func TestStringForEach(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	tcs := []struct {
+		name string
+		code string
+		want values.Value
+	}{
+		{
+			"accumulate chars",
+			// Use a mutable string to accumulate characters visited.
+			`(let ((acc (string-copy "")))
+			   (string-for-each
+			     (lambda (c) (set! acc (string-append acc (string c))))
+			     "abc")
+			   acc)`,
+			values.NewString("abc"),
+		},
+		{
+			"empty string no-op",
+			`(let ((count 0))
+			   (string-for-each (lambda (c) (set! count (+ count 1))) "")
+			   count)`,
+			values.NewInteger(0),
+		},
+		{
+			"counts characters",
+			`(let ((count 0))
+			   (string-for-each (lambda (c) (set! count (+ count 1))) "hello")
+			   count)`,
+			values.NewInteger(5),
+		},
+		{
+			"two strings min length",
+			`(let ((count 0))
+			   (string-for-each (lambda (a b) (set! count (+ count 1))) "abcde" "xy")
+			   count)`,
+			values.NewInteger(2),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			result := eval(t, engine, tc.code)
+			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+		})
+	}
+
+	errs := []struct {
+		name string
+		code string
+	}{
+		{"not a procedure", `(string-for-each 42 "hello")`},
+		{"not a string", `(string-for-each (lambda (c) c) 42)`},
+	}
+	for _, tc := range errs {
+		t.Run(tc.name, func(t *testing.T) {
+			evalExpectError(t, engine, tc.code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add 59 character primitive test cases (`prim_characters_test.go`)
- Add 68 string primitive test cases (`prim_strings_test.go`)
- Add 72 record and promise primitive test cases (`prim_all_test.go`)
- Shared test helpers (`newEngine`, `eval`, `evalExpectError`) defined in `prim_characters_test.go`

## Test Plan
- [x] `go test -v ./internal/extensions/all/...` passes (199 tests)
- [x] `make lint` clean