### PR TITLE
refactor: add RequireIndex helper, migrate 6 ref/set call sites

### DIFF
--- a/plans/CODE_CONSOLIDATION_ARCHITECTURAL.md
+++ b/plans/CODE_CONSOLIDATION_ARCHITECTURAL.md
@@ -1,88 +1,45 @@
 # Higher-Risk Architectural Consolidation Plan
 
-**Status:** PARTIALLY COMPLETE — Indexable interface and numeric predicates done; generic helpers and operation codegen remain
+**Status:** MOSTLY COMPLETE — Indexable ref/set consolidated via `RequireIndex`, numeric predicates done, EqualTo done; operation codegen remains optional
 
 ## Executive Summary
 
 This document explores higher-risk architectural changes that could save significantly more code than the low-risk helpers approach. These changes involve introducing new abstractions, interfaces, or code generation that would require more extensive testing and carry higher implementation risk.
 
-**Estimated remaining savings: ~4,200-7,200 bytes**
-**Risk level: MEDIUM to HIGH**
-**Recommended approach: Implement incrementally with comprehensive testing**
+**All recommended changes complete.** Optional remaining savings: ~2,700 bytes (operation code generation — HIGH risk).
+**Recommended approach: No further action unless operation boilerplate becomes a maintenance burden.**
 
 ---
 
-## Architectural Change 1: Indexable Container Generic Helpers ⚠️ PARTIALLY COMPLETE
+## Architectural Change 1: Index Extraction Consolidation ✅ COMPLETE
 
-**Risk: MEDIUM**
-**Estimated remaining savings: ~800 bytes**
-**Files affected: 3 primitive files, 1 new helper file**
+**Risk: LOW**
+**Savings: ~100 bytes across 6 call sites**
 
-### Current State
+### Decision
 
-The `Indexable` interface **already exists** in `values/values.go`:
+The original proposal was to create `registry/helpers/indexable.go` with generic helpers consuming the `Indexable` interface. This was **rejected** in favor of `RequireIndex` — a simpler approach that consolidates at the argument-extraction level rather than the container-dispatch level.
 
-```go
-type Indexable interface {
-    Value
-    Length() int
-    Get(int) Value
-    Set(int, Value)
-}
-```
+**Why `RequireIndex` over `Indexable` helpers:**
 
-**Implementors**: `Vector` and `ByteVector` implement `Indexable` (verified via compile-time assertions in their respective files).
+1. **Different error sentinels**: Vector uses `ErrNotAVector`, ByteVector uses `ErrNotAByteVector`, String uses `ErrNotAString`. A generic `IndexableRef` would need the sentinel passed in, making it no simpler than the current per-type code.
+2. **Different value semantics**: ByteVector ref returns `NewInteger(int64(byte))`, Vector ref returns the element directly, String ref returns `NewCharacter(rune)`. The post-extraction logic differs per type.
+3. **String doesn't implement `Indexable`**: String's mutation method is `SetChar(int, rune)`, not `Set(int, Value)`, so it can't participate in generic helpers anyway.
+4. **The real duplication was in index extraction**: All 6 ref/set sites repeated the same "extract integer, validate bounds" pattern. `RequireIndex` eliminates that.
 
-**String does NOT implement `Indexable`**: String has `Get()` and `Length()` but its mutation method is `SetChar(int, rune)`, not `Set(int, Value)`. This is a deliberate type safety decision — string mutation requires a `Character`, not an arbitrary `Value`.
+### What Was Done
 
-### Remaining Problem
+`RequireIndex` in `registry/helpers/args.go` combines:
+- Exact integer extraction via `values.ExactInteger` (accepts `*Integer`, `*BigInteger`, integer-valued `*Rational`)
+- Bounds checking via `CheckIndexBounds`
+- Conversion to Go `int`
 
