### PR TITLE
fix: remove dangling comment from deleted isDefineSyntaxSyntax

### DIFF
--- a/machine/expander_time_continuation.go
+++ b/machine/expander_time_continuation.go
@@ -1023,8 +1023,6 @@ func (p *ExpanderTimeContinuation) ExpandBodyWithDefineSyntax(
 	return result, nil
 }
 
-// isDefineSyntaxSyntax checks if a syntax value is a define-syntax form.
-
 // compileDefineSyntaxFromSyntax compiles a define-syntax form and stores the transformer
 // in the expand environment.
 //


### PR DESCRIPTION
## Summary

- Remove orphaned doc comment `// isDefineSyntaxSyntax checks if a syntax value is a define-syntax form.` left behind when the function was deleted in #170

Caught by Copilot review on #170.