### PR TITLE
chore: mark DUPLICATE_CODE_REFACTORING and GOCRITIC_FIXES plans complete

### DIFF
--- a/plans/DUPLICATE_CODE_REFACTORING.md
+++ b/plans/DUPLICATE_CODE_REFACTORING.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-The linter identified 39 duplicate code blocks across 6 packages. 13 have been eliminated (output port helpers, parity checks, integer division, variadic comparisons, optional position extraction, registry helpers). 24 numeric tower type-switch duplicates were closed as intentional architecture (see below). 2 remain actionable.
+The linter identified 39 duplicate code blocks across 6 packages. 13 have been eliminated (output port helpers, parity checks, integer division, variadic comparisons, optional position extraction, registry helpers). 24 numeric tower type-switch duplicates were closed as intentional architecture (see below). 2 match package VM loop duplicates were eliminated by delegating `MatchSyntax` to `MatchSyntaxWithLiterals` (PR #157).
 
 ## Closed: Numeric Tower Type Switch Duplicates (24 duplicates)
 

--- a/plans/GOCRITIC_FIXES.md
+++ b/plans/GOCRITIC_FIXES.md
@@ -1,27 +1,21 @@
 # gocritic Linter Fixes
 
-**Status**: In Progress
+**Status**: Complete
 **Created**: 2026-01-31
 **Last Updated**: 2026-02-09
 **Initial Issues**: 50 gocritic warnings
-**Remaining Issues**: 19 (all ifElseChain)
-**Eliminated**: 31 warnings (62% reduction)
+**Remaining Issues**: 0
+**Eliminated**: 31 warnings fixed explicitly (62%), 19 ifElseChain warnings resolved by subsequent refactoring
 
 ## Overview
 
-The linter identified 50 gocritic warnings. 31 have been fixed across 8 categories (deferInLoop, evalOrder, sprintfQuotedString, appendCombine, underef, sloppyTypeAssert, singleCaseSwitch, deprecatedComment). 19 remain, all ifElseChain warnings.
+The linter identified 50 gocritic warnings. 31 were fixed across 8 categories (deferInLoop, evalOrder, sprintfQuotedString, appendCombine, underef, sloppyTypeAssert, singleCaseSwitch, deprecatedComment). The remaining 19 ifElseChain warnings were resolved by subsequent refactoring: golangci-lint v2.7.2 with gocritic ifElseChain enabled reports 0 warnings.
 
-## Remaining: ifElseChain (19 warnings)
+## Closed: ifElseChain (19 warnings)
 
-**Issue**: Long if-else-if chains that could be switch statements.
+**Status**: Resolved — no longer reported by linter
 
-**Locations**:
-- Production: `go/extensions/gointerop/prim_gointerop.go:98`, `go/extensions/math/prim_math.go:1332`, `go/match/match.go:287,517,721`, `go/tokenizer/tokenizer.go:1741`, `go/values/array_list.go:65`, `go/values/pair.go:255`
-- Test: `go/parser/parser_test.go:1843,1852,2283,2336`, `go/registry/core/prim_identifier_test.go:161`, `go/values/numeric_tower_coverage_test.go:105,131,157,183,242,293`
-
-**Approach**: Review each case individually. Some if-else chains are clearer than switch (e.g., type checks with different operations). Only convert where switch improves readability.
-
-**Impact**: Case-by-case analysis needed. Some conversions improve clarity, others may not.
+The 19 ifElseChain warnings listed in the original plan are no longer flagged by gocritic (golangci-lint v2.7.2). Verified 2026-02-09 with ifElseChain explicitly enabled. The warnings were eliminated by refactoring that occurred across multiple PRs (match package dedup, subsystem simplification, etc.).
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Fix stale text in `DUPLICATE_CODE_REFACTORING.md` that said "2 remain actionable" when all 39/39 are resolved (match package dedup landed in PR #157)
- Close `GOCRITIC_FIXES.md` — all 19 ifElseChain warnings are gone, verified with golangci-lint v2.7.2 with ifElseChain explicitly enabled (0 warnings)

## Test plan

- No code changes, plan files only