-The interface exists but no generic helpers consume it. Three sets of `*-length`, `*-ref`, `*-set!` primitives are still separate hand-written functions with identical structure:
+Migrated 6 call sites:
+- `PrimVectorRef`, `PrimVectorSet` (prim_vectors.go)
+- `PrimBytevectorU8Ref`, `PrimBytevectorU8Set` (prim_byte_vectors.go)
+- `PrimStringRef`, `PrimStringSet` (prim_strings.go)
 
-| Operation | Vector (`prim_vectors.go`) | ByteVector (`prim_byte_vectors.go`) |
-|-----------|---------------------------|-------------------------------------|
-| length | `PrimVectorLength` (~7 lines) | `PrimBytevectorLength` (~7 lines) |
-| ref | `PrimVectorRef` (~14 lines) | `PrimBytevectorU8Ref` (~12 lines) |
-| set! | `PrimVectorSet` (~15 lines) | `PrimBytevectorU8Set` (~16 lines) |
-
-String primitives remain separate due to different mutation semantics.
-
-### Proposed Solution
-
-Create `registry/helpers/indexable.go` with generic helpers that operate on the existing `Indexable` interface:
-
-```go
-// IndexableLength implements the length operation for Vector and ByteVector.
-func IndexableLength(mc *machine.MachineContext, sentinel error, name string) error {
-    container, err := RequireArg[values.Indexable](mc, 0, sentinel, name)
-    if err != nil {
-        return err
-    }
-    mc.SetValue(values.NewInteger(int64(container.Length())))
-    return nil
-}
-```
-
-This consolidates Vector + ByteVector operations (2 types × 3 ops = 6 functions → 3 generic functions + 3 string-specific functions).
-
-### Files to Create/Modify
-
-| File | Action |
-|------|--------|
-| `registry/helpers/indexable.go` | Create generic helpers (~50 lines) |
-| `registry/core/prim_vectors.go` | Simplify length/ref/set (~36 lines removed) |
-| `registry/core/prim_byte_vectors.go` | Simplify length/ref/set (~35 lines removed) |
-
-**Note**: `prim_strings.go` retains its own implementations due to String's different mutation semantics.
-
-**Net change**: +50 lines infrastructure, -71 lines primitives = ~21 lines saved, plus guaranteed behavioral consistency between Vector and ByteVector operations.
-
-### Risks and Mitigations
-
-| Risk | Mitigation |
-|------|------------|
-| Performance overhead from interface dispatch | Go interface dispatch is fast; profile if concerned |
-| ByteVector byte-range validation on set | Validation stays in `ByteVector.Set()` method |
+R7RS improvement: `RequireIndex` accepts any exact integer, not just `*Integer`. This is more correct per R7RS §6.1 (indices are "exact non-negative integers").
 
 ---
 
@@ -203,17 +160,13 @@ This is minimal — 3 lines per primitive. Declarative registration would save t
 
 ## Implementation Roadmap
 
-### Phase A: Indexable Generic Helpers (MEDIUM risk)
+### ~~Phase A: Indexable Generic Helpers~~ — SUPERSEDED by `RequireIndex`
 
-1. Create `registry/helpers/indexable.go` with generic helpers consuming existing `Indexable` interface
-2. Migrate Vector length/ref/set to use generic helpers
-3. Migrate ByteVector length/ref/set to use generic helpers
-4. String primitives remain as-is (different mutation semantics)
-5. Comprehensive testing after each type
+See Architectural Change 1 above. The real duplication was in index extraction, not in container dispatch. `RequireIndex` solved it with less abstraction overhead.
 
-### Phase B: Operation EqualTo Migration (LOW risk)
+### Phase B: Operation EqualTo Migration ✅ COMPLETE
 
-**See CODE_CONSOLIDATION_PLAN.md Phase 6** — helpers already exist in `operation_helpers.go`. This is a mechanical migration of 30 files.
+**See CODE_CONSOLIDATION_PLAN.md Phase 6** — all 34 operations migrated to `sameType`/`fieldMatches`/`fieldMethodMatches`/`sliceMatches`.
 
 ### Phase C: Operation Code Generation (HIGH risk — optional)
 
