### PR TITLE
refactor: normalize ArrayList empty-list encoding and triage TODO items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,12 +6,12 @@ Code Quality
 
 ### Sentinel Value Types
 
-- [ ] Consider using distinct types for EmptyList and Void instead of sentinel values in `SyntaxPair` (`internal/syntax/syntax_pair.go`) and `ArrayList` (`values/array_list.go`). Both packages use the same pattern of sentinel comparison; typed singletons would make the distinction compile-time checkable.
+- [x] Consider using distinct types for EmptyList and Void instead of sentinel values in `SyntaxPair` (`internal/syntax/syntax_pair.go`) and `ArrayList` (`values/array_list.go`). Already done: `emptyListType` and `voidType` are distinct types. Stale `== EmptyList` comparisons cleaned up.
 
 ### ArrayList Special-Case Logic
 
-- [ ] Clean up `ArrayList.Cons` / `Append` logic (`values/array_list.go:~90`). The method has multiple special-case branches for empty lists, void values, and single-element lists that are difficult to follow.
-- [ ] Clean up `ArrayList.IsList` (`values/array_list.go:~138`). Same issue — multiple branches checking length, void, and EmptyList sentinels.
+- [x] Clean up `ArrayList.Cons` / `Append` logic (`values/array_list.go`). Normalized `ArrayListEmptyList` from `[nil, nil]` to `[EmptyList]`. Replaced manual encoding checks in `AppendList` with `IsEmptyList()` helper.
+- [x] Clean up `ArrayList.IsList` (`values/array_list.go`). Removed redundant two-nil encoding branches. `IsList` and `IsEmptyList` now have single clear checks.
 
 ### ByteVector Overflow Handling
 
@@ -24,12 +24,12 @@ Code Quality
 ### MachineContext.Apply
 
 - [x] Add unit tests for `MachineContext.Apply` (`machine/machine_context.go`).
-- [ ] Make `MachineContext.Apply` symmetric with `MachineClosure` apply dispatch — currently the two paths have different calling conventions.
-- [ ] `MachineContext.Apply` accepts variadic parameters but has no mechanism for returning multiple values.
+- [x] Make `MachineContext.Apply` symmetric with `MachineClosure` apply dispatch. Asymmetry is by design: closures run in VM loop (bytecode handles continuation restoration), while Parameters and ComposableContinuation return immediately via `returnImmediate()`.
+- [x] `MachineContext.Apply` accepts variadic parameters but has no mechanism for returning multiple values. Mechanism exists: `Apply` sets up the call, `Run()` executes it, `GetValues()` retrieves multiple return values.
 
 ### CompileTimeContinuation Environment
 
-- [ ] `CompileTimeContinuation.env` (`machine/compile_time_continuation.go`) stores full environment bindings, but only the binding keys are needed at compile time. Replace with a key-only data structure to reduce memory during compilation.
+- [x] `CompileTimeContinuation.env` (`machine/compile_time_continuation.go`) stores full environment bindings. Full env is justified: symbol resolution, macro detection, scope chain, and compile-phase bindings all require the complete environment. Splitting to key-only adds complexity without benefit.
 
 ### Test Improvements
 

--- a/values/array_list.go
+++ b/values/array_list.go
@@ -24,9 +24,8 @@ var (
 	_ Value = (*ArrayList)(nil)
 	_ Tuple = (*ArrayList)(nil)
 
-	// ArrayListEmptyList is the canonical empty ArrayList. It uses the
-	// two-nil encoding [nil, nil], which IsEmptyList() recognizes as ().
-	ArrayListEmptyList = NewArrayList(nil, nil)
+	// ArrayListEmptyList is the canonical empty ArrayList encoding: [EmptyList].
+	ArrayListEmptyList = NewArrayList(EmptyList)
 )
 
 // ArrayList is an array-backed representation of Scheme lists. It stores list
