### PR TITLE
refactor: extract generic sequence accessor helpers

### DIFF
--- a/registry/core/prim_byte_vectors.go
+++ b/registry/core/prim_byte_vectors.go
@@ -95,50 +95,35 @@ func PrimBytevector(ctx context.Context, mc *machine.MachineContext) error {
 // PrimBytevectorLength implements the bytevector-length primitive.
 // Returns length of bytevector.
 func PrimBytevectorLength(_ context.Context, mc *machine.MachineContext) error {
-	bv, err := helpers.RequireArg[*values.ByteVector](mc, 0, values.ErrNotAByteVector, "bytevector-length")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewInteger(int64(len(*bv))))
-	return nil
+	return helpers.SequenceLength[*values.ByteVector](mc, values.ErrNotAByteVector, "bytevector-length")
 }
 
 // PrimBytevectorU8Ref implements the bytevector-u8-ref primitive.
-// Returns byte at index.
+// Returns byte at index as an exact integer (R7RS §6.9).
 func PrimBytevectorU8Ref(_ context.Context, mc *machine.MachineContext) error {
-	bv, err := helpers.RequireArg[*values.ByteVector](mc, 0, values.ErrNotAByteVector, "bytevector-u8-ref")
-	if err != nil {
-		return err
-	}
-	idx, err := helpers.RequireIndex(mc, 1, bv.Length(), "bytevector-u8-ref")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewInteger(int64((*bv)[idx].Value)))
-	return nil
+	return helpers.SequenceRef(mc, values.ErrNotAByteVector, "bytevector-u8-ref",
+		func(bv *values.ByteVector, idx int) values.Value {
+			return values.NewInteger(int64((*bv)[idx].Value))
+		},
+	)
 }
 
 // PrimBytevectorU8Set implements the bytevector-u8-set! primitive.
 // Sets byte at index.
 func PrimBytevectorU8Set(_ context.Context, mc *machine.MachineContext) error {
-	bv, err := helpers.RequireArg[*values.ByteVector](mc, 0, values.ErrNotAByteVector, "bytevector-u8-set!")
-	if err != nil {
-		return err
-	}
-	idx, err := helpers.RequireIndex(mc, 1, bv.Length(), "bytevector-u8-set!")
-	if err != nil {
-		return err
-	}
-	byteVal, err := helpers.RequireType[*values.Integer](mc.Arg(2), values.ErrNotAnInteger, "bytevector-u8-set!")
-	if err != nil {
-		return err
-	}
-	if byteVal.Value < 0 || byteVal.Value > 255 {
-		return values.NewForeignError("bytevector-u8-set!: value must be a byte (0-255)")
-	}
-	(*bv)[idx] = values.NewByte(uint8(byteVal.Value))
-	mc.SetValue(values.Void)
-	return nil
+	return helpers.SequenceSet(mc, values.ErrNotAByteVector, "bytevector-u8-set!",
+		func(bv *values.ByteVector, idx int, mc *machine.MachineContext) error {
+			byteVal, err := helpers.RequireType[*values.Integer](mc.Arg(2), values.ErrNotAnInteger, "bytevector-u8-set!")
+			if err != nil {
+				return err
+			}
+			if byteVal.Value < 0 || byteVal.Value > 255 {
+				return values.NewForeignError("bytevector-u8-set!: value must be a byte (0-255)")
+			}
+			(*bv)[idx] = values.NewByte(uint8(byteVal.Value))
+			return nil
+		},
+	)
 }
 
 // PrimBytevectorCopy implements the bytevector-copy primitive.

--- a/registry/core/prim_vectors.go
+++ b/registry/core/prim_vectors.go
@@ -56,45 +56,28 @@ func PrimVector(_ context.Context, mc *machine.MachineContext) error {
 // PrimVectorLength implements the vector-length primitive.
 // Returns the number of elements in a vector as an integer.
 func PrimVectorLength(_ context.Context, mc *machine.MachineContext) error {
-	v, err := helpers.RequireArg[*values.Vector](mc, 0, values.ErrNotAVector, "vector-length")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewInteger(int64(len(*v))))
-	return nil
+	return helpers.SequenceLength[*values.Vector](mc, values.ErrNotAVector, "vector-length")
 }
 
 // PrimVectorRef implements the vector-ref primitive.
 // Returns the element of a vector at the given index.
 // R7RS §6.8: The index must be an exact non-negative integer.
 func PrimVectorRef(_ context.Context, mc *machine.MachineContext) error {
-	v, err := helpers.RequireArg[*values.Vector](mc, 0, values.ErrNotAVector, "vector-ref")
-	if err != nil {
-		return err
-	}
-	idx, err := helpers.RequireIndex(mc, 1, v.Length(), "vector-ref")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(v.Get(idx))
-	return nil
+	return helpers.SequenceRef(mc, values.ErrNotAVector, "vector-ref",
+		(*values.Vector).Get,
+	)
 }
 
 // PrimVectorSet implements the vector-set! primitive.
 // Sets the element of a vector at the given index to a new value.
 // R7RS §6.8: The index must be an exact non-negative integer.
 func PrimVectorSet(_ context.Context, mc *machine.MachineContext) error {
-	v, err := helpers.RequireArg[*values.Vector](mc, 0, values.ErrNotAVector, "vector-set!")
-	if err != nil {
-		return err
-	}
-	idx, err := helpers.RequireIndex(mc, 1, v.Length(), "vector-set!")
-	if err != nil {
-		return err
-	}
-	v.Set(idx, mc.Arg(2))
-	mc.SetValue(values.Void)
-	return nil
+	return helpers.SequenceSet(mc, values.ErrNotAVector, "vector-set!",
+		func(v *values.Vector, idx int, mc *machine.MachineContext) error {
+			v.Set(idx, mc.Arg(2))
+			return nil
+		},
+	)
 }
 
 // PrimVectorToList implements the vector->list primitive.

