### PR TITLE
opt: targeted micro-optimizations for scope matching hot paths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,10 +9,9 @@ Code Cleanup
 - [x] **Resolution:** Replaced `any` with `*environment.GlobalIndex` in `FreeIdResolution.Global` and `globalBindingProvider.GetGlobal()`, and `*environment.Binding` in `BindingChecker.GetBinding()` and `envBindingChecker.GetBinding()`. Import is safe: `match` → `environment` (no cycle). `SyntaxSymbol.ResolvedBinding any` stays `any` to avoid `syntax` ↔ `environment` cycle.
 
 ### Scope Matching Optimization
-- [ ] **Location:** `internal/syntax/` and `internal/match/`
-- [ ] **Issue:** Scope set matching is mostly brute force O(n×m) comparison
-- [ ] **Goal:** Investigate optimization opportunities (hash-based set comparison, scope indexing)
-- [ ] **Impact:** Performance improvement for complex macro expansions
+- [x] **Status:** CLOSED (2026-02-07) — Linear scan is optimal for practical scope set sizes
+- [x] **Investigation:** Scope sets are typically 0-4 elements (one per lexical form). Hash maps cross over at ~20-30 elements; bitmaps require unbounded IDs; sorted merge adds O(n) insertion cost. Linear scan with pointer equality in a cache line is faster for these sizes.
+- [x] **Changes:** Added size guard (`len(binding) > len(use)` early return), cached `Scopes()` calls in `GetBindingWithScopes`, added perfect-match early termination in `GetLocalIndexWithScopes`, documented rationale in `ScopesMatch`.
 
 ---
 

--- a/environment/environment_frame.go
+++ b/environment/environment_frame.go
@@ -324,13 +324,14 @@ func (p *EnvironmentFrame) GetBindingWithScopes(key *values.Symbol, scopes []*sy
 		if i, ok := env.local.keys[*key]; ok {
 			binding := env.local.bindings[i]
 			if binding != nil {
+				bindingScopes := binding.Scopes()
 				// Check if scopes match
-				if binding.Scopes() == nil || len(binding.Scopes()) == 0 {
+				if len(bindingScopes) == 0 {
 					// Binding has no scopes (top-level or pre-hygiene), accept it
 					return binding
 				}
 				// Check scope compatibility using ScopesMatch from scope_utils
-				if syntax.ScopesMatch(scopes, binding.Scopes()) {
+				if syntax.ScopesMatch(scopes, bindingScopes) {
 					return binding
 				}
 				// Scopes don't match - continue searching parent frames
@@ -352,13 +353,14 @@ func (p *EnvironmentFrame) GetBindingWithScopes(key *values.Symbol, scopes []*sy
 	if ok {
 		binding := ge.global.bindings[i]
 		if binding != nil {
+			bindingScopes := binding.Scopes()
 			// Check if scopes match
-			if binding.Scopes() == nil || len(binding.Scopes()) == 0 {
+			if len(bindingScopes) == 0 {
 				// Binding has no scopes (top-level or pre-hygiene), accept it
 				return binding
 			}
 			// Check scope compatibility
-			if syntax.ScopesMatch(scopes, binding.Scopes()) {
+			if syntax.ScopesMatch(scopes, bindingScopes) {
 				return binding
 			}
 		}
@@ -477,6 +479,10 @@ func (p *EnvironmentFrame) GetLocalIndexWithScopes(key *values.Symbol, scopes []
 					// This is a valid candidate with scope count 0
 					candidates = append(candidates, candidate{NewLocalIndex(i, j), 0})
 				} else if syntax.ScopesMatch(scopes, bindingScopes) {
+					// Perfect match — maximally specific, no need to search further
+					if len(bindingScopes) == len(scopes) {
+						return NewLocalIndex(i, j)
+					}
 					// Scopes match - count how many scopes are in common
 					// (which equals len(bindingScopes) since it's a subset)
 					candidates = append(candidates, candidate{NewLocalIndex(i, j), len(bindingScopes)})

--- a/internal/syntax/scope_utils.go
+++ b/internal/syntax/scope_utils.go
@@ -24,15 +24,24 @@ import "slices"
 // - Top-level bindings (empty scope set) match any reference: {} ⊆ X for all X
 // - A macro-introduced binding only matches references with that macro's intro scope
 // - User bindings don't capture macro-introduced identifiers (different scope sets)
+//
+// Implementation note: Linear scan with pointer equality is intentionally used here.
+// Scope sets are typically 0-4 elements (one per lexical form: macro invocation, lambda,
+// let-syntax, with-binding-scope). For sets this small, linear scan is faster than
+// hash-based or bitmap approaches due to cache locality and zero allocation overhead.
 func ScopesMatch(useScopes, bindingScopes []*Scope) bool {
 	// A binding matches a use if all of the binding's scopes are present in the use's scopes.
 	// This is the subset relationship: bindingScopes ⊆ useScopes
 	//
 	// Empty binding scopes (top-level) match everything since {} ⊆ X for all X.
+
+	// A larger set cannot be a subset of a smaller one.
+	if len(bindingScopes) > len(useScopes) {
+		return false
+	}
 	for _, bindScope := range bindingScopes {
-		found := slices.Contains(useScopes, bindScope)
-		if !found {
-			return false // Binding has a scope that use doesn't have
+		if !slices.Contains(useScopes, bindScope) {
+			return false
 		}
 	}
 	return true


### PR DESCRIPTION
## Summary

Addresses TODO.md "Scope Matching Optimization" item. After investigating alternative data structures (hash maps, bitmaps, sorted merge), the conclusion is that linear scan with pointer equality is optimal for practical scope set sizes (0-4 elements). Instead, three targeted micro-optimizations reduce redundant work on the hot paths:

- **Size guard in `ScopesMatch`**: O(1) early return when `len(bindingScopes) > len(useScopes)` — a larger set cannot be a subset of a smaller one
- **Cache `Scopes()` in `GetBindingWithScopes`**: Store result in local variable instead of calling 2-3 times per iteration; also simplifies `nil || len() == 0` to `len() == 0` (since `len(nil) == 0` in Go)
- **Perfect-match early exit in `GetLocalIndexWithScopes`**: When `len(bindingScopes) == len(scopes)` and `ScopesMatch` is true, the binding is maximally specific (subset + same cardinality = equality) — return immediately without walking the parent chain

Also adds rationale comment to `ScopesMatch` documenting why linear scan is intentional, so future maintainers don't "optimize" to a hash set.

## Files Changed

| File | Change |
|------|--------|
| `internal/syntax/scope_utils.go` | Size guard + inline `found` + rationale comment |
| `environment/environment_frame.go` | Cache `Scopes()` + perfect-match early exit |
| `TODO.md` | Close scope matching optimization item |

## Test Plan

- [x] `go test ./internal/syntax/... ./environment/... ./internal/match/...` — all pass
- [x] `go test ./...` — all 25 packages pass
- [x] `make lint` — 0 issues
- [x] `go_diagnostics` — no errors