### PR TITLE
refactor: migrate operation EqualTo methods to shared helpers

### DIFF
--- a/machine/operation_build_syntax.go
+++ b/machine/operation_build_syntax.go
@@ -65,8 +65,11 @@ func (p *OperationBuildSyntaxList) SchemeString() string {
 }
 
 func (p *OperationBuildSyntaxList) EqualTo(other values.Value) bool {
-	o, ok := other.(*OperationBuildSyntaxList)
-	return ok && p.Count == o.Count
+	v, ok := other.(*OperationBuildSyntaxList)
+	return fieldMatches(p, v, ok,
+		func(op *OperationBuildSyntaxList) int {
+			return op.Count
+		})
 }
 
 func (p *OperationBuildSyntaxList) IsVoid() bool {

--- a/machine/operation_helpers.go
+++ b/machine/operation_helpers.go
@@ -14,6 +14,8 @@
 
 package machine
 
+import "slices"
+
 // sameType is a helper for EqualTo methods on zero-field operations.
 // The caller must perform the type assertion and pass the result.
 //
@@ -50,4 +52,44 @@ func fieldMatches[T comparable, Op any](p, v *Op, ok bool, getField func(*Op) T)
 		return v == p
 	}
 	return getField(p) == getField(v)
+}
+
+// fieldMethodMatches is a helper for EqualTo methods on single-field operations
+// where the field is compared via a method rather than ==.
+//
+// Usage:
+//
+//	func (p *OperationType) EqualTo(o values.Value) bool {
+//	    v, ok := o.(*OperationType)
+//	    return fieldMethodMatches(p, v, ok,
+//	        func(op *OperationType) *FieldType { return op.Field },
+//	        func(a, b *FieldType) bool { return a.EqualTo(b) })
+//	}
+func fieldMethodMatches[T any, Op any](p, v *Op, ok bool, getField func(*Op) T, eq func(T, T) bool) bool {
+	if !ok {
+		return false
+	}
+	if v == nil || p == nil {
+		return v == p
+	}
+	return eq(getField(p), getField(v))
+}
+
+// sliceMatches is a helper for EqualTo methods on operations with a single
+// comparable-element slice field.
+//
+// Usage:
+//
+//	func (p *OperationType) EqualTo(o values.Value) bool {
+//	    v, ok := o.(*OperationType)
+//	    return sliceMatches(p, v, ok, func(op *OperationType) []string { return op.Items })
+//	}
+func sliceMatches[T comparable, Op any](p, v *Op, ok bool, getField func(*Op) []T) bool {
+	if !ok {
+		return false
+	}
+	if v == nil || p == nil {
+		return v == p
+	}
+	return slices.Equal(getField(p), getField(v))
 }

