### PR TITLE
refactor: add per-type numeric conversion helpers

### DIFF
--- a/values/big_float.go
+++ b/values/big_float.go
@@ -78,13 +78,13 @@ func (p *BigFloat) Add(o Number) Number {
 	case *BigFloat:
 		return &BigFloat{value: new(big.Float).Add(p.value, v.value)}
 	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
 	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
 	case *Float:
-		vf := new(big.Float).SetFloat64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
 	case *Rational:
 		vf := new(big.Float).SetRat(v.Rat())
@@ -115,13 +115,13 @@ func (p *BigFloat) Subtract(o Number) Number {
 	case *BigFloat:
 		return &BigFloat{value: new(big.Float).Sub(p.value, v.value)}
 	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
 	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
 	case *Float:
-		vf := new(big.Float).SetFloat64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
 	case *Rational:
 		vf := new(big.Float).SetRat(v.Rat())
@@ -155,13 +155,13 @@ func (p *BigFloat) Multiply(o Number) Number {
 	case *BigFloat:
 		return &BigFloat{value: new(big.Float).Mul(p.value, v.value)}
 	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
 	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
 	case *Float:
-		vf := new(big.Float).SetFloat64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
 	case *Rational:
 		vf := new(big.Float).SetRat(v.Rat())
@@ -192,13 +192,13 @@ func (p *BigFloat) Divide(o Number) Number {
 	case *BigFloat:
 		return &BigFloat{value: new(big.Float).Quo(p.value, v.value)}
 	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
 	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
 	case *Float:
-		vf := new(big.Float).SetFloat64(v.Value)
+		vf := v.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
 	case *Rational:
 		vf := new(big.Float).SetRat(v.Rat())
@@ -307,13 +307,13 @@ func (p *BigFloat) Compare(o Number) int {
 	case *BigFloat:
 		return p.value.Cmp(v.value)
 	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
+		vf := v.bigFloat()
 		return p.value.Cmp(vf)
 	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
+		vf := v.bigFloat()
 		return p.value.Cmp(vf)
 	case *Float:
-		vf := new(big.Float).SetFloat64(v.Value)
+		vf := v.bigFloat()
 		return p.value.Cmp(vf)
 	case *Rational:
 		vf := new(big.Float).SetRat(v.Rat())

--- a/values/big_integer.go
+++ b/values/big_integer.go
@@ -87,6 +87,26 @@ func (p *BigInteger) Int64() int64 {
 	return p.value.Int64()
 }
 
+// Per-type conversion helpers for BigInteger.
+// These eliminate repeated conversion expressions in the type-switch
+// dispatch methods below. Each produces the representation needed by
+// the target type's native arithmetic.
+
+func (p *BigInteger) float64Val() float64 {
+	return float64FromBigInt(p.value)
+}
+
+func (p *BigInteger) bigRat() *big.Rat {
+	return new(big.Rat).SetInt(p.value)
+}
+
+func (p *BigInteger) bigFloat() *big.Float {
+	return new(big.Float).SetInt(p.value)
+}
+func (p *BigInteger) toBigComplex() *BigComplex {
+	return NewBigComplex(p, NewBigIntegerFromInt64(0))
+}
+
 // Add returns the sum of this BigInteger and another number.
 //
 // R7RS §6.2.6: The + procedure returns the sum of its arguments.
@@ -105,24 +125,24 @@ func (p *BigInteger) Add(o Number) Number {
 	case *BigInteger:
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, v.value)}
 	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, big.NewInt(v.Value))}
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, v.bigInt())}
 	case *Float:
 		// no constructor for big.Float from big.Int, so convert via float64
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewFloat(f + v.Value)
 	case *Rational:
 		// Convert BigInteger to Rational and add
-		pRat := new(big.Rat).SetInt(p.value)
+		pRat := p.bigRat()
 		return NewRationalFromRat(new(big.Rat).Add(pRat, v.Rat()))
 	case *Complex:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		// no constructor for big.Float from big.Int, so convert via float64
 		return NewComplex(complex(f, 0) + v.Datum())
 	case *BigFloat:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(self, v.value)}
 	case *BigComplex:
