### PR TITLE
refactor: subsystem simplification — phases 4, 5, 7

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -336,7 +336,7 @@ func (p *Engine) compileExpr(ctx context.Context, stx syntax.SyntaxValue) (*Comp
 		return nil, &CompilationError{Message: "expansion error", Cause: err}
 	}
 
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, p.env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, p.env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, &CompilationError{Message: "compilation error", Cause: err}
@@ -415,7 +415,7 @@ func runBootstrapMacroStx(ctx context.Context, env *environment.EnvironmentFrame
 		return err
 	}
 
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return err

--- a/environment/environment_frame.go
+++ b/environment/environment_frame.go
@@ -227,8 +227,15 @@ func (p *EnvironmentFrame) LocalEnvironment() *LocalEnvironmentFrame {
 	return p.local
 }
 
-// GetBinding returns the binding for the given symbol, searching for local bindings first, then global bindings in the current and parent environments.
+// GetBinding returns the binding for the given symbol, searching local
+// bindings first (up the parent chain), then global bindings.
 // It returns nil if the binding does not exist.
+//
+// Note: this method accesses local.keys and global.keys directly rather
+// than delegating to LocalEnvironmentFrame/GlobalEnvironmentFrame because
+// it returns a *Binding (not an index), and the return value requires no
+// depth tracking — the binding is the same regardless of which frame it
+// was found in.
 func (p *EnvironmentFrame) GetBinding(key *values.Symbol) *Binding {
 	cenv := p
 	var (
@@ -264,57 +271,21 @@ func (p *EnvironmentFrame) GetBinding(key *values.Symbol) *Binding {
 	return nil
 }
 
-// GetIndex returns the index of the binding for the given symbol.
-// It returns either a LocalIndex or GlobalIndex depending on where the binding is found.
-// The boolean return value indicates whether the binding was found.
-// Note: This function has known bugs (skips first frame in loops) and may need fixes.
-func (p *EnvironmentFrame) GetIndex(key *values.Symbol) (*LocalIndex, *GlobalIndex, bool) {
-	cenv := p
-	var (
-		i  int
-		j  int
-		ok bool
-	)
-	if cenv.local != nil {
-		for {
-			cenv = cenv.parent
-			// always check local first
-			i, ok = cenv.local.keys[*key]
-			if ok {
-				return &LocalIndex{i, j}, nil, true
-			}
-			j++
-			if cenv.IsTopLevel() {
-				break
-			}
-		}
-	}
-	if cenv.global != nil {
-		for {
-			cenv = cenv.parent
-			// then check global
-			_, ok = cenv.global.keys[*key]
-			if ok {
-				return nil, &GlobalIndex{Index: key}, true
-			}
-			// stop if at top-level
-			if cenv.IsTopLevel() {
-				break
-			}
-		}
-	}
-	return nil, nil, false
-}
-
-// GetBindingWithScopes returns the binding for the given symbol that matches the provided scopes.
-// This is used for hygienic variable resolution in macros.
-// It searches for local bindings first (walking up the parent chain), then global bindings,
+// GetBindingWithScopes returns the binding for the given symbol that matches
+// the provided scopes. This is used for hygienic variable resolution in macros.
+// It searches local bindings first (walking up the parent chain), then globals,
 // checking scope compatibility at each level.
 //
 // For hygiene to work correctly with nested bindings of the same name:
 //   - Each let-bound variable has scopes from the binding site
 //   - A macro free identifier carries scopes from its definition site
 //   - We search ALL local bindings (not just innermost) to find one with matching scopes
+//
+// Note: this method accesses local.keys and global.keys directly because
+// each iteration requires per-binding scope matching (ScopesMatch) that
+// LocalEnvironmentFrame does not know about. Delegation would push the
+// scope logic into the leaf type or require passing a predicate, neither
+// of which simplifies the code.
 func (p *EnvironmentFrame) GetBindingWithScopes(key *values.Symbol, scopes []*syntax.Scope) *Binding {
 	// Search local bindings in parent chain, checking scopes at each level
 	// This is critical for hygiene: inner bindings may not match the reference's scopes,
@@ -403,59 +374,74 @@ func (p *EnvironmentFrame) MaybeCreateLocalBindingWithScopes(key *values.Symbol,
 	return NewLocalIndex(i, 0), true
 }
 
-// MaybeCreateLocalBinding creates a new local binding in the current local environment or any parent local environment if it does not already exist.
+// MaybeCreateLocalBinding creates a new local binding in the current local
+// environment or any parent local environment if it does not already exist.
 // It returns the LocalIndex of the binding and a boolean indicating whether
 // the binding was created (true) or already existed (false).
+//
+// The parent-chain walk is EnvironmentFrame's responsibility; single-frame
+// lookup delegates to LocalEnvironmentFrame.GetLocalIndex.
 func (p *EnvironmentFrame) MaybeCreateLocalBinding(key *values.Symbol, bt BindingType) (*LocalIndex, bool) {
 	env := p
 	if env.local == nil {
 		return nil, false
 	}
-	ks := env.local.keys
-	i, ok := ks[*key]
-	j := 0
-	for !ok && !env.IsTopLevel() && env.parent.local != nil {
+	depth := 0
+	for {
+		li := env.local.GetLocalIndex(key)
+		if li != nil {
+			return NewLocalIndex(li[0], depth), false
+		}
+		if env.IsTopLevel() || env.parent.local == nil {
+			break
+		}
 		env = env.parent
-		ks = env.local.keys
-		i, ok = ks[*key]
-		j++
+		depth++
 	}
-	if ok {
-		return NewLocalIndex(i, j), false
-	}
-	i = len(p.local.bindings)
-	p.local.keys[*key] = i
-	p.local.bindings = append(p.local.bindings, NewBinding(values.Void, bt))
-	return NewLocalIndex(i, 0), true
+	// Not found in any parent — create in the current (innermost) frame
+	return p.local.EnsureLocalBinding(key, bt)
 }
 
-// GetLocalIndex returns the LocalIndex of the binding for the given symbol, searching local bindings in the current and parent environments.
+// GetLocalIndex returns the LocalIndex of the binding for the given symbol,
+// searching local bindings in the current and parent environments.
 // It returns nil if the binding does not exist.
+//
+// The parent-chain walk is EnvironmentFrame's responsibility; single-frame
+// lookup delegates to LocalEnvironmentFrame.GetLocalIndex.
 func (p *EnvironmentFrame) GetLocalIndex(key *values.Symbol) *LocalIndex {
 	if p == nil || p.local == nil {
 		return nil
 	}
 	env := p
-	ks := env.local.keys
-	i, ok := ks[*key]
-	j := 0
-	for !ok && !env.IsTopLevel() && env.parent.local != nil {
+	depth := 0
+	for {
+		li := env.local.GetLocalIndex(key)
+		if li != nil {
+			return NewLocalIndex(li[0], depth)
+		}
+		if env.IsTopLevel() || env.parent.local == nil {
+			break
+		}
 		env = env.parent
-		ks = env.local.keys
-		i, ok = ks[*key]
-		j++
+		depth++
 	}
-	if !ok {
-		return nil
-	}
-	return NewLocalIndex(i, j)
+	return nil
 }
 
-// GetLocalIndexWithScopes returns the LocalIndex of a local binding that matches the given scopes.
-// This implements Flatt's "maximal" binding resolution: among all bindings whose scopes
-// are a subset of the reference's scopes, we return the one with the LARGEST scope set.
-// This ensures that more specific bindings are preferred over less specific ones.
+// GetLocalIndexWithScopes returns the LocalIndex of a local binding that
+// matches the given scopes.
+//
+// This implements Flatt's "maximal" binding resolution: among all bindings
+// whose scopes are a subset of the reference's scopes, we return the one
+// with the LARGEST scope set. This ensures that more specific bindings are
+// preferred over less specific ones.
+//
 // Returns nil if no matching local binding exists.
+//
+// Note: this method accesses local.keys directly because each iteration
+// requires scope matching and candidate accumulation across the full parent
+// chain (Flatt's "collect-then-maximize" algorithm). A simple delegate-and-
+// adjust-depth pattern cannot express the cross-frame maximization.
 func (p *EnvironmentFrame) GetLocalIndexWithScopes(key *values.Symbol, scopes []*syntax.Scope) *LocalIndex {
 	if p == nil || p.local == nil {
 		return nil
@@ -561,27 +547,12 @@ func (p *EnvironmentFrame) SetLocalValue(li *LocalIndex, v values.Value) error {
 }
 
 // CreateGlobalBinding creates a new global binding in the current global environment.
+// The key is interned before use (consistent with
+// GlobalEnvironmentFrame.CreateGlobalBinding).
 // It returns the GlobalIndex of the new binding and a boolean indicating whether
 // the binding was created (true) or already existed (false).
 func (p *EnvironmentFrame) CreateGlobalBinding(key *values.Symbol, bt BindingType) (*GlobalIndex, bool) {
-	r := p
-	_, ok := r.global.keys[*key]
-	if ok {
-		q := NewGlobalIndex(key)
-		return q, false
-	}
-	i := len(p.global.bindings)
-	p.global.keys[*key] = i
-	// append the new binding at index i
-	p.global.SetBindings(append(p.global.Bindings(), NewBinding(values.Void, bt)))
-	q := NewGlobalIndex(key)
-	return q, true
-}
-
-// MaybeCreateOwnGlobalBinding creates a new global binding in the current or parent global environments if it does not already exist.
-// It returns the GlobalIndex of the binding and a boolean indicating whether
-// the binding was created (true) or already existed (false).
-func (p *EnvironmentFrame) MaybeCreateOwnGlobalBinding(key *values.Symbol, bt BindingType) (*GlobalIndex, bool) {
+	key = p.InternSymbol(key)
 	_, ok := p.global.keys[*key]
 	if ok {
 		return NewGlobalIndex(key), false
@@ -589,15 +560,39 @@ func (p *EnvironmentFrame) MaybeCreateOwnGlobalBinding(key *values.Symbol, bt Bi
 	i := len(p.global.bindings)
 	p.global.keys[*key] = i
 	p.global.SetBindings(append(p.global.Bindings(), NewBinding(values.Void, bt)))
-	q := NewGlobalIndex(key)
-	return q, true
+	return NewGlobalIndex(key), true
 }
 
-// GetGlobalIndex returns the GlobalIndex of the binding for the given symbol, searching global bindings in the current and parent environments.
+// MaybeCreateOwnGlobalBinding creates a new global binding in the current
+// global environment if it does not already exist.
+// The key is interned before use (consistent with
+// GlobalEnvironmentFrame.CreateGlobalBinding).
+// It returns the GlobalIndex of the binding and a boolean indicating whether
+// the binding was created (true) or already existed (false).
+func (p *EnvironmentFrame) MaybeCreateOwnGlobalBinding(key *values.Symbol, bt BindingType) (*GlobalIndex, bool) {
+	key = p.InternSymbol(key)
+	_, ok := p.global.keys[*key]
+	if ok {
+		return NewGlobalIndex(key), false
+	}
+	i := len(p.global.bindings)
+	p.global.keys[*key] = i
+	p.global.SetBindings(append(p.global.Bindings(), NewBinding(values.Void, bt)))
+	return NewGlobalIndex(key), true
+}
+
+// GetGlobalIndex returns the GlobalIndex of the binding for the given symbol,
+// searching global bindings in the current and parent environments.
 // It returns nil if the binding does not exist.
+//
+// The key is interned before lookup to ensure the returned GlobalIndex.Index
+// always points to the canonical symbol (consistent with
+// GlobalEnvironmentFrame.GetGlobalIndex).
+//
 // The returned GlobalIndex records the specific global frame where the binding
 // was found, enabling cross-library macro hygiene (see GlobalIndex.Env).
 func (p *EnvironmentFrame) GetGlobalIndex(key *values.Symbol) *GlobalIndex {
+	key = p.InternSymbol(key)
 	ge := p
 	_, ok := ge.global.keys[*key]
 	for !ok && !ge.IsTopLevel() {

--- a/internal/bootstrap/environment_tiny.go
+++ b/internal/bootstrap/environment_tiny.go
@@ -217,7 +217,7 @@ func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame,
 			// Compile and run
 			tpl := machine.NewNativeTemplate(0, 0, false)
 			// Use inTail=false for top-level expressions
-			cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+			cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 			err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 			if err != nil {
 				return values.WrapForeignErrorf(err, "error compiling bootstrap macro")

--- a/internal/bootstrap/multithreading_test.go
+++ b/internal/bootstrap/multithreading_test.go
@@ -43,7 +43,7 @@ func evalScheme(t *testing.T, env *environment.EnvironmentFrame, code string) (v
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err

--- a/internal/bootstrap/roundtrip_test.go
+++ b/internal/bootstrap/roundtrip_test.go
@@ -45,7 +45,7 @@ func evalSchemeEscape(t *testing.T, env *environment.EnvironmentFrame, code stri
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err

--- a/internal/extensions/eval/prim_eval.go
+++ b/internal/extensions/eval/prim_eval.go
@@ -56,7 +56,7 @@ func PrimEval(ctx context.Context, mc *machine.MachineContext) error {
 
 	// Compile the expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return values.WrapForeignErrorf(err, "eval: compilation error")
@@ -116,7 +116,7 @@ func PrimLoad(ctx context.Context, mc *machine.MachineContext) error {
 
 		// Compile the expression
 		tpl := machine.NewNativeTemplate(0, 0, false)
-		cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+		cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 		err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 		if err != nil {
 			return values.WrapForeignErrorf(err, "load: compilation error in %s", filename.Value)
@@ -373,7 +373,7 @@ func PrimCompile(ctx context.Context, mc *machine.MachineContext) error {
 	// Step 2: Compile to bytecode template
 	// Create a thunk template (0 params, 0 locals, not variadic)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return values.WrapForeignErrorf(err, "compile: compilation failed")

--- a/machine/compile_begin_for_syntax_test.go
+++ b/machine/compile_begin_for_syntax_test.go
@@ -35,7 +35,7 @@ func TestCompileBeginForSyntax_Error_NilEnv(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true, nil), expr)
+	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "begin-for-syntax")
 }
@@ -51,7 +51,7 @@ func TestCompileBeginForSyntax_Error_NilTemplate(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "begin-for-syntax")
 }
@@ -66,7 +66,7 @@ func TestCompileBeginForSyntax_Error_NotPair(t *testing.T) {
 	// Not a pair
 	expr := syntax.NewSyntaxSymbol("bad", nil)
 
-	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "begin-for-syntax")
 }
@@ -81,6 +81,6 @@ func TestCompileBeginForSyntax_Empty(t *testing.T) {
 	// Use an empty SyntaxPair (which returns true for IsSyntaxEmptyList)
 	exprPair := &syntax.SyntaxPair{}
 
-	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), exprPair)
+	err := ccnt.CompileBeginForSyntax(NewCompileTimeCallContext(context.Background(), false, true), exprPair)
 	c.Assert(err, qt.IsNil)
 }

--- a/machine/compile_define_for_syntax_test.go
+++ b/machine/compile_define_for_syntax_test.go
@@ -35,7 +35,7 @@ func TestCompileDefineForSyntax_Error_NilEnv(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true, nil), expr)
+	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "define-for-syntax")
 }
@@ -51,7 +51,7 @@ func TestCompileDefineForSyntax_Error_NilTemplate(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "define-for-syntax")
 }
@@ -66,7 +66,7 @@ func TestCompileDefineForSyntax_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "define-for-syntax")
 }
@@ -82,7 +82,7 @@ func TestCompileDefineForSyntax_Error_MissingExpression(t *testing.T) {
 	name := syntax.NewSyntaxSymbol("x", nil)
 	expr := syntax.NewSyntaxCons(name, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileDefineForSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "define-for-syntax")
 }

--- a/machine/compile_eval_when_test.go
+++ b/machine/compile_eval_when_test.go
@@ -36,7 +36,7 @@ func TestCompileEvalWhen_Error_NilEnv(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, nil), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "eval-when")
 }
@@ -52,7 +52,7 @@ func TestCompileEvalWhen_Error_NilTemplate(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "eval-when")
 }
@@ -67,7 +67,7 @@ func TestCompileEvalWhen_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "eval-when")
 }