--- a/machine/operation_load_literal_integer.go
+++ b/machine/operation_load_literal_integer.go
@@ -46,5 +46,8 @@ func (p *OperationLoadLiteralInteger) IsVoid() bool {
 
 func (p *OperationLoadLiteralInteger) EqualTo(o values.Value) bool {
 	v, ok := o.(*OperationLoadLiteralInteger)
-	return sameType(p, v, ok)
+	return fieldMatches(p, v, ok,
+		func(op *OperationLoadLiteralInteger) int64 {
+			return op.Value
+		})
 }

--- a/machine/operation_load_local_by_local_index_immediate.go
+++ b/machine/operation_load_local_by_local_index_immediate.go
@@ -40,13 +40,13 @@ func (p *OperationLoadLocalByLocalIndexImmediate) IsVoid() bool {
 
 func (p *OperationLoadLocalByLocalIndexImmediate) EqualTo(o values.Value) bool {
 	v, ok := o.(*OperationLoadLocalByLocalIndexImmediate)
-	if !ok {
-		return false
-	}
-	if v == nil || p == nil {
-		return v == p
-	}
-	return p.LocalIndex.EqualTo(v.LocalIndex)
+	return fieldMethodMatches(p, v, ok,
+		func(op *OperationLoadLocalByLocalIndexImmediate) *environment.LocalIndex {
+			return op.LocalIndex
+		},
+		func(a, b *environment.LocalIndex) bool {
+			return a.EqualTo(b)
+		})
 }
 
 func (p *OperationLoadLocalByLocalIndexImmediate) Apply(ctx context.Context, mc *MachineContext) (*MachineContext, error) {

--- a/machine/operation_misc_test.go
+++ b/machine/operation_misc_test.go
@@ -83,8 +83,12 @@ func TestOperationBrk_IsVoid(t *testing.T) {
 }
 
 func TestOperationBrk_EqualTo(t *testing.T) {
-	fn1 := func(ctx context.Context, mc *MachineContext) error { return nil }
-	fn2 := func(ctx context.Context, mc *MachineContext) error { return nil }
+	fn1 := func(ctx context.Context, mc *MachineContext) error {
+		return nil
+	}
+	fn2 := func(ctx context.Context, mc *MachineContext) error {
+		return nil
+	}
 
 	op1 := NewOperationBrk(fn1)
 	op2 := NewOperationBrk(fn2)
@@ -135,7 +139,7 @@ func TestOperationLoadLiteralInteger_EqualTo(t *testing.T) {
 	op3 := NewOperationLoadLiteralInteger(99)
 
 	qt.Assert(t, op1.EqualTo(op2), qt.IsTrue)
-	qt.Assert(t, op1.EqualTo(op3), qt.IsTrue) // Implementation returns true for all non-nil
+	qt.Assert(t, op1.EqualTo(op3), qt.IsFalse)
 	qt.Assert(t, op1.EqualTo(values.NewInteger(42)), qt.IsFalse)
 
 	var nilOp1 *OperationLoadLiteralInteger

--- a/machine/operation_pop_env.go
+++ b/machine/operation_pop_env.go
@@ -50,8 +50,8 @@ func (p *OperationPopEnv) SchemeString() string {
 }
 
 func (p *OperationPopEnv) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationPopEnv)
-	return ok
+	v, ok := other.(*OperationPopEnv)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationPopEnv) IsVoid() bool {

--- a/machine/operation_restore_continuation.go
+++ b/machine/operation_restore_continuation.go
@@ -44,8 +44,5 @@ func (p *OperationRestoreContinuation) IsVoid() bool {
 
 func (p *OperationRestoreContinuation) EqualTo(o values.Value) bool {
 	v, ok := o.(*OperationRestoreContinuation)
-	if !ok {
-		return false
-	}
-	return v == p
+	return sameType(p, v, ok)
 }

--- a/machine/operation_store_local_by_local_index_immediate.go
+++ b/machine/operation_store_local_by_local_index_immediate.go
@@ -40,13 +40,13 @@ func (p *OperationStoreLocalByLocalIndexImmediate) IsVoid() bool {
 
 func (p *OperationStoreLocalByLocalIndexImmediate) EqualTo(o values.Value) bool {
 	v, ok := o.(*OperationStoreLocalByLocalIndexImmediate)
-	if !ok {
-		return false
-	}
-	if v == nil || p == nil {
-		return v == p
-	}
-	return p.LocalIndex.EqualTo(v.LocalIndex)
+	return fieldMethodMatches(p, v, ok,
+		func(op *OperationStoreLocalByLocalIndexImmediate) *environment.LocalIndex {
+			return op.LocalIndex
+		},
+		func(a, b *environment.LocalIndex) bool {
+			return a.EqualTo(b)
+		})
 }
 
 func (p *OperationStoreLocalByLocalIndexImmediate) Apply(ctx context.Context, mc *MachineContext) (*MachineContext, error) {

--- a/machine/operation_syntax_case.go
+++ b/machine/operation_syntax_case.go
@@ -98,8 +98,8 @@ func (p *OperationSyntaxCaseMatch) SchemeString() string {
 }
 
 func (p *OperationSyntaxCaseMatch) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationSyntaxCaseMatch)
-	return ok
+	v, ok := other.(*OperationSyntaxCaseMatch)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationSyntaxCaseMatch) IsVoid() bool {
@@ -165,19 +165,11 @@ func (p *OperationBindPatternVars) SchemeString() string {
 }
 
 func (p *OperationBindPatternVars) EqualTo(other values.Value) bool {
-	o, ok := other.(*OperationBindPatternVars)
-	if !ok {
-		return false
-	}
-	if len(p.PatternVars) != len(o.PatternVars) {
-		return false
-	}
-	for i, v := range p.PatternVars {
-		if o.PatternVars[i] != v {
-			return false
-		}
-	}
-	return true
+	v, ok := other.(*OperationBindPatternVars)
+	return sliceMatches(p, v, ok,
+		func(op *OperationBindPatternVars) []string {
+			return op.PatternVars
+		})
 }
 
 func (p *OperationBindPatternVars) IsVoid() bool {
@@ -204,8 +196,8 @@ func (p *OperationSyntaxCaseNoMatch) SchemeString() string {
 }
 
 func (p *OperationSyntaxCaseNoMatch) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationSyntaxCaseNoMatch)
-	return ok
+	v, ok := other.(*OperationSyntaxCaseNoMatch)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationSyntaxCaseNoMatch) IsVoid() bool {
@@ -257,8 +249,8 @@ func (p *OperationSyntaxTemplateExpand) SchemeString() string {
 }
 
 func (p *OperationSyntaxTemplateExpand) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationSyntaxTemplateExpand)
-	return ok
+	v, ok := other.(*OperationSyntaxTemplateExpand)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationSyntaxTemplateExpand) IsVoid() bool {
@@ -294,8 +286,8 @@ func (p *OperationStoreSyntaxCaseInput) SchemeString() string {
 }
 
 func (p *OperationStoreSyntaxCaseInput) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationStoreSyntaxCaseInput)
-	return ok
+	v, ok := other.(*OperationStoreSyntaxCaseInput)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationStoreSyntaxCaseInput) IsVoid() bool {
@@ -325,8 +317,8 @@ func (p *OperationClearSyntaxCaseInput) SchemeString() string {
 }
 
 func (p *OperationClearSyntaxCaseInput) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationClearSyntaxCaseInput)
-	return ok
+	v, ok := other.(*OperationClearSyntaxCaseInput)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationClearSyntaxCaseInput) IsVoid() bool {

--- a/machine/operation_syntax_rules_transform.go
+++ b/machine/operation_syntax_rules_transform.go
@@ -226,8 +226,8 @@ func (p *OperationSyntaxRulesTransform) SchemeString() string {
 }
 
 func (p *OperationSyntaxRulesTransform) EqualTo(other values.Value) bool {
-	_, ok := other.(*OperationSyntaxRulesTransform)
-	return ok
+	v, ok := other.(*OperationSyntaxRulesTransform)
+	return sameType(p, v, ok)
 }
 
 func (p *OperationSyntaxRulesTransform) IsVoid() bool {

--- a/machine/operation_test.go
+++ b/machine/operation_test.go
@@ -440,9 +440,9 @@ func TestOperationValueMethods(t *testing.T) {
 		op1 := NewOperationRestoreContinuation()
 		op2 := NewOperationRestoreContinuation()
 		qt.Assert(t, op1.IsVoid(), qt.IsFalse)
-		// RestoreContinuation uses pointer equality in EqualTo, so different instances are not equal
+		// RestoreContinuation is a zero-field operation: all non-nil instances are structurally equal
 		qt.Assert(t, op1.EqualTo(op1), qt.IsTrue)
-		qt.Assert(t, op1.EqualTo(op2), qt.IsFalse)
+		qt.Assert(t, op1.EqualTo(op2), qt.IsTrue)
 		qt.Assert(t, op1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 	})
 
@@ -821,9 +821,9 @@ func TestOperationLoadLiteralIntegerMethods(t *testing.T) {
 	op2 := NewOperationLoadLiteralInteger(42)
 	qt.Assert(t, op.EqualTo(op2), qt.IsTrue)
 
-	// Different value - EqualTo only checks type, not value
+	// Different value
 	op3 := NewOperationLoadLiteralInteger(99)
-	qt.Assert(t, op.EqualTo(op3), qt.IsTrue) // EqualTo returns true for same type
+	qt.Assert(t, op.EqualTo(op3), qt.IsFalse)
 
 	// Different type
 	qt.Assert(t, op.EqualTo(values.NewInteger(42)), qt.IsFalse)
@@ -831,7 +831,9 @@ func TestOperationLoadLiteralIntegerMethods(t *testing.T) {
 
 // TestOperationBrkMethods tests OperationBrk methods
 func TestOperationBrkMethods(t *testing.T) {
-	fn := func(ctx context.Context, mc *MachineContext) error { return nil }
+	fn := func(ctx context.Context, mc *MachineContext) error {
+		return nil
+	}
 	op := NewOperationBrk(fn)
 	qt.Assert(t, op.SchemeString(), qt.IsNotNil)
 	qt.Assert(t, op.IsVoid(), qt.IsFalse)


### PR DESCRIPTION
## Summary
- Add `fieldMethodMatches` and `sliceMatches` generic helpers to `operation_helpers.go`
- Migrate 10 operation files to use `sameType`, `fieldMatches`, `fieldMethodMatches`, and `sliceMatches` instead of hand-written EqualTo logic
- Fix `OperationLoadLiteralInteger.EqualTo` to compare Value field (was ignoring it)
- Fix `OperationRestoreContinuation.EqualTo` to use `sameType` (was using pointer equality)
- Update tests to match corrected EqualTo semantics

## Test Plan
- [x] `go test -v ./machine/...` passes
- [x] `make lint` clean