@@ -233,13 +186,13 @@ This is minimal — 3 lines per primitive. Declarative registration would save t
 
 | Change | Risk | Savings | Status |
 |--------|------|---------|--------|
-| Indexable generic helpers | MEDIUM | ~800 bytes | **Interface exists, helpers needed** |
+| Index extraction consolidation | LOW | ~100 bytes | **✅ COMPLETE** — `RequireIndex` (superseded Indexable approach) |
 | Operation EqualTo migration | LOW | ~300 bytes | **✅ COMPLETE** |
 | Numeric predicate methods | MEDIUM | ~800 bytes | **✅ COMPLETE** |
 | Operation code generation | HIGH | ~2,700 bytes | Not started (optional) |
 | Declarative primitives | HIGH | ~2,000 bytes | **DEFERRED** — `RequireArg[T]` reduced need |
 
-**Remaining recommended savings: ~1,100 bytes** (Indexable helpers + EqualTo migration)
+**Remaining recommended savings: 0 bytes** — all recommended changes complete
 **Optional additional savings: ~2,700 bytes** (operation code generation)
 
 ---
@@ -262,9 +215,7 @@ For each architectural change:
 
 ### New Files to Create
 
-| File | Purpose | Lines |
-|------|---------|-------|
-| `registry/helpers/indexable.go` | Generic helpers for `Indexable` interface | ~50 |
+None — all consolidation was achieved through additions to existing files.
 
 ### Already Existing Infrastructure
 
@@ -274,12 +225,14 @@ For each architectural change:
 | `values/vector.go` | `Indexable` implementation |
 | `values/byte_vector.go` | `Indexable` implementation |
 | `machine/operation_helpers.go` | `sameType[T]`, `fieldMatches[T, Op]` |
-| `registry/helpers/args.go` | `RequireArg[T]`, `ParseOptionalStartEnd` |
+| `registry/helpers/args.go` | `RequireArg[T]`, `RequireIndex`, `ParseOptionalStartEnd`, `ParseSubrange` |
 
-### Files to Modify
+### Files Modified
 
 | File | Change |
 |------|--------|
-| `registry/core/prim_vectors.go` | Use Indexable helpers for length/ref/set |
-| `registry/core/prim_byte_vectors.go` | Use Indexable helpers for length/ref/set |
+| `registry/helpers/args.go` | Added `RequireIndex` helper |
+| `registry/core/prim_vectors.go` | `PrimVectorRef`, `PrimVectorSet` use `RequireIndex` |
+| `registry/core/prim_byte_vectors.go` | `PrimBytevectorU8Ref`, `PrimBytevectorU8Set` use `RequireIndex` |
+| `registry/core/prim_strings.go` | `PrimStringRef`, `PrimStringSet` use `RequireIndex` |
 | 30× `machine/operation_*.go` | Use `sameType` / `fieldMatches` for EqualTo |

--- a/plans/CODE_CONSOLIDATION_PLAN.md
+++ b/plans/CODE_CONSOLIDATION_PLAN.md
@@ -1,6 +1,6 @@
 # Code Consolidation Plan: Reducing Code Volume Through Parameterization
 
-**Status:** IN PROGRESS — Phases 2 and 4 partially complete via `RequireArg[T]` and `ParseOptionalStartEnd`
+**Status:** COMPLETE — All 6 phases implemented
 
 ## Executive Summary
 
@@ -16,12 +16,12 @@ This plan identifies opportunities to reduce code volume in the Wile Scheme inte
 
 | Area | Potential Savings | Risk | Status |
 |------|------------------|------|--------|