-		bc := NewBigComplex(p, NewBigIntegerFromInt64(0))
+		bc := p.toBigComplex()
 		return bc.Add(v)
 	}
 	panic(ErrNotANumber)
@@ -142,22 +162,22 @@ func (p *BigInteger) Subtract(o Number) Number {
 	case *BigInteger:
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, v.value)}
 	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, big.NewInt(v.Value))}
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, v.bigInt())}
 	case *Float:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewFloat(f - v.Value)
 	case *Rational:
-		pRat := new(big.Rat).SetInt(p.value)
+		pRat := p.bigRat()
 		return NewRationalFromRat(new(big.Rat).Sub(pRat, v.Rat()))
 	case *Complex:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		// no constructor for big.Float from big.Int, so convert via float64
 		return NewComplex(complex(f, 0) - v.Datum())
 	case *BigFloat:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
 	case *BigComplex:
-		bc := NewBigComplex(p, NewBigIntegerFromInt64(0))
+		bc := p.toBigComplex()
 		return bc.Subtract(v)
 	}
 	panic(ErrNotANumber)
@@ -183,21 +203,21 @@ func (p *BigInteger) Multiply(o Number) Number {
 	case *BigInteger:
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, v.value)}
 	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, big.NewInt(v.Value))}
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, v.bigInt())}
 	case *Float:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewFloat(f * v.Value)
 	case *Rational:
-		pRat := new(big.Rat).SetInt(p.value)
+		pRat := p.bigRat()
 		return NewRationalFromRat(new(big.Rat).Mul(pRat, v.Rat()))
 	case *Complex:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewComplex(complex(f, 0) * v.Datum())
 	case *BigFloat:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
 	case *BigComplex:
-		bc := NewBigComplex(p, NewBigIntegerFromInt64(0))
+		bc := p.toBigComplex()
 		return bc.Multiply(v)
 	}
 	panic(ErrNotANumber)
@@ -226,26 +246,26 @@ func (p *BigInteger) Divide(o Number) Number {
 		return NewRationalFromBigInt(p.value, v.value)
 	case *Integer:
 		// Check if division is exact
-		divisor := big.NewInt(v.Value)
+		divisor := v.bigInt()
 		quo, rem := new(big.Int).QuoRem(p.value, divisor, new(big.Int))
 		if rem.Sign() == 0 {
 			return &BigInteger{value: quo}
 		}
 		return NewRationalFromBigInt(p.value, divisor)
 	case *Float:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewFloat(f / v.Value)
 	case *Rational:
-		pRat := new(big.Rat).SetInt(p.value)
+		pRat := p.bigRat()
 		return NewRationalFromRat(new(big.Rat).Quo(pRat, v.Rat()))
 	case *Complex:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		return NewComplex(complex(f, 0) / v.Datum())
 	case *BigFloat:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
 	case *BigComplex:
-		bc := NewBigComplex(p, NewBigIntegerFromInt64(0))
+		bc := p.toBigComplex()
 		return bc.Divide(v)
 	}
 	panic(ErrNotANumber)