@@ -40,7 +39,7 @@ var (
 //	                           ^^^elements^^^  ^^^terminator
 //	Improper list (1 2 . 3):  [1, 2, 3]
 //	                           ^^elems^^  ^^last=cdr
-//	Empty list ():             [EmptyList]  or  [nil, nil]
+//	Empty list ():             [EmptyList]
 //	Void (no value):           nil  |  []  |  [Void]
 //
 // Length() returns len(slice)-1 for proper lists (element count, excluding
@@ -119,20 +118,14 @@ func (p *ArrayList) AppendList(o Value) *ArrayList {
 		if IsEmptyList(p) {
 			return vs
 		}
-		if IsVoid(vs) {
+		switch {
+		case IsVoid(vs):
 			*q = append(*q, Void)
-		} else {
-			if len(*vs) == 0 {
-				return q
-			}
-			if len(*vs) == 1 && (*vs)[0] == EmptyList {
-				return q
-			}
-			if len(*vs) == 2 && IsVoid((*vs)[0]) && IsVoid((*vs)[1]) {
-				return q
-			}
+		case vs.IsEmptyList():
+			return q
+		default:
 			*q = (*q)[:len(*q)-1]
-			*q = append(*q, (*vs)[:len(*vs)]...)
+			*q = append(*q, (*vs)...)
 		}
 	case *Pair:
 		v0 := vs
@@ -168,21 +161,11 @@ func (p *ArrayList) Cdr() Value {
 	return &q
 }
 
-// IsList returns true if the last element is EmptyList (proper list) or if
-// the list matches an empty-list encoding. Returns false for nil, empty
-// slices, and improper lists.
+// IsList returns true if the last element is EmptyList (proper list).
+// Returns false for nil, empty slices, and improper lists.
 func (p *ArrayList) IsList() bool {
-	if p == nil {
+	if p == nil || len(*p) == 0 {
 		return false
-	}
-	if len(*p) == 0 {
-		return false
-	}
-	if len(*p) == 1 && (*p)[0] == EmptyList {
-		return true
-	}
-	if len(*p) == 2 && IsVoid((*p)[0]) && IsVoid((*p)[1]) {
-		return true
 	}
 	return (*p)[len(*p)-1] == EmptyList
 }
@@ -199,20 +182,13 @@ func (p *ArrayList) Length() int {
 	return len(*p) - 1
 }
 
-// IsEmptyList returns true if this ArrayList encodes the empty list ().
-// Two representations are recognized: [EmptyList] and any two-element slice
-// of void values (for example [nil, nil] or [Void, Void]).
+// IsEmptyList returns true if this ArrayList encodes the empty list ():
+// a single-element slice containing the EmptyList sentinel.
 func (p *ArrayList) IsEmptyList() bool {
 	if p == nil {
 		return false
 	}
-	if len(*p) == 1 && (*p)[0] == EmptyList {
-		return true
-	}
-	if len(*p) == 2 && IsVoid((*p)[0]) && IsVoid((*p)[1]) {
-		return true
-	}
-	return false
+	return len(*p) == 1 && (*p)[0] == EmptyList
 }
 
 // IsVoid returns true if this ArrayList represents the absence of a value.

--- a/values/array_list_test.go
+++ b/values/array_list_test.go
@@ -29,7 +29,7 @@ func TestArrayList_SchemeString(t *testing.T) {
 		{nil, "#<void>"},
 		{NewArrayList(EmptyList), "()"},
 		{NewArrayList(NewCons(nil, nil)), "(#<void> . #<void>)"},
-		{NewArrayList(NewArrayList(nil, nil)), "()"},
+		{NewArrayList(NewArrayList(EmptyList)), "()"},
 		{NewArrayList(EmptyList), "()"},
 		{NewArrayList(NewInteger(1), NewInteger(2), EmptyList), "(1 2)"},
 		{NewArrayList(NewInteger(1), NewInteger(2), NewInteger(3), EmptyList), "(1 2 3)"},
@@ -57,13 +57,13 @@ func TestArrayLis_EqualTo(t *testing.T) {
 			out: true,
 		},
 		{
-			in0: NewArrayList(nil, nil),
-			in1: NewArrayList(nil, nil),
+			in0: NewArrayList(EmptyList),
+			in1: NewArrayList(EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(nil, nil),
-			in1: NewArrayList(nil, nil),
+			in0: NewArrayList(EmptyList),
+			in1: NewArrayList(EmptyList),
 			out: true,
 		},
 		{
@@ -141,7 +141,7 @@ func TestArrayList_IsList(t *testing.T) {
 		out bool
 	}{
 		{in: nil, out: false},
-		{in: NewArrayList(nil, nil), out: true},
+		{in: NewArrayList(EmptyList), out: true},
 		{in: NewArrayList(NewInteger(10), EmptyList), out: true},
 		{in: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList), out: true},
 		{in: NewArrayList(NewInteger(10), NewInteger(20), EmptyList), out: true},
@@ -169,7 +169,7 @@ func TestArrayLis_Length(t *testing.T) {
 			panicMatches: "not a list",
 			out:          -1,
 		},
-		{in: NewArrayList(nil, nil), out: 0},
+		{in: NewArrayList(EmptyList), out: 0},
 		{in: NewArrayList(NewInteger(10), EmptyList), out: 1},
 		{in: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList), out: 1},
 		{in: NewArrayList(NewInteger(10), NewInteger(20), EmptyList), out: 2},
@@ -197,7 +197,7 @@ func TestArrayLis_IsVoid(t *testing.T) {
 		out bool
 	}{
 		{in: nil, out: true},
-		{in: NewArrayList(nil, nil), out: false},
+		{in: NewArrayList(EmptyList), out: false},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
@@ -213,7 +213,7 @@ func TestArrayLis_IsEmptyList(t *testing.T) {
 		out bool
 	}{
 		{in: nil, out: false},
-		{in: NewArrayList(nil, nil), out: true},
+		{in: NewArrayList(EmptyList), out: true},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
@@ -237,23 +237,23 @@ func TestArrayList_Append(t *testing.T) {
 			panicMatches: "not a list",
 		},
 		{
-			in:  NewArrayList(nil, nil),
+			in:  NewArrayList(EmptyList),
 			vs:  (*ArrayList)(nil),
 			out: (*ArrayList)(nil),
 		},
 		{
-			in:  NewArrayList(nil, nil),
+			in:  NewArrayList(EmptyList),
 			vs:  (*ArrayList)(nil),
 			out: (*ArrayList)(nil),
 		},
 		{
-			in:  NewArrayList(nil, nil),
+			in:  NewArrayList(EmptyList),
 			vs:  NewArrayList(NewInteger(10), EmptyList),
 			out: NewArrayList(NewInteger(10), EmptyList),
 		},
 		{
 			in:  NewArrayList(NewInteger(10), EmptyList),
-			vs:  NewArrayList(nil, nil),
+			vs:  NewArrayList(EmptyList),
 			out: NewArrayList(NewInteger(10), EmptyList),
 		},
 		{

--- a/values/utils.go
+++ b/values/utils.go
@@ -225,8 +225,7 @@ func IsList(v Value) bool {
 	if v == nil {
 		return false
 	}
-	// Interface equality on zero-size struct: works for emptyListType{}.
-	if v == EmptyList {
+	if IsEmptyList(v) {
 		return true
 	}
 	switch pr := v.(type) {


### PR DESCRIPTION
## Summary

- Eliminate legacy `[nil, nil]` two-nil encoding for empty ArrayLists; `ArrayListEmptyList` now uses `NewArrayList(EmptyList)`
- Remove dead two-nil branches from `IsList`, `IsEmptyList`, `AppendList`
- Replace manual encoding checks in `AppendList` with `IsEmptyList()` helper
- Replace direct `== EmptyList` in `utils.go` `IsList` with `IsEmptyList()`
- Update 12 test sites from `NewArrayList(nil, nil)` to `NewArrayList(EmptyList)`
- Triage and mark 5 TODO code quality items as resolved with findings

## Test plan
- [x] `go test ./values/...` passes
- [x] `go test ./...` full suite passes
- [x] `make lint` reports 0 issues