-| Primitive type extraction | ~2,000 bytes | LOW | **IN PROGRESS** — `RequireArg[T]` exists, 54/260 sites migrated |
+| Primitive type extraction | ~2,000 bytes | LOW | **✅ COMPLETE** — `RequireArg[T]` + `RequireIndex` |
 | Optional argument parsing | ~650 bytes | LOW | **✅ COMPLETE** — `ParseOptionalStartEnd` in `helpers/args.go` |
-| Compile-time execution pattern | ~400 bytes | MEDIUM | Not started |
-| Operation EqualTo helpers | ~300 bytes | LOW | **IN PROGRESS** — helpers exist, 30 ops need migration |
-| Duplicate math helpers | ~250 bytes | LOW | Not started |
-| Index bounds checking | ~100 bytes | LOW | Not started |
+| Compile-time execution pattern | ~400 bytes | MEDIUM | **✅ COMPLETE** — `expandCompileExecute` in `compile_helpers.go` |
+| Operation EqualTo helpers | ~300 bytes | LOW | **✅ COMPLETE** — all 34 ops migrated |
+| Duplicate math helpers | ~250 bytes | LOW | **✅ COMPLETE** |
+| Index bounds checking | ~100 bytes | LOW | **✅ COMPLETE** — `CheckIndexBounds` + `RequireIndex` |
 | Values arithmetic methods | ~1,600 bytes | HIGH | **Do not implement** |
 | IsVoid boilerplate | ~50 bytes | LOW | **Do not implement** (idiomatic Go) |
 
@@ -135,48 +135,29 @@ make lint
 
 ---
 
-## Phase 3: Index Bounds Checking Helper
+## Phase 3: Index Bounds Checking Helper ✅ COMPLETE
 
 **Savings**: ~100 bytes
 **Risk**: LOW
 
-### Problem
+### Status
 
-6 identical bounds-check patterns in ref/set operations:
+Implemented as two complementary helpers in `registry/helpers/args.go`:
 
-```go
-if idx.Value < 0 || idx.Value >= int64(len(*v)) {
-    return values.NewForeignError("string-ref: index out of bounds")
-}
-```
+1. **`CheckIndexBounds(idx int64, length int, name string) error`** — low-level bounds check
+2. **`RequireIndex(mc, argIdx, length, name) (int, error)`** — extracts exact integer index + bounds check in one call
 
-### Solution
+`RequireIndex` uses `values.ExactInteger` (accepts `*Integer`, `*BigInteger`, integer-valued `*Rational`)
+which is more R7RS-correct than the previous `RequireArg[*values.Integer]` (only accepted `*Integer`).
 
-Add to `registry/helpers/args.go`:
+### Files Modified
 
-```go
-// CheckIndexBounds validates that idx is in range [0, length).
-func CheckIndexBounds(idx int64, length int, name string) error {
-    if idx < 0 || idx >= int64(length) {
-        return values.WrapForeignErrorf(values.ErrIndexOutOfRange, "%s: index %d out of bounds for length %d", name, idx, length)
-    }
-    return nil
-}
-```
-
-### Files to Modify
-
-| File | Pattern |
-|------|---------|
-| `registry/core/prim_strings.go` | string-ref, string-set! |
-| `registry/core/prim_vectors.go` | vector-ref, vector-set! |
-| `registry/core/prim_byte_vectors.go` | bytevector-u8-ref, bytevector-u8-set! |
-
-### Verification
-
-```bash
-go test -v -run "TestPrimString|TestPrimVector|TestPrimByte" ./registry/core/...
-```
+| File | Change |
+|------|--------|
+| `registry/helpers/args.go` | Added `RequireIndex` (~15 lines) |
+| `registry/core/prim_vectors.go` | `PrimVectorRef`, `PrimVectorSet` use `RequireIndex` |
+| `registry/core/prim_byte_vectors.go` | `PrimBytevectorU8Ref`, `PrimBytevectorU8Set` use `RequireIndex` |
+| `registry/core/prim_strings.go` | `PrimStringRef`, `PrimStringSet` use `RequireIndex` |
 
 ---
 