@@ -330,7 +350,7 @@ func (p *BigInteger) ToExact() Number {
 // R7RS §6.2.3: The inexact representation may have limited precision,
 // but the conversion should be as close as practical.
 func (p *BigInteger) ToInexact() Number {
-	f := float64FromBigInt(p.value)
+	f := p.float64Val()
 	return NewFloat(f)
 }
 
@@ -353,9 +373,9 @@ func (p *BigInteger) Compare(o Number) int {
 	case *BigInteger:
 		return p.value.Cmp(v.value)
 	case *Integer:
-		return p.value.Cmp(big.NewInt(v.Value))
+		return p.value.Cmp(v.bigInt())
 	case *Float:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		if f < v.Value {
 			return -1
 		} else if f > v.Value {
@@ -363,13 +383,13 @@ func (p *BigInteger) Compare(o Number) int {
 		}
 		return 0
 	case *BigFloat:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return self.Cmp(v.BigFloatValue())
 	case *Rational:
-		pRat := new(big.Rat).SetInt(p.value)
+		pRat := p.bigRat()
 		return pRat.Cmp(v.Rat())
 	case *Complex:
-		f := float64FromBigInt(p.value)
+		f := p.float64Val()
 		if f < real(v.Value) {
 			return -1
 		} else if f > real(v.Value) {
@@ -377,7 +397,7 @@ func (p *BigInteger) Compare(o Number) int {
 		}
 		return 0
 	case *BigComplex:
-		self := new(big.Float).SetInt(p.value)
+		self := p.bigFloat()
 		return self.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
 	panic(ErrNotANumber)
@@ -402,7 +422,7 @@ func (p *BigInteger) EqualTo(o Value) bool {
 	if !ok {
 		// Also check if equal to regular Integer
 		if i, ok := o.(*Integer); ok {
-			return p.value.Cmp(big.NewInt(i.Value)) == 0
+			return p.value.Cmp(i.bigInt()) == 0
 		}
 		return false
 	}

--- a/values/complex.go
+++ b/values/complex.go
@@ -57,6 +57,17 @@ func (p *Complex) Imag() float64 {
 	return imag(p.Value)
 }
 
+// Per-type conversion helper for Complex.
+// This eliminates repeated conversion expressions in the type-switch
+// dispatch methods below for BigFloat and BigComplex cases.
+
+func (p *Complex) toBigComplex() *BigComplex {
+	return NewBigComplexFromBigFloats(
+		NewBigFloatFromFloat64(real(p.Value)),
+		NewBigFloatFromFloat64(imag(p.Value)),
+	)
+}
+
 // Add returns the sum of this complex number and another number.
 func (p *Complex) Add(o Number) Number {
 	if o.IsZero() {
@@ -69,24 +80,18 @@ func (p *Complex) Add(o Number) Number {
 	case *Complex:
 		return NewComplex(p.Value + v.Value)
 	case *Float:
-		return NewComplex(p.Value + complex(v.Value, 0))
+		return NewComplex(p.Value + v.toComplex())
 	case *Integer:
-		return NewComplex(p.Value + complex(float64(v.Value), 0))
+		return NewComplex(p.Value + v.toComplex())
 	case *BigInteger:
-		return NewComplex(p.Value + complex(float64FromBigInt(v.value), 0))
+		return NewComplex(p.Value + complex(v.float64Val(), 0))
 	case *BigFloat:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Add(v)
 	case *Rational:
-		return NewComplex(p.Value + complex(v.Float64(), 0))
+		return NewComplex(p.Value + v.toComplex())
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Add(v)
 	}
 	panic(ErrNotANumber)
@@ -103,24 +108,18 @@ func (p *Complex) Subtract(o Number) Number {
 	case *Complex:
 		return NewComplex(p.Value - v.Value)
 	case *Float:
-		return NewComplex(p.Value - complex(v.Value, 0))
+		return NewComplex(p.Value - v.toComplex())
 	case *Integer:
-		return NewComplex(p.Value - complex(float64(v.Value), 0))
+		return NewComplex(p.Value - v.toComplex())
 	case *BigInteger:
-		return NewComplex(p.Value - complex(float64FromBigInt(v.value), 0))
+		return NewComplex(p.Value - complex(v.float64Val(), 0))
 	case *BigFloat:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Subtract(v)
 	case *Rational:
-		return NewComplex(p.Value - complex(v.Float64(), 0))
+		return NewComplex(p.Value - v.toComplex())
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Subtract(v)
 	}
 	panic(ErrNotANumber)
@@ -137,24 +136,18 @@ func (p *Complex) Multiply(o Number) Number {
 	case *Complex:
 		return NewComplex(p.Value * v.Value)
 	case *Float:
-		return NewComplex(p.Value * complex(v.Value, 0))
+		return NewComplex(p.Value * v.toComplex())
 	case *Integer:
-		return NewComplex(p.Value * complex(float64(v.Value), 0))
+		return NewComplex(p.Value * v.toComplex())
 	case *BigInteger:
-		return NewComplex(p.Value * complex(float64FromBigInt(v.value), 0))
+		return NewComplex(p.Value * complex(v.float64Val(), 0))
 	case *BigFloat:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Multiply(v)
 	case *Rational:
-		return NewComplex(p.Value * complex(v.Float64(), 0))
+		return NewComplex(p.Value * v.toComplex())
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Multiply(v)
 	}
 	panic(ErrNotANumber)
@@ -169,24 +162,18 @@ func (p *Complex) Divide(o Number) Number {
 	case *Complex:
 		return NewComplex(p.Value / v.Value)
 	case *Float:
-		return NewComplex(p.Value / complex(v.Value, 0))
+		return NewComplex(p.Value / v.toComplex())
 	case *Integer:
-		return NewComplex(p.Value / complex(float64(v.Value), 0))
+		return NewComplex(p.Value / v.toComplex())
 	case *BigInteger:
-		return NewComplex(p.Value / complex(float64FromBigInt(v.value), 0))
+		return NewComplex(p.Value / complex(v.float64Val(), 0))
 	case *BigFloat:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Divide(v)
 	case *Rational:
-		return NewComplex(p.Value / complex(v.Float64(), 0))
+		return NewComplex(p.Value / v.toComplex())
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(p.Value)),
-			NewBigFloatFromFloat64(imag(p.Value)),
-		)
+		bc := p.toBigComplex()
 		return bc.Divide(v)
 	}
 	panic(ErrNotANumber)
@@ -207,7 +194,7 @@ func (p *Complex) LessThan(o Number) bool {
 	case *Integer:
 		return real(p.Value) < float64(v.Value)
 	case *BigInteger:
-		return real(p.Value) < float64FromBigInt(v.value)
+		return real(p.Value) < v.float64Val()
 	case *BigFloat:
 		self := NewBigFloatFromFloat64(real(p.Value))
 		return self.Compare(v) < 0
@@ -297,7 +284,7 @@ func (p *Complex) Compare(o Number) int {
 		return 0
 	case *BigInteger:
 		r := real(p.Value)
-		vf := float64FromBigInt(v.value)
+		vf := v.float64Val()
 		if r < vf {
 			return -1
 		} else if r > vf {

--- a/values/float.go
+++ b/values/float.go
@@ -50,6 +50,22 @@ func (p *Float) Datum() float64 {
 	return p.Value
 }
 
+// Per-type conversion helpers for Float.
+// These eliminate repeated conversion expressions in the type-switch
+// dispatch methods below. Each produces the representation needed by
+// the target type's native arithmetic.
+
+func (p *Float) bigFloat() *big.Float {
+	return new(big.Float).SetFloat64(p.Value)
+}
+
+func (p *Float) toComplex() complex128 {
+	return complex(p.Value, 0)
+}
+func (p *Float) toBigComplex() *BigComplex {
+	return NewBigComplexFromBigFloats(NewBigFloatFromFloat64(p.Value), NewBigFloatFromFloat64(0))
+}
+
 // Add returns the sum of two numbers.
 //
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
@@ -65,14 +81,14 @@ func (p *Float) Add(o Number) Number {
 	case *Float:
 		return NewFloat(p.Value + v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(self, v.value)}
 	case *Rational:
 		return NewFloat(p.Value + v.Float64())
 	case *Complex:
-		return NewComplex(complex(p.Value, 0) + v.Value)
+		return NewComplex(p.toComplex() + v.Value)
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(p.Value), NewBigFloatFromFloat64(0))
+		bc := p.toBigComplex()
 		return bc.Add(v)
 	}
 	panic(ErrNotANumber)
@@ -93,14 +109,14 @@ func (p *Float) Subtract(o Number) Number {
 	case *Float:
 		return NewFloat(p.Value - v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
 	case *Rational:
 		return NewFloat(p.Value - v.Float64())
 	case *Complex:
-		return NewComplex(complex(p.Value, 0) - v.Value)
+		return NewComplex(p.toComplex() - v.Value)
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(p.Value), NewBigFloatFromFloat64(0))
+		bc := p.toBigComplex()
 		return bc.Subtract(v)
 	}
 	panic(ErrNotANumber)
@@ -122,16 +138,16 @@ func (p *Float) Multiply(o Number) Number {
 	case *BigInteger:
 		return NewFloat(p.Value * float64FromBigInt(v.value))
 	case *BigFloat:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
 	case *Float:
 		return NewFloat(p.Value * v.Value)
 	case *Rational:
 		return NewFloat(p.Value * v.Float64())
 	case *Complex:
-		return NewComplex(complex(p.Value, 0) * v.Value)
+		return NewComplex(p.toComplex() * v.Value)
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(p.Value), NewBigFloatFromFloat64(0))
+		bc := p.toBigComplex()
 		return bc.Multiply(v)
 	}
 	panic(ErrNotANumber)
@@ -148,16 +164,16 @@ func (p *Float) Divide(o Number) Number {
 	case *BigInteger:
 		return NewFloat(p.Value / float64FromBigInt(v.value))
 	case *BigFloat:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
 	case *Float:
 		return NewFloat(p.Value / v.Value)
 	case *Rational:
 		return NewFloat(p.Value / v.Float64())
 	case *Complex:
-		return NewComplex(complex(p.Value, 0) / v.Value)
+		return NewComplex(p.toComplex() / v.Value)
 	case *BigComplex:
-		bc := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(p.Value), NewBigFloatFromFloat64(0))
+		bc := p.toBigComplex()
 		return bc.Divide(v)
 	}
 	panic(ErrNotANumber)
@@ -174,20 +190,20 @@ func (p *Float) LessThan(o Number) bool {
 	case *Integer:
 		return p.Value < float64(v.Value)
 	case *BigInteger:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		other := new(big.Float).SetInt(v.BigInt())
 		return self.Cmp(other) < 0
 	case *Float:
 		return p.Value < v.Value
 	case *BigFloat:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return self.Cmp(v.BigFloatValue()) < 0
 	case *Rational:
 		return p.Value < v.Float64()
 	case *Complex:
 		return p.Value < real(v.Value)
 	case *BigComplex:
-		self := new(big.Float).SetFloat64(p.Value)
+		self := p.bigFloat()
 		return self.Cmp(toBigFloat(v.Real()).BigFloatValue()) < 0
 	}
 	panic(ErrNotANumber)
@@ -247,7 +263,7 @@ func (p *Float) Negate() Number {
 // R7RS §6.2.6: Numeric comparisons use mathematical value regardless of exactness.
 // Returns -1 if p < o, 0 if p == o, 1 if p > o.
 func (p *Float) Compare(o Number) int {
-	pf := new(big.Float).SetFloat64(p.Value)
+	pf := p.bigFloat()
 	switch v := o.(type) {
 	case *BigFloat:
 		return pf.Cmp(v.value)

--- a/values/integer.go
+++ b/values/integer.go
@@ -74,6 +74,29 @@ func (p *Integer) Datum() int64 {
 	return p.Value
 }
 
+// Per-type conversion helpers for Integer.
+// These eliminate repeated conversion expressions in the type-switch
+// dispatch methods below. Each produces the representation needed by
+// the target type's native arithmetic.
+
+func (p *Integer) bigInt() *big.Int {
+	return big.NewInt(p.Value)
+}
+
+func (p *Integer) bigFloat() *big.Float {
+	return new(big.Float).SetInt64(p.Value)
+}
+
+func (p *Integer) bigRat() *big.Rat {
+	return big.NewRat(p.Value, 1)
+}
+func (p *Integer) toComplex() complex128 {
+	return complex(float64(p.Value), 0)
+}
+func (p *Integer) toBigComplex() *BigComplex {
+	return NewBigComplex(NewBigIntegerFromInt64(p.Value), NewBigIntegerFromInt64(0))
+}
+
 // Overflow-detecting arithmetic helpers for int64.
 //
 // R7RS §6.2.3 allows implementations to support arbitrarily large exact
@@ -154,22 +177,19 @@ func (p *Integer) Add(o Number) Number {
 	case *Integer:
 		return addInt64(p.Value, v.Value)
 	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Add, big.NewInt(p.Value), v.value)
+		result := newBigIntFromOp((*big.Int).Add, p.bigInt(), v.value)
 		return &BigInteger{value: result}
 	case *Float:
 		return NewFloat(float64(p.Value) + v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return &BigFloat{value: new(big.Float).Add(self, v.value)}
+		return &BigFloat{value: new(big.Float).Add(p.bigFloat(), v.value)}
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		result := new(big.Rat).Add(self, v.Rat())
+		result := new(big.Rat).Add(p.bigRat(), v.Rat())
 		return &Rational{value: result}
 	case *Complex:
-		return NewComplex(complex(float64(p.Value), 0) + v.Value)
+		return NewComplex(p.toComplex() + v.Value)
 	case *BigComplex:
-		bc := NewBigComplex(NewBigIntegerFromInt64(p.Value), NewBigIntegerFromInt64(0))
-		return bc.Add(v)
+		return p.toBigComplex().Add(v)
 	}
 	panic(ErrNotANumber)
 }
@@ -188,22 +208,19 @@ func (p *Integer) Subtract(o Number) Number {
 	case *Integer:
 		return subInt64(p.Value, v.Value)
 	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Sub, big.NewInt(p.Value), v.value)
+		result := newBigIntFromOp((*big.Int).Sub, p.bigInt(), v.value)
 		return &BigInteger{value: result}
 	case *Float:
 		return NewFloat(float64(p.Value) - v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
+		return &BigFloat{value: new(big.Float).Sub(p.bigFloat(), v.value)}
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		result := new(big.Rat).Sub(self, v.Rat())
+		result := new(big.Rat).Sub(p.bigRat(), v.Rat())
 		return &Rational{value: result}
 	case *Complex:
-		return NewComplex(complex(float64(p.Value), 0) - v.Value)
+		return NewComplex(p.toComplex() - v.Value)
 	case *BigComplex:
-		bc := NewBigComplex(NewBigIntegerFromInt64(p.Value), NewBigIntegerFromInt64(0))
-		return bc.Subtract(v)
+		return p.toBigComplex().Subtract(v)
 	}
 	panic(ErrNotANumber)
 }
@@ -225,22 +242,19 @@ func (p *Integer) Multiply(o Number) Number {
 	case *Integer:
 		return mulInt64(p.Value, v.Value)
 	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Mul, big.NewInt(p.Value), v.value)
+		result := newBigIntFromOp((*big.Int).Mul, p.bigInt(), v.value)
 		return &BigInteger{value: result}
 	case *Float:
 		return NewFloat(float64(p.Value) * v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
+		return &BigFloat{value: new(big.Float).Mul(p.bigFloat(), v.value)}
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		result := new(big.Rat).Mul(self, v.Rat())
+		result := new(big.Rat).Mul(p.bigRat(), v.Rat())
 		return &Rational{value: result}
 	case *Complex:
-		return NewComplex(complex(float64(p.Value), 0) * v.Value)
+		return NewComplex(p.toComplex() * v.Value)
 	case *BigComplex:
-		bc := NewBigComplex(NewBigIntegerFromInt64(p.Value), NewBigIntegerFromInt64(0))
-		return bc.Multiply(v)
+		return p.toBigComplex().Multiply(v)
 	}
 	panic(ErrNotANumber)
 }
@@ -268,21 +282,18 @@ func (p *Integer) Divide(o Number) Number {
 		}
 		return result
 	case *BigInteger:
-		return NewRationalFromBigInt(big.NewInt(p.Value), v.value)
+		return NewRationalFromBigInt(p.bigInt(), v.value)
 	case *Float:
 		return NewFloat(float64(p.Value) / v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
+		return &BigFloat{value: new(big.Float).Quo(p.bigFloat(), v.value)}
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		result := new(big.Rat).Quo(self, v.Rat())
+		result := new(big.Rat).Quo(p.bigRat(), v.Rat())
 		return &Rational{value: result}
 	case *Complex:
-		return NewComplex(complex(float64(p.Value), 0) / v.Value)
+		return NewComplex(p.toComplex() / v.Value)
 	case *BigComplex:
-		bc := NewBigComplex(NewBigIntegerFromInt64(p.Value), NewBigIntegerFromInt64(0))
-		return bc.Divide(v)
+		return p.toBigComplex().Divide(v)
 	}
 	panic(ErrNotANumber)
 }
@@ -301,15 +312,13 @@ func (p *Integer) LessThan(o Number) bool {
 	case *Integer:
 		return p.Value < v.Value
 	case *BigInteger:
-		return big.NewInt(p.Value).Cmp(v.BigInt()) < 0
+		return p.bigInt().Cmp(v.BigInt()) < 0
 	case *Float:
 		return float64(p.Value) < v.Value
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return self.Cmp(v.BigFloatValue()) < 0
+		return p.bigFloat().Cmp(v.BigFloatValue()) < 0
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		return self.Cmp(v.Rat()) < 0
+		return p.bigRat().Cmp(v.Rat()) < 0
 	case *Complex:
 		return float64(p.Value) < real(v.Value)
 	case *BigComplex:
@@ -385,7 +394,7 @@ func (p *Integer) Compare(o Number) int {
 		}
 		return 0
 	case *BigInteger:
-		return big.NewInt(p.Value).Cmp(v.value)
+		return p.bigInt().Cmp(v.value)
 	case *Float:
 		pf := float64(p.Value)
 		if pf < v.Value {
@@ -395,11 +404,9 @@ func (p *Integer) Compare(o Number) int {
 		}
 		return 0
 	case *BigFloat:
-		self := new(big.Float).SetInt64(p.Value)
-		return self.Cmp(v.BigFloatValue())
+		return p.bigFloat().Cmp(v.BigFloatValue())
 	case *Rational:
-		self := big.NewRat(p.Value, 1)
-		return self.Cmp(v.Rat())
+		return p.bigRat().Cmp(v.Rat())
 	case *Complex:
 		pf := float64(p.Value)
 		r := real(v.Value)
@@ -410,8 +417,7 @@ func (p *Integer) Compare(o Number) int {
 		}
 		return 0
 	case *BigComplex:
-		self := new(big.Float).SetInt64(p.Value)
-		return self.Cmp(toBigFloat(v.Real()).BigFloatValue())
+		return p.bigFloat().Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
 	panic(ErrNotANumber)
 }
@@ -466,7 +472,7 @@ func (p *Integer) EqualTo(v Value) bool {
 	case *Integer:
 		return p.Value == other.Value
 	case *BigInteger:
-		return other.BigInt().Cmp(big.NewInt(p.Value)) == 0
+		return other.BigInt().Cmp(p.bigInt()) == 0
 	}
 	return false
 }

--- a/values/rational.go
+++ b/values/rational.go
@@ -87,6 +87,18 @@ func (p *Rational) Float64() float64 {
 	return f
 }
 
+// Per-type conversion helpers for Rational.
+// These eliminate repeated conversion expressions in the type-switch
+// dispatch methods below. Each produces the representation needed by
+// the target type's native arithmetic.
+
+func (p *Rational) bigFloat() *big.Float {
+	return new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+}
+func (p *Rational) toComplex() complex128 {
+	return complex(p.Float64(), 0)
+}
+
 // IsInteger returns true if the rational represents an integer (denominator is 1).
 func (p *Rational) IsInteger() bool {
 	return p.value.IsInt()
@@ -107,22 +119,22 @@ func (p *Rational) Add(o Number) Number {
 		result := new(big.Rat).Add(p.value, v.value)
 		return &Rational{value: result}
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		result := new(big.Rat).Add(p.value, other)
 		return &Rational{value: result}
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.value)
+		other := v.bigRat()
 		result := new(big.Rat).Add(p.value, other)
 		return &Rational{value: result}
 	case *Float:
 		return NewFloat(p.Float64() + v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Add(self, v.value)}
 	case *Complex:
-		return NewComplex(complex(p.Float64(), 0) + v.Value)
+		return NewComplex(p.toComplex() + v.Value)
 	case *BigComplex:
-		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		bf := p.bigFloat()
 		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
 		return bc.Add(v)
 	}
@@ -141,22 +153,22 @@ func (p *Rational) Subtract(o Number) Number {
 		result := new(big.Rat).Sub(p.value, v.value)
 		return &Rational{value: result}
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		result := new(big.Rat).Sub(p.value, other)
 		return &Rational{value: result}
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.value)
+		other := v.bigRat()
 		result := new(big.Rat).Sub(p.value, other)
 		return &Rational{value: result}
 	case *Float:
 		return NewFloat(p.Float64() - v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
 	case *Complex:
-		return NewComplex(complex(p.Float64(), 0) - v.Value)
+		return NewComplex(p.toComplex() - v.Value)
 	case *BigComplex:
-		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		bf := p.bigFloat()
 		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
 		return bc.Subtract(v)
 	}
@@ -175,22 +187,22 @@ func (p *Rational) Multiply(o Number) Number {
 		result := new(big.Rat).Mul(p.value, v.value)
 		return &Rational{value: result}
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		result := new(big.Rat).Mul(p.value, other)
 		return &Rational{value: result}
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.value)
+		other := v.bigRat()
 		result := new(big.Rat).Mul(p.value, other)
 		return &Rational{value: result}
 	case *Float:
 		return NewFloat(p.Float64() * v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
 	case *Complex:
-		return NewComplex(complex(p.Float64(), 0) * v.Value)
+		return NewComplex(p.toComplex() * v.Value)
 	case *BigComplex:
-		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		bf := p.bigFloat()
 		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
 		return bc.Multiply(v)
 	}
@@ -209,22 +221,22 @@ func (p *Rational) Divide(o Number) Number {
 		result := new(big.Rat).Quo(p.value, v.value)
 		return &Rational{value: result}
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		result := new(big.Rat).Quo(p.value, other)
 		return &Rational{value: result}
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.value)
+		other := v.bigRat()
 		result := new(big.Rat).Quo(p.value, other)
 		return &Rational{value: result}
 	case *Float:
 		return NewFloat(p.Float64() / v.Value)
 	case *BigFloat:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
 	case *Complex:
-		return NewComplex(complex(p.Float64(), 0) / v.Value)
+		return NewComplex(p.toComplex() / v.Value)
 	case *BigComplex:
-		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		bf := p.bigFloat()
 		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
 		return bc.Divide(v)
 	}
@@ -242,10 +254,10 @@ func (p *Rational) LessThan(o Number) bool {
 	case *Rational:
 		return p.value.Cmp(v.value) < 0
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		return p.value.Cmp(other) < 0
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.BigInt())
+		other := v.bigRat()
 		return p.value.Cmp(other) < 0
 	case *Float:
 		return p.Float64() < v.Value
@@ -255,7 +267,7 @@ func (p *Rational) LessThan(o Number) bool {
 	case *Complex:
 		return p.Float64() < real(v.Value)
 	case *BigComplex:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return self.Cmp(toBigFloat(v.Real()).BigFloatValue()) < 0
 	}
 	panic(ErrNotANumber)
@@ -311,10 +323,10 @@ func (p *Rational) Compare(o Number) int {
 	case *Rational:
 		return p.value.Cmp(v.value)
 	case *Integer:
-		other := big.NewRat(v.Value, 1)
+		other := v.bigRat()
 		return p.value.Cmp(other)
 	case *BigInteger:
-		other := new(big.Rat).SetInt(v.BigInt())
+		other := v.bigRat()
 		return p.value.Cmp(other)
 	case *Float:
 		pf := p.Float64()
@@ -337,7 +349,7 @@ func (p *Rational) Compare(o Number) int {
 		}
 		return 0
 	case *BigComplex:
-		self := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(p.value)
+		self := p.bigFloat()
 		return self.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
 	panic(ErrNotANumber)


### PR DESCRIPTION
## Summary
- Add private conversion helper methods to each numeric type: `bigInt()`, `bigFloat()`, `bigRat()`, `toComplex()`, `toBigComplex()`, `float64Val()`
- Eliminates ~80 duplicated conversion expressions across type-switch dispatch in arithmetic operations
- No behavior change — pure refactor reducing code volume

## Test Plan
- [x] `go test -v ./values/...` passes
- [x] `make lint` clean