### PR TITLE
docs: add RegisterFunc to changelog and mark FFI Phase 1 complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Add `Abs()`, `ToExact()`, `ToInexact()` methods to the `Number` interface
 - Add `IsInteger()`, `IsRational()`, `IsFinite()`, `IsNaN()` predicate methods to the `Number` interface
 - Add `EvalWithSource`, `EvalMultipleWithSource`, and `CompileWithSource` methods for source-tracked evaluation — source locations appear in `RuntimeError.Source` and `RuntimeError.StackTrace`
+- Add `RegisterFunc` for registering Go functions with natural signatures — supports `int64`, `int`, `float64`, `string`, `bool`, `[]byte`, `Value`, `context.Context`, variadic parameters, and `(T, error)` returns
+- Add `ErrTypeConversion` sentinel for FFI runtime type mismatch errors
 - Wire `ErrExceptionEscape` to carry source location and stack trace from per-operation source tracking
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -314,7 +314,9 @@ Support for Racket's `@`-reader syntax for inline documentation and text process
 ---
 
 ### Go FFI
-- [ ] Registry-based (Phase 1) → Reflection-based (Phase 2) → Plugin support (Phase 3).
+- [x] **Phase 1: `RegisterFunc`** — Register Go functions with natural signatures via reflection. Supports `int64`, `int`, `float64`, `string`, `bool`, `[]byte`, `Value`, `context.Context`, variadic params, and `(T, error)` returns. Reflection happens once at registration; runtime uses pre-computed converters. PR #139.
+- [ ] Phase 2: Struct/slice/map mapping (Go structs ↔ Scheme records/alists, `[]T` ↔ lists/vectors, `map[K]V` ↔ hash tables), bidirectional callbacks (Scheme procedures as Go `func(...)` arguments)
+- [ ] Phase 3: Plugin support (dynamic extension loading via registry pattern)
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `RegisterFunc` and `ErrTypeConversion` entries to `[Unreleased]` in CHANGELOG.md
- Mark Go FFI Phase 1 complete in TODO.md, expand Phase 2 and Phase 3 descriptions

Follow-up to PR #139.