### PR TITLE
fix: flaky TestMutexAbandonedOnTermination

### DIFF
--- a/internal/extensions/threads/prim_threads_test.go
+++ b/internal/extensions/threads/prim_threads_test.go
@@ -693,9 +693,12 @@ func TestMutexAbandonedOnTermination(t *testing.T) {
 			               ;; sleep to keep thread alive while we terminate it
 			               (thread-sleep! 10)))))
 			   (thread-start! t)
-			   ;; Give the thread time to acquire the mutex
-			   (thread-sleep! 0)
-			   (thread-yield!)
+			   ;; Wait until the child thread actually acquires the mutex.
+			   ;; mutex-state returns the owner thread (not a symbol) when locked.
+			   (let wait ()
+			     (when (symbol? (mutex-state m))
+			       (thread-yield!)
+			       (wait)))
 			   (thread-terminate! t)
 			   ;; The mutex should be abandoned
 			   (let ((state (mutex-state m)))


### PR DESCRIPTION
## Summary

- Replace timing-based `(thread-sleep! 0) (thread-yield!)` with a named-let polling loop that waits until `mutex-state` returns the owner thread object (not a symbol), ensuring the child thread has actually acquired the mutex before `thread-terminate!` runs.

## Test plan

- [x] `go test -run TestMutexAbandonedOnTermination -count=100` — 100/100 passes
- [x] Full threads test suite passes
- [x] `make lint` — 0 issues