@@ -193,64 +174,15 @@ No further work needed.
 
 ---
 
-## Phase 5: Compile-Time Execution Helper
+## Phase 5: Compile-Time Execution Helper ✅ COMPLETE
 
 **Savings**: ~400 bytes
 **Risk**: MEDIUM
 
-### Problem
+### Status
 
-3 files share identical 30-line expand-compile-execute pattern:
-
-| File | Form |
-|------|------|
-| `machine/compile_begin_for_syntax.go` | begin-for-syntax |
-| `machine/compile_define_for_syntax.go` | define-for-syntax |
-| `machine/compile_eval_when.go` | eval-when |
-
-Common pattern:
-```go
-expandEnv := p.env.Expand()
-ectx := NewExpandTimeCallContext()
-expander := NewExpanderTimeContinuation(p.env)
-
-expandedExpr, err := expander.ExpandExpression(ectx, stxVal)
-if err != nil {
-    return values.WrapForeignErrorf(err, "[form]: expansion failed")
-}
-
-tmpTpl := NewNativeTemplate(0, 0, false)
-tmpCcnt := NewCompiletimeContinuation(tmpTpl, expandEnv)
-err = tmpCcnt.CompileExpression(ctctx, expandedExpr)
-if err != nil {
-    return values.WrapForeignErrorf(err, "[form]: compilation failed")
-}
-
-cont := NewMachineContinuation(nil, tmpTpl, expandEnv)
-mc := NewMachineContext(context.Background(), cont)
-err = mc.Run()
-if err != nil {
-    return values.WrapForeignErrorf(err, "[form]: evaluation failed")
-}
-```
-
-### Solution
-
-Extract `ExecuteAtCompileTime` helper on `*CompileTimeContinuation`. Create in `machine/compile_helpers.go` or add to existing helpers file.
-
-### Files to Modify
-
-| File | Change |
-|------|--------|
-| `machine/compile_begin_for_syntax.go` | Replace expand-compile-execute block with helper call |
-| `machine/compile_define_for_syntax.go` | Replace expand-compile-execute block with helper call |
-| `machine/compile_eval_when.go` | Replace expand-compile-execute block with helper call |
-
-### Verification
-
-```bash
-go test -v -run "TestMacro|TestSyntax|TestBeginForSyntax|TestDefineForSyntax|TestEvalWhen" ./machine/...
-```
+Implemented as `expandCompileExecute` on `*CompileTimeContinuation` in `machine/compile_helpers.go`.
+All 3 call sites (`begin-for-syntax`, `define-for-syntax`, `eval-when`) use the helper.
 
 ---
 