--- a/registry/helpers/doc.go
+++ b/registry/helpers/doc.go
@@ -36,6 +36,12 @@
 //   - [ComplexOrFloat]: return Float if imaginary part is zero
 //   - [MakeTypePredicate]: factory for type predicate primitives
 //
+// # Sequence Accessors
+//
+//   - [SequenceLength]: generic length for Vector/ByteVector
+//   - [SequenceRef]: generic indexed read with element conversion closure
+//   - [SequenceSet]: generic indexed mutation with element setter closure
+//
 // # List Operations
 //
 //   - [ListToVector]: convert list to vector

--- a/registry/helpers/sequence.go
+++ b/registry/helpers/sequence.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"github.com/aalpar/wile/machine"
+	"github.com/aalpar/wile/values"
+)
+
+// SequenceLength extracts a sequence of type T from arg 0, and sets
+// the machine context value to its length as an exact integer.
+// T must be a pointer type satisfying interface{ Length() int }.
+func SequenceLength[T interface{ Length() int }](
+	mc *machine.MachineContext,
+	sentinel error,
+	name string,
+) error {
+	seq, err := RequireArg[T](mc, 0, sentinel, name)
+	if err != nil {
+		return err
+	}
+	mc.SetValue(values.NewInteger(int64(seq.Length())))
+	return nil
+}
+
+// SequenceRef extracts a sequence of type T from arg 0, validates an
+// exact integer index from arg 1, and sets the machine context value
+// to getElement(seq, idx). The getElement closure handles type-specific
+// element retrieval (e.g., Vector.Get vs ByteVector byte-to-integer conversion).
+func SequenceRef[T interface{ Length() int }](
+	mc *machine.MachineContext,
+	sentinel error,
+	name string,
+	getElement func(T, int) values.Value,
+) error {
+	seq, err := RequireArg[T](mc, 0, sentinel, name)
+	if err != nil {
+		return err
+	}
+	idx, err := RequireIndex(mc, 1, seq.Length(), name)
+	if err != nil {
+		return err
+	}
+	mc.SetValue(getElement(seq, idx))
+	return nil
+}
+
+// SequenceSet extracts a sequence of type T from arg 0, validates an
+// exact integer index from arg 1, and delegates to setElement(seq, idx, mc)
+// for the type-specific mutation. Sets Void on success.
+func SequenceSet[T interface{ Length() int }](
+	mc *machine.MachineContext,
+	sentinel error,
+	name string,
+	setElement func(T, int, *machine.MachineContext) error,
+) error {
+	seq, err := RequireArg[T](mc, 0, sentinel, name)
+	if err != nil {
+		return err
+	}
+	idx, err := RequireIndex(mc, 1, seq.Length(), name)
+	if err != nil {
+		return err
+	}
+	err = setElement(seq, idx, mc)
+	if err != nil {
+		return err
+	}
+	mc.SetValue(values.Void)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `SequenceLength`, `SequenceRef`, `SequenceSet` generics in `registry/helpers/sequence.go` to consolidate the repeated extract-sequence → validate-index → operate pattern
- Refactor 6 primitives (`vector-length`, `vector-ref`, `vector-set!`, `bytevector-length`, `bytevector-u8-ref`, `bytevector-u8-set!`) to delegate to the generics with type-specific closures
- Normalize Vector length to use `Length()` instead of `len(*v)`, picking up the Void guard consistently
- Update `doc.go` package comment with new Sequence Accessors section

## Test plan
- [x] `go build ./...` compiles
- [x] `make lint` — 0 issues
- [x] `go test ./registry/helpers/...` passes
- [x] `go test ./registry/core/...` — all vector and bytevector tests pass
- [x] `go test ./...` — full suite passes