@@ -85,7 +85,7 @@ func TestCompileEvalWhen_EmptyBody(t *testing.T) {
 		syntax.NewSyntaxEmptyList(nil), nil)
 	expr := syntax.NewSyntaxCons(phases, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil) // Empty body is valid, emits void
 }
 
@@ -104,7 +104,7 @@ func TestCompileEvalWhen_Error_UnknownPhase(t *testing.T) {
 	expr := syntax.NewSyntaxCons(phases,
 		syntax.NewSyntaxCons(body, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "unknown phase")
 }
@@ -124,7 +124,7 @@ func TestCompileEvalWhen_RunPhase(t *testing.T) {
 	expr := syntax.NewSyntaxCons(phases,
 		syntax.NewSyntaxCons(body, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(tpl.operations) > 0, qt.IsTrue)
 }
@@ -142,6 +142,6 @@ func TestCompileEvalWhen_EmptyPhases(t *testing.T) {
 	expr := syntax.NewSyntaxCons(phases,
 		syntax.NewSyntaxCons(body, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileEvalWhen(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 }

--- a/machine/compile_quasisyntax_test.go
+++ b/machine/compile_quasisyntax_test.go
@@ -82,7 +82,7 @@ func TestCompileQuasisyntax_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "quasisyntax")
 }
@@ -96,7 +96,7 @@ func TestCompileUnsyntax_Error(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileUnsyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileUnsyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "unsyntax")
 }
@@ -110,7 +110,7 @@ func TestCompileUnsyntaxSplicing_Error(t *testing.T) {
 
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileUnsyntaxSplicing(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileUnsyntaxSplicing(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "unsyntax-splicing")
 }
@@ -726,11 +726,11 @@ func TestExpandQuasisyntaxList_ImproperList(t *testing.T) {
 
 func TestCompileQuasisyntaxTemplate_PureLiteral(t *testing.T) {
 	c := qt.New(t)
-	ccnt, env := newTestCompiler()
+	ccnt, _ := newTestCompiler()
 
 	// Pure literal should emit only LoadLiteral
 	stx := makeTestSyntaxSymbol("bindSymbolWithScopes")
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	err := ccnt.compileQuasisyntaxTemplate(ctctx, stx, 1)
 	c.Assert(err, qt.IsNil)
@@ -768,7 +768,7 @@ func TestCompileQuasisyntaxTemplate_WithUnsyntax(t *testing.T) {
 
 func TestCompileQuasisyntaxTemplate_NestedPure(t *testing.T) {
 	c := qt.New(t)
-	ccnt, env := newTestCompiler()
+	ccnt, _ := newTestCompiler()
 
 	// Nested but no unsyntax -> still pure literal
 	stx := makeTestSyntaxList(
@@ -778,7 +778,7 @@ func TestCompileQuasisyntaxTemplate_NestedPure(t *testing.T) {
 			makeTestSyntaxSymbol("c"),
 		),
 	)
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	err := ccnt.compileQuasisyntaxTemplate(ctctx, stx, 1)
 	c.Assert(err, qt.IsNil)
@@ -816,37 +816,37 @@ func TestCompileQuasisyntaxTemplate_NestedWithUnsyntax(t *testing.T) {
 
 func TestCompileQuasisyntax_Error_NonPairArg(t *testing.T) {
 	c := qt.New(t)
-	ccnt, env := newTestCompiler()
+	ccnt, _ := newTestCompiler()
 
 	expr := makeTestSyntaxSymbol("bindSymbolWithScopes")
-	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "quasisyntax")
 }
 
 func TestCompileQuasisyntax_Error_ExtraArgs(t *testing.T) {
 	c := qt.New(t)
-	ccnt, env := newTestCompiler()
+	ccnt, _ := newTestCompiler()
 
 	expr := makeTestSyntaxList(
 		makeTestSyntaxSymbol("template"),
 		makeTestSyntaxSymbol("extra"),
 	)
-	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "quasisyntax")
 }
 
 func TestCompileQuasisyntax_Error_ImproperArgsList(t *testing.T) {
 	c := qt.New(t)
-	ccnt, env := newTestCompiler()
+	ccnt, _ := newTestCompiler()
 
 	expr := syntax.NewSyntaxCons(
 		makeTestSyntaxSymbol("template"),
 		makeTestSyntaxSymbol("extra"),
 		nil,
 	)
-	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileQuasisyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "quasisyntax")
 }

--- a/machine/compile_syntax_case_test.go
+++ b/machine/compile_syntax_case_test.go
@@ -34,7 +34,7 @@ func TestCompileSyntaxCase_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "syntax-case")
 }
@@ -50,7 +50,7 @@ func TestCompileSyntaxCase_Error_NoLiterals(t *testing.T) {
 	input := syntax.NewSyntaxSymbol("x", nil)
 	expr := syntax.NewSyntaxCons(input, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "syntax-case")
 }
@@ -68,7 +68,7 @@ func TestCompileSyntaxCase_Error_NoClauses(t *testing.T) {
 	expr := syntax.NewSyntaxCons(input,
 		syntax.NewSyntaxCons(literals, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntaxCase(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "syntax-case")
 }

--- a/machine/compile_syntax_form_test.go
+++ b/machine/compile_syntax_form_test.go
@@ -35,7 +35,7 @@ func TestCompileSyntax_SingleArg(t *testing.T) {
 	template := syntax.NewSyntaxSymbol("bindSymbolWithScopes", nil)
 	expr := syntax.NewSyntaxCons(template, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 	c.Assert(len(tpl.operations) > 0, qt.IsTrue)
 }
@@ -50,7 +50,7 @@ func TestCompileSyntax_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "syntax")
 }
@@ -68,7 +68,7 @@ func TestCompileSyntax_Error_TooManyArgs(t *testing.T) {
 	expr := syntax.NewSyntaxCons(template,
 		syntax.NewSyntaxCons(extra, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "syntax")
 }
@@ -182,7 +182,7 @@ func TestCompileSyntax_EscapeFormCompilesDirectly(t *testing.T) {
 		syntax.NewSyntaxCons(foo, syntax.NewSyntaxEmptyList(nil), nil), nil)
 	expr := syntax.NewSyntaxCons(escapeForm, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 
 	// Verify NO OperationSyntaxTemplateExpand was generated
@@ -210,7 +210,7 @@ func TestCompileSyntax_NonEscapeEllipsisUsesRuntimeExpansion(t *testing.T) {
 		syntax.NewSyntaxCons(ellipsis, syntax.NewSyntaxEmptyList(nil), nil), nil)
 	expr := syntax.NewSyntaxCons(template, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 
 	// Verify OperationSyntaxTemplateExpand WAS generated

--- a/machine/compile_time_call_context.go
+++ b/machine/compile_time_call_context.go
@@ -16,8 +16,6 @@ package machine
 
 import (
 	"context"
-
-	"github.com/aalpar/wile/environment"
 )
 
 // CompileTimeCallContext carries contextual information through the compilation process.
@@ -56,7 +54,6 @@ import (
 // Use NotInExpression() when entering a definition-only context (e.g., library body).
 type CompileTimeCallContext struct {
 	ctx          context.Context
-	env          *environment.EnvironmentFrame
 	inTail       bool
 	inExpression bool
 }
@@ -65,11 +62,9 @@ type CompileTimeCallContext struct {
 // Parameters:
 //   - inTail: true if compiling an expression in tail position
 //   - inExpression: true if compiling an expression (vs. a definition)
-//   - env: the environment frame for variable resolution during compilation
-func NewCompileTimeCallContext(ctx context.Context, inTail, inExpression bool, env *environment.EnvironmentFrame) CompileTimeCallContext {
+func NewCompileTimeCallContext(ctx context.Context, inTail, inExpression bool) CompileTimeCallContext {
 	return CompileTimeCallContext{
 		ctx:          ctx,
-		env:          env,
 		inTail:       inTail,
 		inExpression: inExpression,
 	}
@@ -89,7 +84,6 @@ func NewCompileTimeCallContext(ctx context.Context, inTail, inExpression bool, e
 func (p CompileTimeCallContext) NotInTail() CompileTimeCallContext {
 	return CompileTimeCallContext{
 		ctx:          p.ctx,
-		env:          p.env,
 		inTail:       false,
 		inExpression: p.inExpression,
 	}
@@ -101,7 +95,6 @@ func (p CompileTimeCallContext) NotInTail() CompileTimeCallContext {
 func (p CompileTimeCallContext) NotInExpression() CompileTimeCallContext {
 	return CompileTimeCallContext{
 		ctx:          p.ctx,
-		env:          p.env,
 		inTail:       p.inTail,
 		inExpression: false,
 	}

--- a/machine/compile_time_continuation_mutual_test.go
+++ b/machine/compile_time_continuation_mutual_test.go
@@ -62,7 +62,7 @@ func TestCompileContext_CompileDefine_MutualRecursion_NotSupported(t *testing.T)
 	econt1 := NewExpanderTimeContinuation(env)
 	prog1Syntax, err := econt1.ExpandExpression(ectx, prog1)
 	qt.Assert(t, err, qt.IsNil)
-	cnt := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cnt := NewCompileTimeCallContext(context.Background(), false, true)
 	err = cctx1.CompileExpression(cnt, prog1Syntax)
 	// This SHOULD fail - mutual recursion requires both functions to be pre-declared
 	qt.Assert(t, err, qt.IsNotNil, qt.Commentf("Should fail: forward references not supported"))
@@ -91,7 +91,7 @@ func TestCompileContext_CompileDefine_SelfRecursion_FunctionForm(t *testing.T) {
 	econt := NewExpanderTimeContinuation(env)
 	progSyntax, err := econt.ExpandExpression(ectx, prog)
 	qt.Assert(t, err, qt.IsNil)
-	cnt := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cnt := NewCompileTimeCallContext(context.Background(), false, true)
 	err = cctx.CompileExpression(cnt, progSyntax)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("Should be able to compile fact referencing itself"))
 

--- a/machine/compile_time_continuation_test.go
+++ b/machine/compile_time_continuation_test.go
@@ -362,7 +362,7 @@ func evalSchemeString(code string) (values.Value, error) {
 		// Compile
 		tpl := NewNativeTemplate(0, 0, false)
 		cctx := NewCompiletimeContinuation(tpl, env)
-		cnt := NewCompileTimeCallContext(context.Background(), false, true, env)
+		cnt := NewCompileTimeCallContext(context.Background(), false, true)
 		err = cctx.CompileExpression(cnt, expanded)
 		if err != nil {
 			return nil, err
@@ -578,7 +578,7 @@ func newTopLevelThunk(prog syntax.SyntaxValue, env *environment.EnvironmentFrame
 	}
 	// Use inTail=false for top-level expressions. Top-level is NOT tail position
 	// because there's no outer function to return to.
-	cnt := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cnt := NewCompileTimeCallContext(context.Background(), false, true)
 	err = cctx.CompileExpression(cnt, prog)
 	if err != nil {
 		return nil, err
@@ -1851,7 +1851,7 @@ func TestCompileSelfEvaluatingNilDirect(t *testing.T) {
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
 	ctc := NewCompiletimeContinuation(tpl, env)
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	// Call with nil to test the nil branch
 	err := ctc.CompileSelfEvaluating(ctctx, nil)

--- a/machine/compile_transformer.go
+++ b/machine/compile_transformer.go
@@ -85,7 +85,7 @@ func compileAndEvalLambdaTransformer(ctx context.Context, env *environment.Envir
 		return nil, values.WrapForeignErrorf(err, "error expanding transformer")
 	}
 
-	cctx := NewCompileTimeCallContext(ctx, false, true, expandEnv)
+	cctx := NewCompileTimeCallContext(ctx, false, true)
 	compiler := NewCompiletimeContinuation(tpl, expandEnv)
 	err = compiler.CompileExpression(cctx, expandedExpr)
 	if err != nil {

--- a/machine/compile_validated.go
+++ b/machine/compile_validated.go
@@ -414,7 +414,7 @@ func (p *CompileTimeContinuation) CompileValidatedLambda(ctctx CompileTimeCallCo
 // throughout the body, enabling forward references between defines.
 func (p *CompileTimeContinuation) compileBody(ctctx CompileTimeCallContext, clause validate.ValidatedBodyAndParams, childEnv *environment.EnvironmentFrame, tpl *NativeTemplate) error {
 	childCompiler := NewCompiletimeContinuation(tpl, childEnv)
-	lambdaBodyContext := NewCompileTimeCallContext(ctctx.ctx, true, ctctx.inExpression, childEnv)
+	lambdaBodyContext := NewCompileTimeCallContext(ctctx.ctx, true, ctctx.inExpression)
 
 	// R7RS §5.3.2: Internal definitions use letrec* semantics
 	// Pass 1: Pre-declare all define bindings so forward references work
@@ -778,7 +778,7 @@ func (p *CompileTimeContinuation) compileValidatedLiteral(ctctx CompileTimeCallC
 func (p *CompileTimeContinuation) CompileValidatedDynamicWind(ctctx CompileTimeCallContext, _ string, v *validate.ValidatedDynamicWind) error {
 	// Phase 1: Compile and push before, thunk, after to stack
 	// Note: We compile in expression context (not tail) since we need all three values
-	exprCtx := NewCompileTimeCallContext(ctctx.ctx, false, true, p.env)
+	exprCtx := NewCompileTimeCallContext(ctctx.ctx, false, true)
 
 	err := p.compileValidated(exprCtx, v.Before)
 	if err != nil {

--- a/machine/compile_validated_test.go
+++ b/machine/compile_validated_test.go
@@ -208,7 +208,7 @@ func TestCompileValidated_UnknownExprType(t *testing.T) {
 	env := newTopLevelEnv(environment.NewTopLevelEnvironment().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
 	ctc := NewCompiletimeContinuation(tpl, env)
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	// Create a mock ValidatedExpr that compileValidated doesn't know about
 	mock := &mockValidatedExpr{}

--- a/machine/compile_with_syntax_test.go
+++ b/machine/compile_with_syntax_test.go
@@ -35,7 +35,7 @@ func TestCompileWithSyntax_Error_NoArgs(t *testing.T) {
 	// Empty args
 	expr := syntax.NewSyntaxEmptyList(nil)
 
-	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "with-syntax")
 }
@@ -51,7 +51,7 @@ func TestCompileWithSyntax_Error_NoBody(t *testing.T) {
 	bindings := syntax.NewSyntaxEmptyList(nil)
 	expr := syntax.NewSyntaxCons(bindings, syntax.NewSyntaxEmptyList(nil), nil)
 
-	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "with-syntax")
 }
@@ -69,6 +69,6 @@ func TestCompileWithSyntax_EmptyBindings(t *testing.T) {
 	expr := syntax.NewSyntaxCons(bindings,
 		syntax.NewSyntaxCons(body, syntax.NewSyntaxEmptyList(nil), nil), nil)
 
-	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true, env), expr)
+	err := ccnt.CompileWithSyntax(NewCompileTimeCallContext(context.Background(), false, true), expr)
 	c.Assert(err, qt.IsNil)
 }

--- a/machine/coverage_fullruntime_test.go
+++ b/machine/coverage_fullruntime_test.go
@@ -63,7 +63,7 @@ func newTopLevelThunkExt(sv syntax.SyntaxValue, env *environment.EnvironmentFram
 	// Compile the expanded expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = ctc.CompileExpression(ctctx, expanded)
 	if err != nil {
 		return nil, err

--- a/machine/coverage_improvement_test.go
+++ b/machine/coverage_improvement_test.go
@@ -34,10 +34,8 @@ import (
 
 // TestCompileTimeCallContext_NotInExpression tests the NotInExpression method
 func TestCompileTimeCallContext_NotInExpression(t *testing.T) {
-	env := environment.NewTopLevelEnvironment().Runtime()
-
 	// Create a context that is in expression mode
-	ctx := NewCompileTimeCallContext(context.Background(), true, true, env)
+	ctx := NewCompileTimeCallContext(context.Background(), true, true)
 	qt.Assert(t, ctx.inExpression, qt.IsTrue)
 	qt.Assert(t, ctx.inTail, qt.IsTrue)
 
@@ -48,8 +46,6 @@ func TestCompileTimeCallContext_NotInExpression(t *testing.T) {
 	qt.Assert(t, newCtx.inExpression, qt.IsFalse)
 	// Verify that inTail is preserved
 	qt.Assert(t, newCtx.inTail, qt.IsTrue)
-	// Verify that env is preserved
-	qt.Assert(t, newCtx.env, qt.Equals, env)
 
 	// Verify original context is unchanged
 	qt.Assert(t, ctx.inExpression, qt.IsTrue)
@@ -140,7 +136,7 @@ func TestCompileUnquoteDirectCall(t *testing.T) {
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
 	ctc := NewCompiletimeContinuation(tpl, env)
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	sctx := syntax.NewZeroValueSourceContext()
 	expr := schemeutil.DatumToSyntaxValue(sctx, values.NewSymbol("x"))
@@ -155,7 +151,7 @@ func TestCompileUnquoteSplicingDirectCall(t *testing.T) {
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
 	ctc := NewCompiletimeContinuation(tpl, env)
-	ctctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := NewCompileTimeCallContext(context.Background(), false, true)
 
 	sctx := syntax.NewZeroValueSourceContext()
 	expr := schemeutil.DatumToSyntaxValue(sctx, values.NewSymbol("x"))

--- a/machine/hygiene_test.go
+++ b/machine/hygiene_test.go
@@ -71,7 +71,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, letMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 
 	// Compile the define-syntax for swap!
 	ctc = machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx = machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx = machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args = extractDefineSyntaxArgs(t, defineSyntaxForm)
 	err = ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -118,7 +118,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 
 	// Compile the expanded form
 	ctc2 := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx2 := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx2 := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = ctc2.CompileExpression(ctctx2, expanded)
 	if err != nil {
 		t.Fatalf("failed to compile: %v", err)
@@ -140,7 +140,7 @@ func TestLetMacroExpansion(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestLetMacroSimple(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -217,7 +217,7 @@ func TestMultipleElementsWithTrailingEllipsis(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -271,7 +271,7 @@ func TestLetMacroFull(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, letMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -308,7 +308,7 @@ func TestScopeCreation(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	qt.Assert(t, err, qt.IsNil)
@@ -527,7 +527,7 @@ func TestAuxiliarySyntaxShadowing(t *testing.T) {
 							sym, ok := car.(*syntax.SyntaxSymbol)
 							if ok && sym.Sym.Key == "define-syntax" {
 								ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-								ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+								ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 								args := extractDefineSyntaxArgs(t, expanded)
 								err := ctc.CompileDefineSyntax(ctctx, args)
 								if err != nil {
@@ -609,7 +609,7 @@ func TestBoundIdentifierHygieneInNestedSyntaxRules(t *testing.T) {
 	`)
 
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	args := extractDefineSyntaxArgs(t, outerMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("failed to compile outer macro"))

--- a/machine/let_shadow_macro_test.go
+++ b/machine/let_shadow_macro_test.go
@@ -54,7 +54,7 @@ func runSchemeCodeWithEnvForShadowTest(t *testing.T, env *environment.Environmen
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err

--- a/machine/library_loader.go
+++ b/machine/library_loader.go
@@ -179,7 +179,7 @@ func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expec
 
 	// Compile the form
 	// Use inTail=false for top-level expressions
-	cctx := NewCompileTimeCallContext(ctx, false, true, libEnv)
+	cctx := NewCompileTimeCallContext(ctx, false, true)
 	compiler := NewCompiletimeContinuation(tpl, libEnv)
 
 	// Set up to capture the compiled library

--- a/machine/library_scheme_test.go
+++ b/machine/library_scheme_test.go
@@ -85,7 +85,7 @@ func compileAndRun(t *testing.T, env *environment.EnvironmentFrame, sv syntax.Sy
 	// Compile the expanded expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = ctc.CompileExpression(ctctx, expanded)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func TestSchemeLibraryImports(t *testing.T) {
 	// Compile the import
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil, qt.Commentf("import of all scheme libraries failed"))
@@ -205,7 +205,7 @@ func TestSchemeLibraryImportsWithUsage(t *testing.T) {
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil)
 
@@ -267,7 +267,7 @@ func TestLibraryInternalMacroHygiene(t *testing.T) {
 	compiler.SetLibraryCallback(func(lib *machine.CompiledLibrary) {
 		compiledLib = lib
 	})
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = compiler.CompileExpression(ctctx, expanded)
 	c.Assert(err, qt.IsNil, qt.Commentf("library compilation should succeed"))
 	c.Assert(compiledLib, qt.IsNotNil, qt.Commentf("library callback should have been called"))
@@ -334,7 +334,7 @@ func TestIndividualSchemeLibraries(t *testing.T) {
 
 			tpl := machine.NewNativeTemplate(0, 0, false)
 			ctc := machine.NewCompiletimeContinuation(tpl, env)
-			ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+			ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 			err := ctc.CompileImport(ctctx, args)
 			c.Assert(err, qt.IsNil, qt.Commentf("failed to import (scheme %s)", lib.name))
 

--- a/machine/library_test.go
+++ b/machine/library_test.go
@@ -200,7 +200,7 @@ func TestCompileDefineLibrary_Basic(t *testing.T) {
 	// Compile the library
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileDefineLibrary(ctctx, args)
 	qt.Assert(t, err, qt.IsNil)
@@ -219,7 +219,7 @@ func TestCompileDefineLibrary_Empty(t *testing.T) {
 	// Compile
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileDefineLibrary(ctctx, args)
 	qt.Assert(t, err, qt.IsNil)
@@ -242,7 +242,7 @@ func TestCompileImport_LibraryNotFound(t *testing.T) {
 	// Compile - should fail because (scheme base) doesn't exist
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	qt.Assert(t, err, qt.IsNotNil) // Library not found
@@ -263,7 +263,7 @@ func TestCompileImport_NoRegistry(t *testing.T) {
 	// Compile - should fail because no registry is configured
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	qt.Assert(t, err, qt.IsNotNil)
@@ -283,7 +283,7 @@ func TestCompileExport_TopLevelError(t *testing.T) {
 	// Compile - should error at top level
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileExport(ctctx, args)
 	qt.Assert(t, err, qt.IsNotNil)
@@ -406,7 +406,7 @@ func TestImport_Simple(t *testing.T) {
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil)
@@ -434,7 +434,7 @@ func TestImport_OnlyModifier(t *testing.T) {
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil)
@@ -459,7 +459,7 @@ func TestImport_PrefixModifier(t *testing.T) {
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctc := machine.NewCompiletimeContinuation(tpl, env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil)
@@ -759,7 +759,7 @@ func TestLibraryForwardReferences(t *testing.T) {
 	// Compile the library - this should succeed with forward references
 	// Before the letrec* semantics fix, this would fail with:
 	// "no such local or global binding \"callee\""
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	compiler := machine.NewCompiletimeContinuation(tpl, env)
 	err = compiler.CompileExpression(ctctx, expanded)

--- a/machine/machine_context.go
+++ b/machine/machine_context.go
@@ -78,6 +78,7 @@ type MachineContext struct {
 	counters         VMCounters           // performance counters (plain uint64, single-goroutine)
 	threadID         uint64               // SRFI-18 thread identity: 0 = primordial thread
 	thread           *values.Thread       // SRFI-18 thread object: nil = primordial thread
+	syntaxCase       *syntaxCaseState     // per-context syntax-case expansion state; nil when not in syntax-case
 }
 
 // NewMachineContext creates a new machine context with the given context and continuation.

--- a/machine/operation_syntax_case.go
+++ b/machine/operation_syntax_case.go
@@ -37,17 +37,22 @@ import (
 //   - If match fails: value register = #f
 type OperationSyntaxCaseMatch struct{}
 
-// syntaxCaseBindings stores pattern variable bindings from a successful match.
-// This is stored in the machine context and accessed by OperationBindPatternVars.
-var currentSyntaxCaseBindings map[string]syntax.SyntaxValue
+// syntaxCaseState holds per-context state for syntax-case expansion.
+// It is stored on MachineContext (not as package globals) so that
+// syntax-case is reentrant and safe for concurrent macro expansion.
+type syntaxCaseState struct {
+	bindings map[string]syntax.SyntaxValue // pattern variable bindings from last match
+	matcher  *match.SyntaxMatcher          // matcher from last match (needed for ellipsis expansion)
+	input    syntax.SyntaxValue            // input syntax object being matched
+}
 
-// currentSyntaxCaseMatcher stores the matcher from the last successful match.
-// This is needed for template expansion with ellipsis.
-var currentSyntaxCaseMatcher *match.SyntaxMatcher
-
-// currentSyntaxCaseInput stores the input syntax object being matched.
-// This is used instead of the eval stack to avoid interference with procedure calls in the body.
-var currentSyntaxCaseInput syntax.SyntaxValue
+// ensureSyntaxCaseState lazily initializes the syntaxCaseState on the context.
+func ensureSyntaxCaseState(mc *MachineContext) *syntaxCaseState {
+	if mc.syntaxCase == nil {
+		mc.syntaxCase = &syntaxCaseState{}
+	}
+	return mc.syntaxCase
+}
 
 func NewOperationSyntaxCaseMatch() *OperationSyntaxCaseMatch {
 	return &OperationSyntaxCaseMatch{}
@@ -61,11 +66,12 @@ func (p *OperationSyntaxCaseMatch) Apply(ctx context.Context, mctx *MachineConte
 		return nil, mctx.Error(fmt.Sprintf("syntax-case: expected clause in value register, got %T", clauseVal))
 	}
 
-	// Get input from global (set by OperationStoreSyntaxCaseInput)
-	if currentSyntaxCaseInput == nil {
+	// Get input from per-context state (set by OperationStoreSyntaxCaseInput)
+	sc := mctx.syntaxCase
+	if sc == nil || sc.input == nil {
 		return nil, mctx.Error("syntax-case: no input available")
 	}
-	input := currentSyntaxCaseInput
+	input := sc.input
 
 	// Create a matcher
 	matcher := match.NewSyntaxMatcherWithEllipsisVars(clause.patternVars, clause.bytecode, clause.ellipsisVars)
@@ -81,9 +87,9 @@ func (p *OperationSyntaxCaseMatch) Apply(ctx context.Context, mctx *MachineConte
 		return mctx, nil // nolint:errcheck, nilerr
 	}
 
-	// Match succeeded - store bindings and matcher
-	currentSyntaxCaseBindings = matcher.GetBindings()
-	currentSyntaxCaseMatcher = matcher
+	// Match succeeded - store bindings and matcher in per-context state
+	sc.bindings = matcher.GetBindings()
+	sc.matcher = matcher
 	mctx.SetValue(values.TrueValue)
 	mctx.pc++
 	return mctx, nil
@@ -127,7 +133,8 @@ func NewOperationBindPatternVars(patternVars map[string]struct{}) *OperationBind
 }
 
 func (p *OperationBindPatternVars) Apply(ctx context.Context, mctx *MachineContext) (*MachineContext, error) {
-	if currentSyntaxCaseBindings == nil {
+	sc := mctx.syntaxCase
+	if sc == nil || sc.bindings == nil {
 		return nil, mctx.Error("syntax-case: no pattern bindings available")
 	}
 
@@ -140,7 +147,7 @@ func (p *OperationBindPatternVars) Apply(ctx context.Context, mctx *MachineConte
 	for _, varName := range p.PatternVars {
 		sym := childEnv.InternSymbol(values.NewSymbol(varName))
 		li, _ := childEnv.MaybeCreateLocalBinding(sym, environment.BindingTypeVariable)
-		stxVal, ok := currentSyntaxCaseBindings[varName]
+		stxVal, ok := sc.bindings[varName]
 		if ok && li == nil {
 			continue
 		}
@@ -217,7 +224,8 @@ func NewOperationSyntaxTemplateExpand() *OperationSyntaxTemplateExpand {
 }
 
 func (p *OperationSyntaxTemplateExpand) Apply(ctx context.Context, mctx *MachineContext) (*MachineContext, error) {
-	if currentSyntaxCaseMatcher == nil {
+	sc := mctx.syntaxCase
+	if sc == nil || sc.matcher == nil {
 		return nil, mctx.Error("syntax: no pattern matcher available for template expansion")
 	}
 
@@ -230,7 +238,7 @@ func (p *OperationSyntaxTemplateExpand) Apply(ctx context.Context, mctx *Machine
 
 	// Expand the template using the matcher (handles ellipsis)
 	// Use nil for intro scope and freeIds for now - hygiene can be added later
-	expanded, err := currentSyntaxCaseMatcher.ExpandWithIntroScope(template, nil, nil)
+	expanded, err := sc.matcher.ExpandWithIntroScope(template, nil, nil)
 	if err != nil {
 		return nil, mctx.WrapError(err, "syntax: template expansion error")
 	}
@@ -266,12 +274,13 @@ func NewOperationStoreSyntaxCaseInput() *OperationStoreSyntaxCaseInput {
 }
 
 func (p *OperationStoreSyntaxCaseInput) Apply(ctx context.Context, mctx *MachineContext) (*MachineContext, error) {
+	sc := ensureSyntaxCaseState(mctx)
 	val := mctx.GetValue()
 	// Convert to syntax value if needed (handles Pairs, Vectors, etc.)
 	if stx, ok := val.(syntax.SyntaxValue); ok {
-		currentSyntaxCaseInput = stx
+		sc.input = stx
 	} else {
-		currentSyntaxCaseInput = schemeutil.DatumToSyntaxValue(nil, val)
+		sc.input = schemeutil.DatumToSyntaxValue(nil, val)
 	}
 	mctx.pc++
 	return mctx, nil
@@ -303,7 +312,7 @@ func NewOperationClearSyntaxCaseInput() *OperationClearSyntaxCaseInput {
 }
 
 func (p *OperationClearSyntaxCaseInput) Apply(ctx context.Context, mctx *MachineContext) (*MachineContext, error) {
-	currentSyntaxCaseInput = nil
+	mctx.syntaxCase = nil
 	mctx.pc++
 	return mctx, nil
 }

--- a/machine/operation_syntax_case_test.go
+++ b/machine/operation_syntax_case_test.go
@@ -288,9 +288,6 @@ func TestOperationStoreSyntaxCaseInput_IsVoid(t *testing.T) {
 func TestOperationStoreSyntaxCaseInput_Apply_SyntaxValue(t *testing.T) {
 	c := qt.New(t)
 
-	// Clear any previous state
-	currentSyntaxCaseInput = nil
-
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
 	mc := NewMachineContext(context.Background(), NewMachineContinuation(nil, tpl, env))
@@ -303,15 +300,13 @@ func TestOperationStoreSyntaxCaseInput_Apply_SyntaxValue(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(currentSyntaxCaseInput, qt.IsNotNil)
+	c.Assert(mc.syntaxCase, qt.IsNotNil)
+	c.Assert(mc.syntaxCase.input, qt.IsNotNil)
 	c.Assert(mc.pc, qt.Equals, 1)
 }
 
 func TestOperationStoreSyntaxCaseInput_Apply_NonSyntaxValue(t *testing.T) {
 	c := qt.New(t)
-
-	// Clear any previous state
-	currentSyntaxCaseInput = nil
 
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
@@ -325,7 +320,8 @@ func TestOperationStoreSyntaxCaseInput_Apply_NonSyntaxValue(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(currentSyntaxCaseInput, qt.IsNotNil)
+	c.Assert(mc.syntaxCase, qt.IsNotNil)
+	c.Assert(mc.syntaxCase.input, qt.IsNotNil)
 }
 
 // =============================================================================
@@ -373,18 +369,20 @@ func TestOperationClearSyntaxCaseInput_IsVoid(t *testing.T) {
 func TestOperationClearSyntaxCaseInput_Apply(t *testing.T) {
 	c := qt.New(t)
 
-	// Set up some input
-	currentSyntaxCaseInput = syntax.NewSyntaxSymbol("test", nil)
-
 	env := environment.NewTopLevelEnvironment().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
 	mc := NewMachineContext(context.Background(), NewMachineContinuation(nil, tpl, env))
+
+	// Set up some input via the per-context state
+	mc.syntaxCase = &syntaxCaseState{
+		input: syntax.NewSyntaxSymbol("test", nil),
+	}
 
 	op := NewOperationClearSyntaxCaseInput()
 	result, err := op.Apply(context.Background(), mc)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result, qt.IsNotNil)
-	c.Assert(currentSyntaxCaseInput, qt.IsNil)
+	c.Assert(mc.syntaxCase, qt.IsNil)
 	c.Assert(mc.pc, qt.Equals, 1)
 }

--- a/machine/record_test.go
+++ b/machine/record_test.go
@@ -55,7 +55,7 @@ func evalScheme(t *testing.T, code string) values.Value {
 
 		// Compile
 		tpl := machine.NewNativeTemplate(0, 0, false)
-		cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+		cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 		err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 		qt.Assert(t, err, qt.IsNil)
 

--- a/machine/source_recording_test.go
+++ b/machine/source_recording_test.go
@@ -39,7 +39,7 @@ func compileScheme(t *testing.T, code string) *NativeTemplate {
 	expanded, err := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
 	qt.Assert(t, err, qt.IsNil)
 
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -112,7 +112,7 @@ func TestSourceRecording_Call(t *testing.T) {
 	ectx := context.Background()
 	expanded, err := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
 	qt.Assert(t, err, qt.IsNil)
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -141,7 +141,7 @@ func TestSourceRecording_SetBang(t *testing.T) {
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
 	expanded, _ := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	err := NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -182,7 +182,7 @@ func TestSourceRecording_SourceLocationPreserved(t *testing.T) {
 	expanded, err := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
 	qt.Assert(t, err, qt.IsNil)
 
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 

--- a/machine/source_tracking_coverage_test.go
+++ b/machine/source_tracking_coverage_test.go
@@ -538,7 +538,7 @@ func TestSourceRecording_Symbol(t *testing.T) {
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
 	expanded, _ := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	_ = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 
 	// Now reference x
@@ -573,7 +573,7 @@ func TestSourceRecording_Literal(t *testing.T) {
 	expanded, err := NewExpanderTimeContinuation(env).ExpandExpression(ectx, stx)
 	c.Assert(err, qt.IsNil)
 
-	cctx := NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := NewCompileTimeCallContext(context.Background(), false, true)
 	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	c.Assert(err, qt.IsNil)
 

--- a/machine/syntax_rules_test.go
+++ b/machine/syntax_rules_test.go
@@ -72,7 +72,7 @@ func TestSyntaxRulesSimpleVariable(t *testing.T) {
 
 	// Compile define-syntax
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
 		t.Fatalf("failed to compile define-syntax: %v", err)
@@ -116,7 +116,7 @@ func TestSyntaxRulesWithLiteral(t *testing.T) {
 
 	// Compile define-syntax
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
 		t.Fatalf("failed to compile define-syntax: %v", err)
@@ -154,7 +154,7 @@ func TestSyntaxRulesWithEllipsis(t *testing.T) {
 
 	// Compile define-syntax
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
 		t.Fatalf("failed to compile define-syntax: %v", err)
@@ -197,7 +197,7 @@ func TestSyntaxRulesWithCustomEllipsis(t *testing.T) {
 
 	// Compile define-syntax
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
 		t.Fatalf("failed to compile define-syntax with custom ellipsis: %v", err)
@@ -238,7 +238,7 @@ func TestSyntaxRulesWithUnderscoreInLiterals(t *testing.T) {
 
 	// Compile define-syntax
 	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+	ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
 		t.Fatalf("failed to compile define-syntax with _ in literals: %v", err)
@@ -276,7 +276,7 @@ func TestSyntaxRulesEllipsisInLiteralsAccepted(t *testing.T) {
 
 		// Compile should succeed - ellipsis in literals disables ellipsis functionality
 		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-		ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+		ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 		err := ctc.CompileDefineSyntax(ctctx, args)
 		if err != nil {
 			t.Fatalf("expected ellipsis in literals to compile, got: %v", err)
@@ -296,7 +296,7 @@ func TestSyntaxRulesEllipsisInLiteralsAccepted(t *testing.T) {
 
 		// Compile should succeed - ellipsis in literals disables ellipsis functionality
 		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
-		ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false, env)
+		ctctx := machine.NewCompileTimeCallContext(context.Background(), false, false)
 		err := ctc.CompileDefineSyntax(ctctx, args)
 		if err != nil {
 			t.Fatalf("expected custom ellipsis in literals to compile, got: %v", err)

--- a/plans/SUBSYSTEM_SIMPLIFICATION.md
+++ b/plans/SUBSYSTEM_SIMPLIFICATION.md
@@ -31,7 +31,7 @@ The dependency graph is clean (no cycles) and the package layering is sound. The
                    registry/helpers
 ```
 
-## Phase 1: Unified Port Base (Low Risk, High Impact)
+## Phase 1: Unified Port Base (Low Risk, High Impact) ✅ DONE
 
 ### Problem
 
@@ -124,7 +124,7 @@ make lint                  # No new issues
 
 ---
 
-## Phase 2: AsList() Deduplication (Low Risk, Moderate Impact)
+## Phase 2: AsList() Deduplication (Low Risk, Moderate Impact) ✅ DONE
 
 ### Problem
 
@@ -191,7 +191,7 @@ make lint
 
 ---
 
-## Phase 3: ErrMachineHalt → nil at Run() Boundary (Medium Risk, High Impact)
+## Phase 3: ErrMachineHalt → nil at Run() Boundary (Medium Risk, High Impact) ✅ DONE
 
 ### Problem
 
@@ -272,7 +272,7 @@ Medium — requires careful audit of all `Run()` callers. Some callers may depen
 
 ---
 
-## Phase 4: syntax-case Globals → Per-Context State (Medium Risk, Medium Impact)
+## Phase 4: syntax-case Globals → Per-Context State (Medium Risk, Medium Impact) ✅ DONE
 
 ### Problem
 
@@ -314,16 +314,16 @@ Each `OperationStoreSyntaxCaseInput`, `OperationSyntaxCaseMatch`, `OperationBind
 | File | Changes |
 |------|---------|
 | `machine/machine_context.go` | Add `syntaxCase *syntaxCaseState` field |
-| `machine/operation_syntax_case.go` | Replace global reads/writes with `mc.syntaxCase.*` |
+| `machine/operation_syntax_case.go` | Replace 3 globals with `syntaxCaseState` struct + `ensureSyntaxCaseState()` helper; all operations use `mc.syntaxCase.*` |
+| `machine/operation_syntax_case_test.go` | Update tests to use `mc.syntaxCase` instead of package globals |
 
-### Verification
+### Implementation Notes
 
-```bash
-go test ./machine/...
-make lint
-# Verify no remaining references to the globals:
-grep -n 'currentSyntaxCase' machine/*.go
-```
+- `syntaxCaseState` struct defined in `operation_syntax_case.go` (co-located with the operations that use it)
+- `ensureSyntaxCaseState(mc)` lazily allocates the state on first use (StoreSyntaxCaseInput)
+- `ClearSyntaxCaseInput` sets `mc.syntaxCase = nil` (releases the entire state)
+- `NewSubContext()` does NOT propagate `syntaxCase` — it's per-expansion, not per-thread
+- Zero behavioral change: all tests pass unchanged
 
 ### Impact
 
@@ -334,7 +334,7 @@ grep -n 'currentSyntaxCase' machine/*.go
 
 ---
 
-## Phase 5: Environment Lookup Delegation (Low Risk, Moderate Impact)
+## Phase 5: Environment Lookup Delegation (Low Risk, Moderate Impact) ✅ DONE
 
 ### Problem
 
@@ -342,51 +342,43 @@ grep -n 'currentSyntaxCase' machine/*.go
 
 There is also a semantic discrepancy: `GlobalEnvironmentFrame.GetGlobalIndex` interns the symbol before lookup; `EnvironmentFrame.GetGlobalIndex` does not.
 
-### Design
+### Investigation Results
 
-Refactor `EnvironmentFrame` lookup methods to delegate to the underlying frame types for leaf-level lookups, keeping only parent-chain traversal as `EnvironmentFrame`'s unique responsibility:
+1. **Depth tracking**: `EnvironmentFrame.GetLocalIndex` walks the parent chain with a depth counter `j`. `LocalEnvironmentFrame.GetLocalIndex` always returns depth 0. Delegation requires the walker to adjust depth: `NewLocalIndex(li[0], depth)`. Same applies to `MaybeCreateLocalBinding`.
 
-```go
-func (p *EnvironmentFrame) GetLocalIndex(key *values.Symbol) *LocalIndex {
-    curr := p
-    depth := 0
-    for curr != nil {
-        if li := curr.local.GetLocalIndex(key); li != nil {
-            li.Depth = depth  // adjust depth for parent chain
-            return li
-        }
-        curr = curr.parent
-        depth++
-    }
-    return nil
-}
-```
+2. **Interning discrepancy**: Confirmed latent bug. `EnvironmentFrame.GetGlobalIndex` returned `GlobalIndex.Index` pointing to an uninternmed symbol. Works today because all consumers use `*gi.Index` (value comparison), but violates the invariant that returned `GlobalIndex` values should hold interned symbols. Same gap existed in `CreateGlobalBinding` and `MaybeCreateOwnGlobalBinding`.
 
-### Investigation Required
+3. **GetIndex**: Zero production callers, documented bug (skips first frame). Deleted.
 
-Before implementing, verify:
-1. Whether `EnvironmentFrame.GetLocalIndex` adjusts the `LocalIndex.Depth` field (parent-chain depth tracking) — this is the part that can't delegate naively
-2. Whether the symbol-interning discrepancy in `GetGlobalIndex` is a bug or intentional
-3. Whether `GetBinding` and `GetIndex` have subtle differences from their delegate candidates
+4. **GetBinding/GetBindingWithScopes/GetLocalIndexWithScopes**: Complex per-iteration scope matching logic (ScopesMatch, candidate accumulation, Flatt's maximization) makes delegation a net negative — it would push scope-awareness into the leaf types or require a predicate parameter, neither of which simplifies anything. Documented in comments.
+
+### Changes Implemented
+
+**Tier 1 — High value, safe:**
+- Deleted `GetIndex` (dead code with documented bug, zero callers)
+- Added `InternSymbol(key)` to `GetGlobalIndex`, `CreateGlobalBinding`, `MaybeCreateOwnGlobalBinding` — all three now intern the key before lookup/create, consistent with `GlobalEnvironmentFrame.CreateGlobalBinding` and `GlobalEnvironmentFrame.GetGlobalIndex`
+
+**Tier 2 — Moderate value, delegation:**
+- `GetLocalIndex`: delegates single-frame lookup to `LocalEnvironmentFrame.GetLocalIndex`, adjusts depth
+- `MaybeCreateLocalBinding`: delegates single-frame lookup to `LocalEnvironmentFrame.GetLocalIndex`, creation to `LocalEnvironmentFrame.EnsureLocalBinding`
+
+**Tier 3 — Low value, documented as intentionally non-delegated:**
+- `GetBinding`: returns `*Binding` (no depth tracking needed), direct map access is equivalent
+- `GetBindingWithScopes`: per-iteration scope matching prevents clean delegation
+- `GetLocalIndexWithScopes`: cross-frame candidate maximization (Flatt model) prevents delegate-and-adjust pattern
 
 ### Files Modified
 
 | File | Changes |
 |------|---------|
-| `environment/environment_frame.go` | Refactor `GetLocalIndex`, `GetGlobalIndex`, `GetBinding`, `GetIndex` to delegate |
-
-### Verification
-
-```bash
-go test ./environment/... ./machine/... ./registry/...
-make lint
-```
+| `environment/environment_frame.go` | Deleted `GetIndex`; added interning to `GetGlobalIndex`, `CreateGlobalBinding`, `MaybeCreateOwnGlobalBinding`; refactored `GetLocalIndex` and `MaybeCreateLocalBinding` to delegate; added doc comments to Tier 3 methods |
 
 ### Impact
 
-- Removes duplicated map-lookup code
-- Closes the symbol-interning gap (or documents it)
-- Makes delegation chain explicit
+- Dead code (`GetIndex`) eliminated
+- Symbol interning gap closed — `GlobalIndex.Index` now always points to interned symbol
+- `GetLocalIndex` and `MaybeCreateLocalBinding` have clear responsibility split: `EnvironmentFrame` owns the walk, `LocalEnvironmentFrame` owns the lookup
+- Non-delegated methods documented with rationale
 
 ---
 
@@ -496,7 +488,7 @@ Medium — `Restore` vs `PopContinuation` have intentionally different semantics
 
 ---
 
-## Phase 7: CompileTimeCallContext.env Audit (Low Risk, Low Impact)
+## Phase 7: CompileTimeCallContext.env Audit (Low Risk, Low Impact) ✅ DONE
 
 ### Problem
 
@@ -517,18 +509,24 @@ grep -n 'NewCompileTimeCallContext' machine/*.go | grep -v test
 
 If they always agree, remove `env` from `CompileTimeCallContext`. If they sometimes differ, document when and why.
 
-### Files Modified (if removing env)
+### Investigation Result
+
+`ctctx.env` is never read anywhere in the codebase — confirmed by grep. The field is written at construction and copied through `NotInTail()`/`NotInExpression()` but never consumed. It is pure dead state.
+
+### Files Modified
 
 | File | Changes |
 |------|---------|
-| `machine/compile_time_call_context.go` | Remove `env` field |
-| All callers of `NewCompileTimeCallContext` | Remove `env` argument |
-| All readers of `ctctx.env` | Replace with `p.env` (receiver) |
+| `machine/compile_time_call_context.go` | Remove `env` field, remove `env` parameter from constructor, remove from copy methods |
+| ~30 production + test files | Remove 4th argument from `NewCompileTimeCallContext()` calls |
+| `machine/coverage_improvement_test.go` | Remove assertion on `newCtx.env` |
+| `machine/compile_quasisyntax_test.go` | Replace `ccnt, env := newTestCompiler()` with `ccnt, _ :=` (5 sites) |
 
 ### Impact
 
-- Either removes a redundant field or documents a subtle invariant
-- Low effort either way
+- Dead field removed from a value-type struct passed by copy through the entire compiler
+- Constructor signature simplified: `NewCompileTimeCallContext(ctx, inTail, inExpression)` — no more env parameter
+- State space reduced from `ctx × env × inTail × inExpression` to `ctx × inTail × inExpression`
 
 ---
 
@@ -676,13 +674,13 @@ Do not reintroduce a dispatch table. If the repetition becomes painful (e.g., ad
 Phases are independent and can be executed in any order. Recommended sequence by risk/impact:
 
 ```
-Phase 1 (Port Base)        ─── low risk, high impact, self-contained
-Phase 2 (AsList)           ─── low risk, moderate impact, trivial
-Phase 3 (ErrMachineHalt)   ─── medium risk, high impact, wide blast radius
-Phase 4 (syntax-case)      ─── medium risk, medium impact, 1 file
-Phase 5 (Env Delegation)   ─── low risk, moderate impact, investigation needed
+Phase 1 (Port Base)        ─── ✅ DONE (commit b99e98a)
+Phase 2 (AsList)           ─── ✅ DONE (commit b99e98a)
+Phase 3 (ErrMachineHalt)   ─── ✅ DONE (commit b99e98a)
+Phase 4 (syntax-case)      ─── ✅ DONE (moved globals to MachineContext.syntaxCase)
+Phase 5 (Env Delegation)   ─── ✅ DONE (interning gap closed, GetLocalIndex/MaybeCreateLocalBinding delegated, GetIndex deleted)
 Phase 6 (VM State Struct)  ─── medium risk, high impact, investigation needed
-Phase 7 (CallContext env)  ─── low risk, low impact, investigation needed
+Phase 7 (CallContext env)  ─── ✅ DONE (env field removed from CompileTimeCallContext)
 ```
 
-Phases 5, 6, and 7 require investigation before implementation. The "Investigation Required" sections describe what to verify.
+Phase 6 requires investigation before implementation. The "Investigation Required" section describes what to verify.

--- a/registry/core/prim_control_test.go
+++ b/registry/core/prim_control_test.go
@@ -621,7 +621,7 @@ func TestDynamicWindEscape(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 

--- a/registry/core/prim_io_test.go
+++ b/registry/core/prim_io_test.go
@@ -65,7 +65,7 @@ func TestDisplayWithBuffer(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -92,7 +92,7 @@ func TestWriteWithBuffer(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -119,7 +119,7 @@ func TestWriteCharWithBuffer(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -146,7 +146,7 @@ func TestNewlineWithBuffer(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -173,7 +173,7 @@ func TestReadToken(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -202,7 +202,7 @@ func TestReadSyntax(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -232,7 +232,7 @@ func TestRead(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -261,7 +261,7 @@ func TestReadWithPort(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	// We need to test read with an explicit port - use lambda to capture port
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -294,7 +294,7 @@ func TestDisplayWithSymbol(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -322,7 +322,7 @@ func TestWriteWithString(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -349,7 +349,7 @@ func TestWriteCharWithUnicode(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -378,7 +378,7 @@ func TestReadMultipleTokens(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	// Read first token
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -405,7 +405,7 @@ func TestDisplayWithInteger(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -432,7 +432,7 @@ func TestDisplayWithBoolean(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -459,7 +459,7 @@ func TestWriteWithSymbol(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -507,7 +507,7 @@ func TestDisplayWithList(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -536,7 +536,7 @@ func TestWriteWithList(t *testing.T) {
 
 	env, err := bootstrap.NewTopLevelEnvironmentFrameTiny(context.TODO())
 	qt.Assert(t, err, qt.IsNil)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -577,7 +577,7 @@ func TestStringPorts(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -607,7 +607,7 @@ func TestStringInputPort(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -641,7 +641,7 @@ func TestBytevectorPorts(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -671,7 +671,7 @@ func TestBytevectorInputPort(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
@@ -753,7 +753,7 @@ func TestPortPredicates(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 
 			tpl := machine.NewNativeTemplate(0, 0, false)
-			cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+			cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 			err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 			qt.Assert(t, err, qt.IsNil)
 

--- a/registry/core/test_helpers_test.go
+++ b/registry/core/test_helpers_test.go
@@ -43,7 +43,7 @@ func runProgramAST(t *testing.T, prog values.Value) (values.Value, error) {
 // runProgramASTWithEnv runs a program AST with the given environment.
 func runProgramASTWithEnv(t *testing.T, env *environment.EnvironmentFrame, prog values.Value) (values.Value, error) {
 	t.Helper()
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ccnt := machine.NewCompiletimeContinuation(tpl, env)
 	sctx := syntax.NewZeroValueSourceContext()
@@ -86,7 +86,7 @@ func runSchemeCodeWithEnv(t *testing.T, env *environment.EnvironmentFrame, code 
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true, env)
+	cctx := machine.NewCompileTimeCallContext(context.Background(), false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func runSchemeCodeWithEnvAndContext(ctx context.Context, t *testing.T, env *envi
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -60,7 +60,7 @@ func Compile(ctx context.Context, env *environment.EnvironmentFrame, expr syntax
 	}
 
 	// Use inTail=false for top-level expressions
-	cctx := machine.NewCompileTimeCallContext(ctx, false, true, env)
+	cctx := machine.NewCompileTimeCallContext(ctx, false, true)
 	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, values.WrapForeignErrorf(err, "compilation error")


### PR DESCRIPTION
## Summary

- **Phase 4**: Move 3 syntax-case mutable globals to per-context `syntaxCaseState` struct on `MachineContext`, making syntax-case reentrant and thread-safe
- **Phase 5**: Fix interning gap in `EnvironmentFrame` global methods (now consistent with `GlobalEnvironmentFrame`), delegate `GetLocalIndex`/`MaybeCreateLocalBinding` to leaf types, delete dead `GetIndex` method
- **Phase 7**: Remove dead `env` field from `CompileTimeCallContext` (written but never read), simplify constructor from 4 to 3 params across ~30 call sites

## Changes

### Phase 4: syntax-case globals → per-context state
- New `syntaxCaseState` struct with `bindings`, `matcher`, `input` fields
- `ensureSyntaxCaseState()` helper for lazy initialization
- `ClearSyntaxCaseInput` sets `mc.syntaxCase = nil` (releases entire state)
- Not propagated to sub-contexts

### Phase 5: Environment lookup delegation
- `GetGlobalIndex`, `CreateGlobalBinding`, `MaybeCreateOwnGlobalBinding` now call `InternSymbol(key)` before lookup/create
- `GetLocalIndex` and `MaybeCreateLocalBinding` delegate single-frame lookup to `LocalEnvironmentFrame.GetLocalIndex` with depth adjustment
- Deleted `GetIndex` (zero production callers, documented bug that skips first frame)
- Documented why `GetBinding`, `GetBindingWithScopes`, `GetLocalIndexWithScopes` don't delegate (complex per-iteration scope logic)

### Phase 7: Dead field removal
- Removed `env *environment.EnvironmentFrame` from `CompileTimeCallContext`
- Simplified constructor: `NewCompileTimeCallContext(ctx, inTail, inExpression)`
- Updated `NotInTail()` and `NotInExpression()` copy methods

## Test plan
- [x] `go test ./...` — all 25 test packages pass
- [x] `make lint` — 0 issues
- [x] Plans file updated with investigation results

🤖 Generated with [Claude Code](https://claude.com/claude-code)