### PR TITLE
refactor: deduplicate Vector/ByteVector SchemeString

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,24 +37,22 @@ Code Quality
 - [x] `operation_test.go:~240` — `OperationRestoreContinuation` test shows `CallDepth()=0` because no real call is active. Same improvement needed.
 - [x] `compile_time_continuation_test.go:~509` — `mc.Run()` should return `ErrMachineHalt` but currently does not. Investigate and fix the assertion.
 
-### Collection/Indexable/Tuple Method Duplication
+### Indexable Method Duplication
 
-Refactor duplicated methods across value types implementing `Collection`, `Indexable`, and `Tuple`.
+Investigated all items. Most are already resolved, semantically different, or too trivial to abstract.
 
-**100% duplicates (extract immediately):**
-- [ ] `Vector.AsList()` / `ByteVector.AsList()` — 20 lines identical. Extract `indexableToList(len int, get func(int) Value) Tuple`.
-- [ ] `Vector.SchemeString()` / `ByteVector.SchemeString()` — identical except prefix (`"#("` vs `"#u8("`). Extract `formatIndexable(prefix string, len int, get func(int) Value) string`.
+**Extracted:**
+- [x] `Vector.SchemeString()` / `ByteVector.SchemeString()` — extracted `formatIndexable()` helper in `values/utils.go`.
 
-**~95% duplicates (parameterize):**
-- [ ] `Vector.EqualTo()` / `ByteVector.EqualTo()` — same structure; only element comparison differs.
-- [ ] `Vector.Get()` / `ByteVector.Get()` — trivial, but signals missing shared abstraction.
+**Closed (no action):**
+- [x] `Vector.AsList()` / `ByteVector.AsList()` — already simplified in SUBSYSTEM_SIMPLIFICATION Phase 2; both delegate to `List()`.
+- [x] `Vector.EqualTo()` / `ByteVector.EqualTo()` — semantic difference: Vector uses recursive `EqualTo()`, ByteVector compares `uint8` directly. Cannot safely unify.
+- [x] `Vector.Get()` / `ByteVector.Get()` — trivial one-liner (`return (*p)[i]`), no extraction benefit.
+- [x] `IsVoid()` across types — single-line `return p == nil`; abstracting adds indirection for zero cognitive benefit.
+- [x] `EqualTo()` preambles — type-specific assertions prevent clean unification.
+- [x] `ForEach()` Pair vs ArrayList — different data structures (linked list vs array).
 
-**Pattern duplication (structural):**
-- [ ] `IsVoid()` across Vector, ByteVector, Pair, ArrayList — all `p == nil`.
-- [ ] `EqualTo()` preambles across 5 types — type assertion + nil handling + length check.
-- [ ] `ForEach()` in Pair vs ArrayList — loop + callback + error handling.
-
-**Locations:** `values/vector.go`, `values/byte_vector.go`, `values/pair.go`, `values/array_list.go`, `values/empty_list.go`
+**Locations:** `values/utils.go`, `values/vector.go`, `values/byte_vector.go`
 
 ---
 

--- a/values/byte_vector.go
+++ b/values/byte_vector.go
@@ -14,10 +14,6 @@
 
 package values
 
-import (
-	"strings"
-)
-
 var (
 	_ Value     = (*ByteVector)(nil)
 	_ Indexable = (*ByteVector)(nil)
@@ -162,17 +158,7 @@ func (p *ByteVector) EqualTo(v Value) bool {
 
 // SchemeString returns the Scheme representation of the bytevector.
 func (p *ByteVector) SchemeString() string {
-	q := &strings.Builder{}
-	q.WriteString("#u8(")
-	if len(*p) > 0 {
-		q.WriteString(" ")
-		q.WriteString((*p)[0].SchemeString())
-		for _, v := range (*p)[1:] {
-			q.WriteString(" ")
-			q.WriteString(v.SchemeString())
-		}
-		q.WriteString(" ")
-	}
-	q.WriteString(")")
-	return q.String()
+	return formatIndexable("#u8(", len(*p), func(i int) Value {
+		return (*p)[i]
+	})
 }

--- a/values/utils.go
+++ b/values/utils.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base32"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -26,6 +27,25 @@ import (
 const (
 	byteCnt = 128 / 8
 )
+
+// formatIndexable builds the Scheme external representation for a
+// fixed-size indexable collection.  Format: prefix elem1 elem2 ... )
+// with elements separated by spaces.
+func formatIndexable(prefix string, length int, get func(int) Value) string {
+	q := &strings.Builder{}
+	q.WriteString(prefix)
+	if length > 0 {
+		q.WriteString(" ")
+		q.WriteString(get(0).SchemeString())
+		for i := 1; i < length; i++ {
+			q.WriteString(" ")
+			q.WriteString(get(i).SchemeString())
+		}
+		q.WriteString(" ")
+	}
+	q.WriteString(")")
+	return q.String()
+}
 
 // List constructs a proper list from the given values.
 // Returns EmptyList if no arguments are provided.

--- a/values/vector.go
+++ b/values/vector.go
@@ -15,10 +15,6 @@
 // Package values provides Scheme runtime value types.
 package values
 
-import (
-	"strings"
-)
-
 var (
 	_ Value     = (*Vector)(nil)
 	_ Indexable = (*Vector)(nil)
@@ -116,18 +112,7 @@ func (p *Vector) AsList() Tuple {
 // Format: #( element1 element2 ... ) with elements separated by spaces.
 // Empty vectors are represented as #().
 func (p *Vector) SchemeString() string {
-	q := &strings.Builder{}
-	q.WriteString("#(")
-	if len(*p) > 0 {
-		q.WriteString(" ")
-		v := (*p)[0]
-		q.WriteString(v.SchemeString())
-		for _, v = range (*p)[1:] {
-			q.WriteString(" ")
-			q.WriteString(v.SchemeString())
-		}
-		q.WriteString(" ")
-	}
-	q.WriteString(")")
-	return q.String()
+	return formatIndexable("#(", len(*p), func(i int) Value {
+		return (*p)[i]
+	})
 }


### PR DESCRIPTION
## Summary

- Extract `formatIndexable()` helper in `values/utils.go` that builds Scheme external representations for fixed-size indexable collections
- Simplify `Vector.SchemeString()` and `ByteVector.SchemeString()` from ~15-line bodies to 3-line closures delegating to the helper
- Update TODO.md: mark SchemeString item done, close remaining 6 items with investigation notes, retitle section

## Test plan

- [x] `go test ./values/...` passes
- [x] `go test ./...` passes
- [x] `make lint` — 0 issues