@@ -356,9 +288,9 @@ Already documented as a separate initiative in `plans/TOKENIZER_CONSOLIDATION_PL
 |-------|-------------|---------|------|--------|
 | 1 | Remove duplicate math helpers | 250 bytes | LOW | **✅ COMPLETE** |
 | 2 | `RequireArg[T]` migration | ~18 lines | LOW | **✅ COMPLETE** (67/67 convertible; see triage for non-convertible) |
-| 3 | Index bounds checking | 100 bytes | LOW | Not started |
+| 3 | Index bounds checking | 100 bytes | LOW | **✅ COMPLETE** — `CheckIndexBounds` + `RequireIndex` |
 | 4 | Optional start/end parser | 650 bytes | LOW | **✅ COMPLETE** |
-| 5 | Compile-time execution helper | 400 bytes | MEDIUM | Not started |
+| 5 | Compile-time execution helper | 400 bytes | MEDIUM | **✅ COMPLETE** — `expandCompileExecute` |
 | 6 | Operation EqualTo migration | 300 bytes | LOW | **✅ COMPLETE** |
 
 ---

--- a/registry/core/prim_byte_vectors.go
+++ b/registry/core/prim_byte_vectors.go
@@ -110,15 +110,11 @@ func PrimBytevectorU8Ref(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	idx, err := helpers.RequireArg[*values.Integer](mc, 1, values.ErrNotAnInteger, "bytevector-u8-ref")
+	idx, err := helpers.RequireIndex(mc, 1, bv.Length(), "bytevector-u8-ref")
 	if err != nil {
 		return err
 	}
-	err = helpers.CheckIndexBounds(idx.Value, len(*bv), "bytevector-u8-ref")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewInteger(int64((*bv)[idx.Value].Value)))
+	mc.SetValue(values.NewInteger(int64((*bv)[idx].Value)))
 	return nil
 }
 
@@ -129,23 +125,18 @@ func PrimBytevectorU8Set(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	idx, err := helpers.RequireArg[*values.Integer](mc, 1, values.ErrNotAnInteger, "bytevector-u8-set!")
+	idx, err := helpers.RequireIndex(mc, 1, bv.Length(), "bytevector-u8-set!")
 	if err != nil {
 		return err
 	}
-	obj := mc.Arg(2)
-	err = helpers.CheckIndexBounds(idx.Value, len(*bv), "bytevector-u8-set!")
-	if err != nil {
-		return err
-	}
-	byteVal, err := helpers.RequireType[*values.Integer](obj, values.ErrNotAnInteger, "bytevector-u8-set!")
+	byteVal, err := helpers.RequireType[*values.Integer](mc.Arg(2), values.ErrNotAnInteger, "bytevector-u8-set!")
 	if err != nil {
 		return err
 	}
 	if byteVal.Value < 0 || byteVal.Value > 255 {
 		return values.NewForeignError("bytevector-u8-set!: value must be a byte (0-255)")
 	}
-	(*bv)[idx.Value] = values.NewByte(uint8(byteVal.Value))
+	(*bv)[idx] = values.NewByte(uint8(byteVal.Value))
 	mc.SetValue(values.Void)
 	return nil
 }

--- a/registry/core/prim_strings.go
+++ b/registry/core/prim_strings.go
@@ -97,16 +97,12 @@ func PrimStringRef(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	idx, err := helpers.RequireArg[*values.Integer](mc, 1, values.ErrNotANumber, "string-ref")
-	if err != nil {
-		return err
-	}
 	runes := []rune(s.Value)
-	err = helpers.CheckIndexBounds(idx.Value, len(runes), "string-ref")
+	idx, err := helpers.RequireIndex(mc, 1, len(runes), "string-ref")
 	if err != nil {
 		return err
 	}
-	mc.SetValue(values.NewCharacter(runes[idx.Value]))
+	mc.SetValue(values.NewCharacter(runes[idx]))
 	return nil
 }
 
@@ -118,20 +114,15 @@ func PrimStringSet(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	idx, err := helpers.RequireArg[*values.Integer](mc, 1, values.ErrNotANumber, "string-set!")
-	if err != nil {
-		return err
-	}
 	char, err := helpers.RequireArg[*values.Character](mc, 2, values.ErrNotACharacter, "string-set!")
 	if err != nil {
 		return err
 	}
-	length := s.Len()
-	err = helpers.CheckIndexBounds(idx.Value, length, "string-set!")
+	idx, err := helpers.RequireIndex(mc, 1, s.Len(), "string-set!")
 	if err != nil {
 		return err
 	}
-	s.SetChar(int(idx.Value), char.Value)
+	s.SetChar(idx, char.Value)
 	mc.SetValue(values.Void)
 	return nil
 }

--- a/registry/core/prim_vectors.go
+++ b/registry/core/prim_vectors.go
@@ -72,16 +72,11 @@ func PrimVectorRef(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	k := mc.Arg(1)
-	idx, ok := values.ExactInteger(k)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotANumber, "vector-ref: expected an exact integer but got %T", k)
-	}
-	err = helpers.CheckIndexBounds(idx, len(*v), "vector-ref")
+	idx, err := helpers.RequireIndex(mc, 1, v.Length(), "vector-ref")
 	if err != nil {
 		return err
 	}
-	mc.SetValue((*v)[idx])
+	mc.SetValue(v.Get(idx))
 	return nil
 }
 
@@ -93,17 +88,11 @@ func PrimVectorSet(_ context.Context, mc *machine.MachineContext) error {
 	if err != nil {
 		return err
 	}
-	k := mc.Arg(1)
-	obj := mc.Arg(2)
-	idx, ok := values.ExactInteger(k)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotANumber, "vector-set!: expected an exact integer but got %T", k)
-	}
-	err = helpers.CheckIndexBounds(idx, len(*v), "vector-set!")
+	idx, err := helpers.RequireIndex(mc, 1, v.Length(), "vector-set!")
 	if err != nil {
 		return err
 	}
-	(*v)[idx] = obj
+	v.Set(idx, mc.Arg(2))
 	mc.SetValue(values.Void)
 	return nil
 }

--- a/registry/helpers/args.go
+++ b/registry/helpers/args.go
@@ -90,6 +90,24 @@ func CheckIndexBounds(idx int64, length int, name string) error {
 	return nil
 }
 
+// RequireIndex extracts an exact integer index from mc.Arg(argIdx) and validates
+// it is in range [0, length). Accepts *Integer, *BigInteger, and integer-valued
+// *Rational via values.ExactInteger, which is more R7RS-correct than requiring
+// *Integer alone (R7RS §6.1: indices are exact non-negative integers).
+func RequireIndex(mc *machine.MachineContext, argIdx int, length int, name string) (int, error) {
+	k := mc.Arg(argIdx)
+	idx, ok := values.ExactInteger(k)
+	if !ok {
+		return 0, values.WrapForeignErrorf(values.ErrNotAnInteger,
+			"%s: expected an exact integer index but got %s", name, k.SchemeString())
+	}
+	err := CheckIndexBounds(idx, length, name)
+	if err != nil {
+		return 0, err
+	}
+	return int(idx), nil
+}
+
 // ValidateStartEnd checks the invariant 0 <= start <= end <= length.
 // Returns a wrapped ErrIndexOutOfRange error if any bound is violated.
 func ValidateStartEnd(start, end, length int64, name string) error {


### PR DESCRIPTION
## Summary

- Add `RequireIndex` helper to `registry/helpers/args.go` — combines exact integer extraction + bounds checking in one call
- Migrate 6 ref/set primitives (`PrimVectorRef`, `PrimVectorSet`, `PrimBytevectorU8Ref`, `PrimBytevectorU8Set`, `PrimStringRef`, `PrimStringSet`) to use it
- More R7RS-correct: accepts `*BigInteger` and integer-valued `*Rational` via `values.ExactInteger`, not just `*Integer`
- Update both consolidation plans to mark all phases complete; supersede the Indexable generic helpers proposal

## Changes

- `registry/helpers/args.go` — new `RequireIndex(mc, argIdx, length, name) (int, error)`
- `registry/core/prim_vectors.go` — `PrimVectorRef`, `PrimVectorSet` simplified
- `registry/core/prim_byte_vectors.go` — `PrimBytevectorU8Ref`, `PrimBytevectorU8Set` simplified
- `registry/core/prim_strings.go` — `PrimStringRef`, `PrimStringSet` simplified
- `plans/CODE_CONSOLIDATION_PLAN.md` — all 6 phases marked COMPLETE
- `plans/CODE_CONSOLIDATION_ARCHITECTURAL.md` — Architectural Change 1 rewritten (Indexable approach superseded by RequireIndex)

Net: **-126 lines** (93 insertions, 219 deletions)

## Test plan

- [x] `make test` — all 25 packages pass
- [x] `make lint` — 0 issues
- [x] `go_diagnostics` — clean