### PR TITLE
fix: address architectural review findings across numeric tower, tokenizer, and VM

### DIFF
--- a/internal/extensions/io/prim_read_write.go
+++ b/internal/extensions/io/prim_read_write.go
@@ -51,6 +51,70 @@ func getOptionalOutputPort(mc *machine.MachineContext, argIndex int) (values.Out
 	return p, nil
 }
 
+// getOptionalInputPort extracts an optional input port from a variadic argument list.
+// If the list is empty, returns the current input port.
+// Otherwise, extracts and validates the port from the list's car.
+func getOptionalInputPort(mc *machine.MachineContext, argIndex int) (values.TextualReader, error) {
+	o := mc.Arg(argIndex)
+	tuple, ok := o.(values.Tuple)
+	if !ok {
+		return nil, values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %T", o)
+	}
+	if !tuple.IsList() {
+		return nil, values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %s", tuple.SchemeString())
+	}
+	if tuple.IsEmptyList() {
+		return GetCurrentInputPort(), nil
+	}
+	p, ok := tuple.Car().(values.TextualReader)
+	if !ok {
+		return nil, values.WrapForeignErrorf(values.ErrNotAnInputPort, "expected an input port but got %T", tuple.Car())
+	}
+	return p, nil
+}
+
+// getRequiredBinaryInputPort extracts a required binary input port from a variadic argument list.
+// Returns an error if the list is empty (no default port for binary I/O).
+// Also returns the validated tuple for callers that need to extract further arguments.
+func getRequiredBinaryInputPort(o values.Value, name string) (values.BinaryReader, values.Tuple, error) {
+	tuple, ok := o.(values.Tuple)
+	if !ok {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %T", name, o)
+	}
+	if !tuple.IsList() {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %s", name, tuple.SchemeString())
+	}
+	if tuple.IsEmptyList() {
+		return nil, nil, values.NewForeignError(name + ": no binary input port specified")
+	}
+	p, ok := tuple.Car().(values.BinaryReader)
+	if !ok {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAnInputPort, "%s: expected a binary input port but got %T", name, tuple.Car())
+	}
+	return p, tuple, nil
+}
+
+// getRequiredBinaryOutputPort extracts a required binary output port from a variadic argument list.
+// Returns an error if the list is empty (no default port for binary I/O).
+// Also returns the validated tuple for callers that need to extract further arguments.
+func getRequiredBinaryOutputPort(o values.Value, name string) (values.BinaryWriter, values.Tuple, error) {
+	tuple, ok := o.(values.Tuple)
+	if !ok {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %T", name, o)
+	}
+	if !tuple.IsList() {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %s", name, tuple.SchemeString())
+	}
+	if tuple.IsEmptyList() {
+		return nil, nil, values.NewForeignError(name + ": no binary output port specified")
+	}
+	p, ok := tuple.Car().(values.BinaryWriter)
+	if !ok {
+		return nil, nil, values.WrapForeignErrorf(values.ErrNotAnOutputPort, "%s: expected a binary output port but got %T", name, tuple.Car())
+	}
+	return p, tuple, nil
+}
+
 // extractOptionalPositions extracts optional start and end positions from a tuple.
 // The tuple is expected to contain [start [end]] as integers.
 // Returns the extracted start and end values, or the provided defaults if not present.
@@ -94,25 +158,9 @@ func extractOptionalPositions(tuple values.Tuple, defaultStart, defaultEnd int64
 // Reads from the current input port if no port is specified.
 // R7RS §6.13.2: read uses datum labels to handle circular and shared structures.
 func PrimRead(ctx context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %s", tuple.SchemeString())
-	}
-
-	// Get the port to read from
-	var port values.TextualReader
-	if tuple.IsEmptyList() {
-		port = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "expected an input port but got %T", tuple.Car())
-		}
-		port = p
+	port, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	prss, ok := Parsers[port]
@@ -142,25 +190,9 @@ func PrimRead(ctx context.Context, mc *machine.MachineContext) error {
 // Reads a single token from port.
 // Reads from the current input port if no port is specified.
 func PrimReadToken(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %s", tuple.SchemeString())
-	}
-
-	// Get the port to read from
-	var port values.TextualReader
-	if tuple.IsEmptyList() {
-		port = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "expected an input port but got %T", tuple.Car())
-		}
-		port = p
+	port, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	tknz, ok := Tokenizers[port]
@@ -187,25 +219,9 @@ func PrimReadToken(_ context.Context, mc *machine.MachineContext) error {
 // Reads datum with source information.
 // Reads from the current input port if no port is specified.
 func PrimReadSyntax(ctx context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %s", tuple.SchemeString())
-	}
-
-	// Get the port to read from
-	var port values.TextualReader
-	if tuple.IsEmptyList() {
-		port = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "expected an input port but got %T", tuple.Car())
-		}
-		port = p
+	port, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	// Get or create a parser if one does not exist
@@ -313,25 +329,11 @@ func PrimDisplay(_ context.Context, mc *machine.MachineContext) error {
 // PrimNewline implements the newline primitive.
 // Writes a newline character to the output port.
 func PrimNewline(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %T", o)
+	writer, err := getOptionalOutputPort(mc, 0)
+	if err != nil {
+		return err
 	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "expected a list but got %s", tuple.SchemeString())
-	}
-	var writer values.OutputPort
-	if tuple.IsEmptyList() {
-		writer = GetCurrentOutputPort()
-	} else {
-		p, ok := tuple.Car().(values.OutputPort)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnOutputPort, "expected an output port but got %T", tuple.Car())
-		}
-		writer = p
-	}
-	_, err := writer.Write([]byte("\n"))
+	_, err = writer.Write([]byte("\n"))
 	if err != nil {
 		return values.WrapForeignErrorf(err, "error writing newline to output port")
 	}
@@ -349,25 +351,11 @@ func PrimNewline(_ context.Context, mc *machine.MachineContext) error {
 // (write-simple obj) or (write-simple obj port)
 func PrimWriteSimple(_ context.Context, mc *machine.MachineContext) error {
 	obj := mc.Arg(0)
-	o := mc.Arg(1)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-simple: expected a list but got %T", o)
+	writer, err := getOptionalOutputPort(mc, 1)
+	if err != nil {
+		return err
 	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-simple: expected a list but got %s", tuple.SchemeString())
-	}
-	var writer values.OutputPort
-	if tuple.IsEmptyList() {
-		writer = GetCurrentOutputPort()
-	} else {
-		p, ok := tuple.Car().(values.OutputPort)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnOutputPort, "write-simple: expected an output port but got %T", tuple.Car())
-		}
-		writer = p
-	}
-	_, err := writer.Write([]byte(obj.SchemeString()))
+	_, err = writer.Write([]byte(obj.SchemeString()))
 	if err != nil {
 		return values.WrapForeignErrorf(err, "write-simple: error writing to output port")
 	}
@@ -408,24 +396,9 @@ func PrimWriteShared(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.2: (read-char [port])
 // Reads and returns a single character from the input port.
 func PrimReadChar(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-char: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-char: expected a list but got %s", tuple.SchemeString())
-	}
-
-	var reader values.TextualReader
-	if tuple.IsEmptyList() {
-		reader = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-char: expected an input port but got %T", tuple.Car())
-		}
-		reader = p
+	reader, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	r, _, err := reader.ReadRune()
@@ -444,24 +417,9 @@ func PrimReadChar(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.2: (peek-char [port])
 // Reads and returns a single character from the input port without consuming it.
 func PrimPeekChar(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "peek-char: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "peek-char: expected a list but got %s", tuple.SchemeString())
-	}
-
-	var reader values.TextualReader
-	if tuple.IsEmptyList() {
-		reader = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "peek-char: expected an input port but got %T", tuple.Car())
-		}
-		reader = p
+	reader, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	r, _, err := reader.ReadRune()
@@ -485,24 +443,9 @@ func PrimPeekChar(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.2: (read-line [port])
 // Reads a line of text from the input port, not including the line ending.
 func PrimReadLine(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-line: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-line: expected a list but got %s", tuple.SchemeString())
-	}
-
-	var reader values.TextualReader
-	if tuple.IsEmptyList() {
-		reader = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-line: expected an input port but got %T", tuple.Car())
-		}
-		reader = p
+	reader, err := getOptionalInputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
 	var line []rune
@@ -551,8 +494,6 @@ func PrimCharReadyQ(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.2: (read-string k [port])
 // Reads up to k characters from the input port and returns them as a string.
 func PrimReadString(_ context.Context, mc *machine.MachineContext) error {
-	rest := mc.Arg(1)
-
 	k, err := helpers.RequireArg[*values.Integer](mc, 0, values.ErrNotANumber, "read-string")
 	if err != nil {
 		return err
@@ -561,24 +502,9 @@ func PrimReadString(_ context.Context, mc *machine.MachineContext) error {
 		return values.NewForeignError("read-string: k must be non-negative")
 	}
 
-	// Get the port from rest arguments
-	tuple, ok := rest.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-string: expected a list but got %T", rest)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-string: expected a list but got %s", tuple.SchemeString())
-	}
-
-	var reader values.TextualReader
-	if tuple.IsEmptyList() {
-		reader = GetCurrentInputPort()
-	} else {
-		p, ok := tuple.Car().(values.TextualReader)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-string: expected an input port but got %T", tuple.Car())
-		}
-		reader = p
+	reader, err := getOptionalInputPort(mc, 1)
+	if err != nil {
+		return err
 	}
 
 	// Read up to k characters
@@ -687,7 +613,6 @@ func PrimWriteString(_ context.Context, mc *machine.MachineContext) error {
 // Writes byte to the given binary output port and returns an unspecified value.
 func PrimWriteU8(_ context.Context, mc *machine.MachineContext) error {
 	byteVal := mc.Arg(0)
-	rest := mc.Arg(1)
 
 	// Validate byte argument (must be exact integer 0-255)
 	var b byte
@@ -701,27 +626,11 @@ func PrimWriteU8(_ context.Context, mc *machine.MachineContext) error {
 		return values.WrapForeignErrorf(values.ErrNotANumber, "write-u8: expected an exact integer but got %T", byteVal)
 	}
 
-	// Get the port from rest arguments
-	tuple, ok := rest.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-u8: expected a list but got %T", rest)
+	p, _, err := getRequiredBinaryOutputPort(mc.Arg(1), "write-u8")
+	if err != nil {
+		return err
 	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-u8: expected a list but got %s", tuple.SchemeString())
-	}
-
-	// WriteByte to the appropriate port
-	if tuple.IsEmptyList() {
-		// Default to current output port - but write-u8 requires a binary port
-		return values.NewForeignError("write-u8: no binary output port specified")
-	}
-
-	port := tuple.Car()
-	p, ok := port.(values.BinaryWriter)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAnOutputPort, "write-u8: expected a binary output port but got %T", port)
-	}
-	err := p.WriteByte(b)
+	err = p.WriteByte(b)
 	if err != nil {
 		return values.WrapForeignErrorf(err, "write-u8: error writing byte")
 	}
@@ -735,23 +644,9 @@ func PrimWriteU8(_ context.Context, mc *machine.MachineContext) error {
 // Reads the next byte from the given binary input port and returns it as an exact integer.
 // Returns eof-object at end of file.
 func PrimReadU8(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-u8: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-u8: expected a list but got %s", tuple.SchemeString())
-	}
-
-	if tuple.IsEmptyList() {
-		return values.NewForeignError("read-u8: no binary input port specified")
-	}
-
-	port := tuple.Car()
-	p, ok := port.(values.BinaryReader)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-u8: expected a binary input port but got %T", port)
+	p, _, err := getRequiredBinaryInputPort(mc.Arg(0), "read-u8")
+	if err != nil {
+		return err
 	}
 	b, err := p.ReadByte()
 	if errors.Is(err, io.EOF) {
@@ -770,23 +665,9 @@ func PrimReadU8(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.3: (peek-u8 [port])
 // Like read-u8, but does not consume the byte from the port.
 func PrimPeekU8(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "peek-u8: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "peek-u8: expected a list but got %s", tuple.SchemeString())
-	}
-
-	if tuple.IsEmptyList() {
-		return values.NewForeignError("peek-u8: no binary input port specified")
-	}
-
-	port := tuple.Car()
-	p, ok := port.(values.BinaryReader)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAnInputPort, "peek-u8: expected a binary input port but got %T", port)
+	p, _, err := getRequiredBinaryInputPort(mc.Arg(0), "peek-u8")
+	if err != nil {
+		return err
 	}
 	b, err := p.ReadByte()
 	if errors.Is(err, io.EOF) {
@@ -821,8 +702,6 @@ func PrimU8ReadyQ(_ context.Context, mc *machine.MachineContext) error {
 // Reads the next k bytes from port into a newly allocated bytevector.
 // Returns eof-object if no bytes are available before end of file.
 func PrimReadBytevector(_ context.Context, mc *machine.MachineContext) error {
-	rest := mc.Arg(1)
-
 	k, err := helpers.RequireArg[*values.Integer](mc, 0, values.ErrNotANumber, "read-bytevector")
 	if err != nil {
 		return err
@@ -831,23 +710,9 @@ func PrimReadBytevector(_ context.Context, mc *machine.MachineContext) error {
 		return values.NewForeignError("read-bytevector: k must be non-negative")
 	}
 
-	// Get the port from rest arguments
-	tuple, ok := rest.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-bytevector: expected a list but got %T", rest)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-bytevector: expected a list but got %s", tuple.SchemeString())
-	}
-
-	if tuple.IsEmptyList() {
-		return values.NewForeignError("read-bytevector: no binary input port specified")
-	}
-
-	port := tuple.Car()
-	p, ok := port.(values.BinaryReader)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-bytevector: expected a binary input port but got %T", port)
+	p, _, err := getRequiredBinaryInputPort(mc.Arg(1), "read-bytevector")
+	if err != nil {
+		return err
 	}
 
 	// Read up to k bytes
@@ -876,27 +741,15 @@ func PrimReadBytevector(_ context.Context, mc *machine.MachineContext) error {
 // Reads bytes from port into an existing bytevector.
 // Returns the number of bytes read, or eof-object if no bytes available.
 func PrimReadBytevectorBang(_ context.Context, mc *machine.MachineContext) error {
-	rest := mc.Arg(1)
-
 	bv, err := helpers.RequireArg[*values.ByteVector](mc, 0, values.ErrNotAByteVector, "read-bytevector!")
 	if err != nil {
 		return err
 	}
 
-	// Parse optional arguments: [port [start [end]]]
-	tuple, ok := rest.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-bytevector!: expected a list but got %T", rest)
+	p, tuple, err := getRequiredBinaryInputPort(mc.Arg(1), "read-bytevector!")
+	if err != nil {
+		return err
 	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "read-bytevector!: expected a list but got %s", tuple.SchemeString())
-	}
-
-	if tuple.IsEmptyList() {
-		return values.NewForeignError("read-bytevector!: no binary input port specified")
-	}
-
-	port := tuple.Car()
 
 	// Extract optional start/end arguments
 	start, end, err := extractOptionalPositions(tuple, 0, int64(len(*bv)), "read-bytevector!")
@@ -911,12 +764,6 @@ func PrimReadBytevectorBang(_ context.Context, mc *machine.MachineContext) error
 	}
 	if end < start || end > bvLen {
 		return values.NewForeignError("read-bytevector!: end index out of bounds")
-	}
-
-	// Read into temporary buffer
-	p, ok2 := port.(values.BinaryReader)
-	if !ok2 {
-		return values.WrapForeignErrorf(values.ErrNotAnInputPort, "read-bytevector!: expected a binary input port but got %T", port)
 	}
 
 	buf := make([]byte, end-start)
@@ -943,8 +790,6 @@ func PrimReadBytevectorBang(_ context.Context, mc *machine.MachineContext) error
 // R7RS §6.13.3: (write-bytevector bytevector [port [start [end]]])
 // Writes the bytes of bytevector to port.
 func PrimWriteBytevector(_ context.Context, mc *machine.MachineContext) error {
-	rest := mc.Arg(1)
-
 	bv, err := helpers.RequireArg[*values.ByteVector](mc, 0, values.ErrNotAByteVector, "write-bytevector")
 	if err != nil {
 		return err
@@ -952,20 +797,10 @@ func PrimWriteBytevector(_ context.Context, mc *machine.MachineContext) error {
 
 	bvLen := int64(len(*bv))
 
-	// Parse optional arguments: [port [start [end]]]
-	tuple, ok := rest.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-bytevector: expected a list but got %T", rest)
+	p, tuple, err := getRequiredBinaryOutputPort(mc.Arg(1), "write-bytevector")
+	if err != nil {
+		return err
 	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "write-bytevector: expected a list but got %s", tuple.SchemeString())
-	}
-
-	if tuple.IsEmptyList() {
-		return values.NewForeignError("write-bytevector: no binary output port specified")
-	}
-
-	port := tuple.Car()
 
 	// Extract optional start/end arguments
 	start, end, err := extractOptionalPositions(tuple, 0, bvLen, "write-bytevector")
@@ -981,11 +816,6 @@ func PrimWriteBytevector(_ context.Context, mc *machine.MachineContext) error {
 		return values.NewForeignError("write-bytevector: end index out of bounds")
 	}
 
-	// Write bytes to the appropriate port
-	p, ok2 := port.(values.BinaryWriter)
-	if !ok2 {
-		return values.WrapForeignErrorf(values.ErrNotAnOutputPort, "write-bytevector: expected a binary output port but got %T", port)
-	}
 	data := bv.AsBytes(int(start), int(end))
 	_, err = p.Write(data)
 	if err != nil {
@@ -1000,27 +830,12 @@ func PrimWriteBytevector(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.13.3: (flush-output-port [port])
 // Flushes any buffered output to the underlying output device.
 func PrimFlushOutputPort(_ context.Context, mc *machine.MachineContext) error {
-	o := mc.Arg(0)
-	tuple, ok := o.(values.Tuple)
-	if !ok {
-		return values.WrapForeignErrorf(values.ErrNotAList, "flush-output-port: expected a list but got %T", o)
-	}
-	if !tuple.IsList() {
-		return values.WrapForeignErrorf(values.ErrNotAList, "flush-output-port: expected a list but got %s", tuple.SchemeString())
+	port, err := getOptionalOutputPort(mc, 0)
+	if err != nil {
+		return err
 	}
 
-	var port values.OutputPort
-	if tuple.IsEmptyList() {
-		port = GetCurrentOutputPort()
-	} else {
-		p, ok := tuple.Car().(values.OutputPort)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAnOutputPort, "flush-output-port: expected an output port but got %T", tuple.Car())
-		}
-		port = p
-	}
-
-	err := port.Flush()
+	err = port.Flush()
 	if err != nil {
 		return values.WrapForeignErrorf(err, "flush-output-port: error flushing port")
 	}

--- a/internal/extensions/math/prim_math.go
+++ b/internal/extensions/math/prim_math.go
@@ -28,30 +28,6 @@ import (
 	"github.com/aalpar/wile/values"
 )
 
-// extractReal extracts a float64 from a real number for division operations.
-// Returns the float64 value, whether the input was exact, and any error.
-//
-// R7RS §6.2.6: Division procedures work on all real numbers.
-func extractReal(v values.Value, name string) (float64, bool, error) {
-	switch n := v.(type) {
-	case *values.Integer:
-		return float64(n.Value), true, nil
-	case *values.BigInteger:
-		f, _ := new(big.Float).SetInt(n.BigInt()).Float64()
-		return f, true, nil
-	case *values.Float:
-		return n.Value, false, nil
-	case *values.Rational:
-		f, _ := n.Rat().Float64()
-		return f, true, nil
-	case *values.BigFloat:
-		f, _ := n.BigFloatValue().Float64()
-		return f, false, nil
-	default:
-		return 0, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected a real number but got %T", name, v)
-	}
-}
-
 // ensureInexactDecimal ensures a float string has a decimal point, even in
 // scientific notation. "5e-324" becomes "5.0e-324", "1" becomes "1.0".
 func ensureInexactDecimal(s string) string {
@@ -487,11 +463,11 @@ func PrimFloorDiv(_ context.Context, mc *machine.MachineContext) error {
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "floor/")
+	n0, exact0, err := helpers.ExtractReal(o0, "floor/")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "floor/")
+	n1, exact1, err := helpers.ExtractReal(o1, "floor/")
 	if err != nil {
 		return err
 	}
@@ -518,11 +494,11 @@ func PrimFloorQuotient(_ context.Context, mc *machine.MachineContext) error {
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "floor-quotient")
+	n0, exact0, err := helpers.ExtractReal(o0, "floor-quotient")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "floor-quotient")
+	n1, exact1, err := helpers.ExtractReal(o1, "floor-quotient")
 	if err != nil {
 		return err
 	}
@@ -548,11 +524,11 @@ func PrimFloorRemainder(_ context.Context, mc *machine.MachineContext) error {
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "floor-remainder")
+	n0, exact0, err := helpers.ExtractReal(o0, "floor-remainder")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "floor-remainder")
+	n1, exact1, err := helpers.ExtractReal(o1, "floor-remainder")
 	if err != nil {
 		return err
 	}
@@ -580,11 +556,11 @@ func PrimTruncateDiv(_ context.Context, mc *machine.MachineContext) error {
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "truncate/")
+	n0, exact0, err := helpers.ExtractReal(o0, "truncate/")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "truncate/")
+	n1, exact1, err := helpers.ExtractReal(o1, "truncate/")
 	if err != nil {
 		return err
 	}
@@ -611,11 +587,11 @@ func PrimTruncateQuotient(_ context.Context, mc *machine.MachineContext) error {
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "truncate-quotient")
+	n0, exact0, err := helpers.ExtractReal(o0, "truncate-quotient")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "truncate-quotient")
+	n1, exact1, err := helpers.ExtractReal(o1, "truncate-quotient")
 	if err != nil {
 		return err
 	}
@@ -641,11 +617,11 @@ func PrimTruncateRemainder(_ context.Context, mc *machine.MachineContext) error 
 	o0 := mc.Arg(0)
 	o1 := mc.Arg(1)
 
-	n0, exact0, err := extractReal(o0, "truncate-remainder")
+	n0, exact0, err := helpers.ExtractReal(o0, "truncate-remainder")
 	if err != nil {
 		return err
 	}
-	n1, exact1, err := extractReal(o1, "truncate-remainder")
+	n1, exact1, err := helpers.ExtractReal(o1, "truncate-remainder")
 	if err != nil {
 		return err
 	}

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -78,7 +78,7 @@ const (
 	MessageCannotParseNumber                     = "cannot parse number"
 	MessageCodePointExceedsUnicodeMaximum        = "character code point exceeds Unicode maximum (0x10FFFF)"
 	MessageCodePointIsSurrogate                  = "character code point is a surrogate (0xD800-0xDFFF)"
-	MessageInvalidHexEscape                      = "character code point is a surrogate (0xD800-0xDFFF)"
+	MessageInvalidHexEscape                      = "invalid hex escape"
 	MessageInvalidCharacterHexEscape             = "invalid character hex escape"
 	MessageInvalidCharacterMnemonic              = "invalid character mnemonic"
 	MessageUnterminatedExtendedSymbol            = "unterminated extended symbol"
@@ -97,13 +97,13 @@ func init() {
 	for i := 0; i < len(digs); i++ {
 		digs[i] = -1
 	}
-	for i := '0'; i < '9'; i++ {
-		digs['0'] = int(i - '0')
+	for i := '0'; i <= '9'; i++ {
+		digs[i] = int(i - '0')
 	}
-	for i := 'a'; i < 'f'; i++ {
+	for i := 'a'; i <= 'f'; i++ {
 		digs[i] = int(i-'a') + 10
 	}
-	for i := 'A'; i < 'F'; i++ {
+	for i := 'A'; i <= 'F'; i++ {
 		digs[i] = int(i-'A') + 10
 	}
 }

--- a/machine/operation_load_literal_integer.go
+++ b/machine/operation_load_literal_integer.go
@@ -31,7 +31,7 @@ func NewOperationLoadLiteralInteger(v int64) *OperationLoadLiteralInteger {
 }
 
 func (p *OperationLoadLiteralInteger) Apply(ctx context.Context, mc *MachineContext) (*MachineContext, error) {
-	mc.value = nil
+	mc.value = MultipleValues{values.NewInteger(p.Value)}
 	mc.pc++
 	return mc, nil
 }

--- a/machine/operation_misc_test.go
+++ b/machine/operation_misc_test.go
@@ -116,7 +116,7 @@ func TestOperationLoadLiteralInteger(t *testing.T) {
 
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, newMc.pc, qt.Equals, 1)
-	qt.Assert(t, newMc.value, qt.IsNil)
+	qt.Assert(t, newMc.value, qt.DeepEquals, MultipleValues{values.NewInteger(42)})
 }
 
 func TestOperationLoadLiteralInteger_SchemeString(t *testing.T) {

--- a/registry/core/prim_arithmetic.go
+++ b/registry/core/prim_arithmetic.go
@@ -161,53 +161,22 @@ func PrimNumEq(_ context.Context, mc *machine.MachineContext) error {
 	})
 }
 
-// isNonRealComplex returns true if n is a complex number with non-zero imaginary part.
-// R7RS §6.2.6: ordering comparisons (<, >, <=, >=) require real arguments.
-func isNonRealComplex(n values.Number) bool {
-	switch v := n.(type) {
-	case *values.Complex:
-		return !v.IsReal()
-	case *values.BigComplex:
-		return !v.IsReal()
-	default:
-		return false
-	}
-}
-
 // PrimNumLt implements the < primitive.
 //
 // R7RS §6.2.6: Ordering comparisons require real arguments.
 func PrimNumLt(_ context.Context, mc *machine.MachineContext) error {
-	var complexErr error
-	err := helpers.NumericChainCompare(mc, "<", func(prev, curr values.Number) bool {
-		if isNonRealComplex(prev) || isNonRealComplex(curr) {
-			complexErr = values.WrapForeignErrorf(values.ErrNotANumber, "<: requires real arguments")
-			return true
-		}
+	return helpers.NumericChainCompareReal(mc, "<", func(prev, curr values.Number) bool {
 		return !prev.LessThan(curr)
 	})
-	if complexErr != nil {
-		return complexErr
-	}
-	return err
 }
 
 // PrimNumGt implements the > primitive.
 //
 // R7RS §6.2.6: Ordering comparisons require real arguments.
 func PrimNumGt(_ context.Context, mc *machine.MachineContext) error {
-	var complexErr error
-	err := helpers.NumericChainCompare(mc, ">", func(prev, curr values.Number) bool {
-		if isNonRealComplex(prev) || isNonRealComplex(curr) {
-			complexErr = values.WrapForeignErrorf(values.ErrNotANumber, ">: requires real arguments")
-			return true
-		}
+	return helpers.NumericChainCompareReal(mc, ">", func(prev, curr values.Number) bool {
 		return !curr.LessThan(prev)
 	})
-	if complexErr != nil {
-		return complexErr
-	}
-	return err
 }
 
 // PrimNumLe implements the <= primitive.
@@ -215,22 +184,13 @@ func PrimNumGt(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.2.6: Returns #t if its arguments are monotonically nondecreasing.
 // IEEE 754: Any comparison with NaN returns #f.
 func PrimNumLe(_ context.Context, mc *machine.MachineContext) error {
-	var complexErr error
-	err := helpers.NumericChainCompare(mc, "<=", func(prev, curr values.Number) bool {
-		if isNonRealComplex(prev) || isNonRealComplex(curr) {
-			complexErr = values.WrapForeignErrorf(values.ErrNotANumber, "<=: requires real arguments")
-			return true
-		}
+	return helpers.NumericChainCompareReal(mc, "<=", func(prev, curr values.Number) bool {
 		// NaN fails all comparisons per IEEE 754
 		if prev.IsNaN() || curr.IsNaN() {
-			return true // fails the comparison
+			return true
 		}
 		return curr.LessThan(prev)
 	})
-	if complexErr != nil {
-		return complexErr
-	}
-	return err
 }
 
 // PrimNumGe implements the >= primitive.
@@ -238,22 +198,13 @@ func PrimNumLe(_ context.Context, mc *machine.MachineContext) error {
 // R7RS §6.2.6: Returns #t if its arguments are monotonically nonincreasing.
 // IEEE 754: Any comparison with NaN returns #f.
 func PrimNumGe(_ context.Context, mc *machine.MachineContext) error {
-	var complexErr error
-	err := helpers.NumericChainCompare(mc, ">=", func(prev, curr values.Number) bool {
-		if isNonRealComplex(prev) || isNonRealComplex(curr) {
-			complexErr = values.WrapForeignErrorf(values.ErrNotANumber, ">=: requires real arguments")
-			return true
-		}
+	return helpers.NumericChainCompareReal(mc, ">=", func(prev, curr values.Number) bool {
 		// NaN fails all comparisons per IEEE 754
 		if prev.IsNaN() || curr.IsNaN() {
-			return true // fails the comparison
+			return true
 		}
 		return prev.LessThan(curr)
 	})
-	if complexErr != nil {
-		return complexErr
-	}
-	return err
 }
 
 // PrimAbs implements the abs primitive.
@@ -281,36 +232,6 @@ func PrimMax(_ context.Context, mc *machine.MachineContext) error {
 	})
 }
 
-// extractInteger extracts an integer value from Integer, BigInteger, or Float (if integral).
-// Returns (int64Value, bigIntValue, isInexact, error).
-// If bigIntValue is non-nil, use that; otherwise use int64Value.
-func extractInteger(v values.Value, name string) (int64, *big.Int, bool, error) {
-	switch n := v.(type) {
-	case *values.Integer:
-		return n.Value, nil, false, nil
-	case *values.BigInteger:
-		return 0, n.BigInt(), false, nil
-	case *values.Float:
-		// Check if it's an integer value
-		if math.IsInf(n.Value, 0) || math.IsNaN(n.Value) {
-			return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %v", name, n.Value)
-		}
-		if math.Floor(n.Value) != n.Value {
-			return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %v", name, n.Value)
-		}
-		// Check if it fits in int64
-		if n.Value >= -9223372036854775808 && n.Value <= 9223372036854775807 {
-			return int64(n.Value), nil, true, nil
-		}
-		// Large float needs BigInt
-		bf := new(big.Float).SetFloat64(n.Value)
-		bi, _ := bf.Int(nil)
-		return 0, bi, true, nil
-	default:
-		return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %T", name, v)
-	}
-}
-
 // integerDivisionOp is a helper for integer division operations (quotient, remainder, modulo).
 // It handles both regular integers and big integers, preserving exactness.
 func integerDivisionOp(
@@ -323,11 +244,11 @@ func integerDivisionOp(
 	o1 := mc.Arg(1)
 
 	// Extract integer values, tracking inexactness
-	v0, big0, inexact0, err := extractInteger(o0, name)
+	v0, big0, inexact0, err := helpers.ExtractInteger(o0, name)
 	if err != nil {
 		return err
 	}
-	v1, big1, inexact1, err := extractInteger(o1, name)
+	v1, big1, inexact1, err := helpers.ExtractInteger(o1, name)
 	if err != nil {
 		return err
 	}

--- a/registry/core/prim_byte_vectors.go
+++ b/registry/core/prim_byte_vectors.go
@@ -135,11 +135,7 @@ func PrimBytevectorCopy(_ context.Context, mc *machine.MachineContext) error {
 	}
 	rest := mc.Arg(1)
 
-	start, end, err := helpers.ParseOptionalStartEnd(rest, int64(len(*bv)), "bytevector-copy")
-	if err != nil {
-		return err
-	}
-	err = helpers.ValidateStartEnd(start, end, int64(len(*bv)), "bytevector-copy")
+	start, end, err := helpers.ParseSubrange(rest, len(*bv), "bytevector-copy")
 	if err != nil {
 		return err
 	}
@@ -167,15 +163,11 @@ func PrimBytevectorCopyBang(_ context.Context, mc *machine.MachineContext) error
 	}
 	rest := mc.Arg(3)
 
-	start, end, err := helpers.ParseOptionalStartEnd(rest, int64(len(*fromBv)), "bytevector-copy!")
+	start, end, err := helpers.ParseSubrange(rest, len(*fromBv), "bytevector-copy!")
 	if err != nil {
 		return err
 	}
-	err = helpers.ValidateStartEnd(start, end, int64(len(*fromBv)), "bytevector-copy!")
-	if err != nil {
-		return err
-	}
-	if atIdx.Value < 0 || atIdx.Value+(end-start) > int64(len(*toBv)) {
+	if atIdx.Value < 0 || atIdx.Value+int64(end-start) > int64(len(*toBv)) {
 		return values.WrapForeignErrorf(values.ErrIndexOutOfRange, "bytevector-copy!: invalid destination index")
 	}
 
@@ -226,11 +218,7 @@ func PrimUtf8ToString(_ context.Context, mc *machine.MachineContext) error {
 	}
 	rest := mc.Arg(1)
 
-	start, end, err := helpers.ParseOptionalStartEnd(rest, int64(len(*bv)), "utf8->string")
-	if err != nil {
-		return err
-	}
-	err = helpers.ValidateStartEnd(start, end, int64(len(*bv)), "utf8->string")
+	start, end, err := helpers.ParseSubrange(rest, len(*bv), "utf8->string")
 	if err != nil {
 		return err
 	}
@@ -254,11 +242,7 @@ func PrimStringToUtf8(_ context.Context, mc *machine.MachineContext) error {
 	rest := mc.Arg(1)
 
 	s := str.Value
-	start, end, err := helpers.ParseOptionalStartEnd(rest, int64(len(s)), "string->utf8")
-	if err != nil {
-		return err
-	}
-	err = helpers.ValidateStartEnd(start, end, int64(len(s)), "string->utf8")
+	start, end, err := helpers.ParseSubrange(rest, len(s), "string->utf8")
 	if err != nil {
 		return err
 	}

--- a/registry/core/prim_prompt.go
+++ b/registry/core/prim_prompt.go
@@ -79,7 +79,7 @@ func PrimCallWithContinuationPrompt(ctx context.Context, mc *machine.MachineCont
 		return err
 	}
 
-	tag, err := helpers.RequireType[*machine.PromptTag](tagVal, values.ErrNotAProcedure, "call-with-continuation-prompt")
+	tag, err := helpers.RequireType[*machine.PromptTag](tagVal, values.ErrNotAPromptTag, "call-with-continuation-prompt")
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func PrimCallWithContinuationPrompt(ctx context.Context, mc *machine.MachineCont
 // Returns an ErrPromptAbort that propagates up through Run() to the
 // enclosing call-with-continuation-prompt or RunWithEscapeHandling.
 func PrimAbortCurrentContinuation(_ context.Context, mc *machine.MachineContext) error {
-	tag, err := helpers.RequireArg[*machine.PromptTag](mc, 0, values.ErrNotAProcedure, "abort-current-continuation")
+	tag, err := helpers.RequireArg[*machine.PromptTag](mc, 0, values.ErrNotAPromptTag, "abort-current-continuation")
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func PrimCallWithComposableContinuation(ctx context.Context, mc *machine.Machine
 		return err
 	}
 
-	tag, err := helpers.RequireType[*machine.PromptTag](tagVal, values.ErrNotAProcedure, "call-with-composable-continuation")
+	tag, err := helpers.RequireType[*machine.PromptTag](tagVal, values.ErrNotAPromptTag, "call-with-composable-continuation")
 	if err != nil {
 		return err
 	}
@@ -214,7 +214,7 @@ func PrimCallWithComposableContinuation(ctx context.Context, mc *machine.Machine
 	// Find the prompt in the continuation chain or on the context itself.
 	prompt, found := mc.FindPrompt(tag)
 	if !found {
-		return values.WrapForeignErrorf(values.ErrNotAProcedure, "call-with-composable-continuation: no prompt found for tag %s", tag.SchemeString())
+		return values.WrapForeignErrorf(values.ErrNotAPromptTag, "call-with-composable-continuation: no prompt found for tag %s", tag.SchemeString())
 	}
 
 	// Slice the continuation chain from mc.cont to the prompt.

--- a/registry/helpers/integer.go
+++ b/registry/helpers/integer.go
@@ -284,6 +284,38 @@ func integerFoldBig(
 	return nil
 }
 
+// ExtractInteger extracts an integer value from Integer, BigInteger, or Float (if integral).
+// Returns (int64Value, bigIntValue, isInexact, error).
+// If bigIntValue is non-nil, use that; otherwise use int64Value.
+//
+// R7RS §6.2.6: Integer operations accept exact and inexact integer arguments.
+func ExtractInteger(v values.Value, name string) (int64, *big.Int, bool, error) {
+	switch n := v.(type) {
+	case *values.Integer:
+		return n.Value, nil, false, nil
+	case *values.BigInteger:
+		return 0, n.BigInt(), false, nil
+	case *values.Float:
+		// Check if it's an integer value
+		if math.IsInf(n.Value, 0) || math.IsNaN(n.Value) {
+			return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %v", name, n.Value)
+		}
+		if math.Floor(n.Value) != n.Value {
+			return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %v", name, n.Value)
+		}
+		// Check if it fits in int64
+		if n.Value >= -9223372036854775808 && n.Value <= 9223372036854775807 {
+			return int64(n.Value), nil, true, nil
+		}
+		// Large float needs BigInt
+		bf := new(big.Float).SetFloat64(n.Value)
+		bi, _ := bf.Int(nil)
+		return 0, bi, true, nil
+	default:
+		return 0, nil, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected an integer but got %T", name, v)
+	}
+}
+
 // FloorDivide performs floor division, returning quotient and remainder.
 func FloorDivide(n0, n1 int64) (q, r int64) {
 	q = n0 / n1

--- a/registry/helpers/numeric.go
+++ b/registry/helpers/numeric.go
@@ -166,6 +166,46 @@ func NumericChainCompare(
 	return nil
 }
 
+// isNonRealComplex returns true if n is a complex number with non-zero imaginary part.
+// R7RS §6.2.6: ordering comparisons (<, >, <=, >=) require real arguments.
+func isNonRealComplex(n values.Number) bool {
+	switch v := n.(type) {
+	case *values.Complex:
+		return !v.IsReal()
+	case *values.BigComplex:
+		return !v.IsReal()
+	default:
+		return false
+	}
+}
+
+// NumericChainCompareReal is a helper for ordering comparison primitives (<, >, <=, >=).
+// It wraps NumericChainCompare with complex-number rejection: any non-real complex
+// argument causes an immediate error rather than a boolean #f result.
+//
+// The fails callback should return true when the comparison fails (i.e. the pair
+// does not satisfy the ordering relation), false when it succeeds.
+func NumericChainCompareReal(
+	mc *machine.MachineContext,
+	name string,
+	fails func(prev, curr values.Number) bool,
+) error {
+	var complexErr error
+	err := NumericChainCompare(mc, name, func(prev, curr values.Number) bool {
+		if isNonRealComplex(prev) || isNonRealComplex(curr) {
+			complexErr = values.WrapForeignErrorf(
+				values.ErrNotANumber, "%s: requires real arguments", name,
+			)
+			return true
+		}
+		return fails(prev, curr)
+	})
+	if complexErr != nil {
+		return complexErr
+	}
+	return err
+}
+
 // NumericExtremum is a helper for min/max primitives.
 // First arg at index 0, rest at index 1. Returns the extremum value
 // where isBetter returns true if candidate should replace current.

--- a/registry/helpers/value_conv.go
+++ b/registry/helpers/value_conv.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"math"
+	"math/big"
 
 	"github.com/aalpar/wile/values"
 )
@@ -75,5 +76,29 @@ func ToFloat64(v values.Value) (float64, error) {
 		return f, nil
 	default:
 		return 0, values.WrapForeignErrorf(values.ErrNotANumber, "expected a real number but got %T", v)
+	}
+}
+
+// ExtractReal extracts a float64 from a real number, tracking exactness.
+// Returns the float64 value, whether the input was exact, and any error.
+//
+// R7RS §6.2.6: Division procedures work on all real numbers.
+func ExtractReal(v values.Value, name string) (float64, bool, error) {
+	switch n := v.(type) {
+	case *values.Integer:
+		return float64(n.Value), true, nil
+	case *values.BigInteger:
+		f, _ := new(big.Float).SetInt(n.BigInt()).Float64()
+		return f, true, nil
+	case *values.Float:
+		return n.Value, false, nil
+	case *values.Rational:
+		f, _ := n.Rat().Float64()
+		return f, true, nil
+	case *values.BigFloat:
+		f, _ := n.BigFloatValue().Float64()
+		return f, false, nil
+	default:
+		return 0, false, values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected a real number but got %T", name, v)
 	}
 }

--- a/values/big_complex.go
+++ b/values/big_complex.go
@@ -131,8 +131,12 @@ func promoteToBigComplexPart(n Number) Number {
 }
 
 // addParts adds two BigComplex-compatible parts.
+// Inputs are promoted to BigComplex-compatible types (BigInteger, Rational,
+// or BigFloat) to handle results from multiplyParts that may return Integer
+// via the exact-zero multiplication optimization.
 func addParts(a, b Number) Number {
-	// Parts are BigInteger, Rational, or BigFloat
+	a = promoteToBigComplexPart(a)
+	b = promoteToBigComplexPart(b)
 	switch va := a.(type) {
 	case *BigInteger:
 		switch vb := b.(type) {
@@ -159,7 +163,10 @@ func addParts(a, b Number) Number {
 }
 
 // subtractParts subtracts two BigComplex-compatible parts.
+// Inputs are promoted for the same reason as addParts.
 func subtractParts(a, b Number) Number {
+	a = promoteToBigComplexPart(a)
+	b = promoteToBigComplexPart(b)
 	switch va := a.(type) {
 	case *BigInteger:
 		switch vb := b.(type) {
@@ -333,21 +340,10 @@ func (p *BigComplex) Subtract(o Number) Number {
 // R7RS §6.2.2 Exactness: exact * exact = exact, exact * inexact = inexact.
 func (p *BigComplex) Multiply(o Number) Number {
 	if o.IsZero() {
-		// Return zero with appropriate exactness
-		if p.IsExact() {
-			switch v := o.(type) {
-			case *BigInteger, *Integer:
-				return NewBigIntegerFromInt64(0)
-			case *BigComplex:
-				if v.IsExact() {
-					return NewBigIntegerFromInt64(0)
-				}
-			}
-		}
-		return NewBigFloatFromFloat64(0)
+		return multiplyResultForZero(o, p)
 	}
-	if p.IsZero() {
-		return p
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *BigComplex:

--- a/values/big_float.go
+++ b/values/big_float.go
@@ -146,10 +146,10 @@ func (p *BigFloat) Subtract(o Number) Number {
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *BigFloat) Multiply(o Number) Number {
 	if o.IsZero() {
-		return NewBigFloatFromFloat64(0)
+		return multiplyResultForZero(o, p)
 	}
-	if p.IsZero() {
-		return p
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *BigFloat:

--- a/values/big_integer.go
+++ b/values/big_integer.go
@@ -194,10 +194,10 @@ func (p *BigInteger) Subtract(o Number) Number {
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *BigInteger) Multiply(o Number) Number {
 	if o.IsZero() {
-		return NewBigIntegerFromInt64(0)
+		return multiplyResultForZero(o, p)
 	}
-	if p.IsZero() {
-		return p
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *BigInteger:
@@ -418,17 +418,16 @@ func (p *BigInteger) IsVoid() bool {
 // R7RS §6.2.6: The = procedure compares numerical values for equality.
 // BigInteger also compares equal to Integer when values match.
 func (p *BigInteger) EqualTo(o Value) bool {
-	v, ok := o.(*BigInteger)
-	if !ok {
-		// Also check if equal to regular Integer
-		i, ok := o.(*Integer)
-		if ok {
-			return p.value.Cmp(i.bigInt()) == 0
+	switch other := o.(type) {
+	case *BigInteger:
+		if other == nil || p == nil {
+			return p == other
 		}
-		return false
+		return p.value.Cmp(other.value) == 0
+	case *Integer:
+		return p.value.Cmp(other.bigInt()) == 0
+	case *Rational:
+		return other.value.Cmp(new(big.Rat).SetInt(p.BigInt())) == 0
 	}
-	if v == nil || p == nil {
-		return p == v
-	}
-	return p.value.Cmp(v.value) == 0
+	return false
 }

--- a/values/big_number_test.go
+++ b/values/big_number_test.go
@@ -353,9 +353,10 @@ func TestBigInteger_ZeroOptimizations(t *testing.T) {
 	sum2 := zero.Add(bi)
 	c.Assert(sum2, SchemeEquals, bi)
 
-	// Multiply by zero
+	// Multiply by zero — returns exact zero (may be Integer due to R7RS exact-zero rule)
 	prod := bi.Multiply(zero)
-	c.Assert(prod.(*BigInteger).IsZero(), qt.IsTrue)
+	c.Assert(prod.IsZero(), qt.IsTrue)
+	c.Assert(prod.IsExact(), qt.IsTrue)
 }
 
 func TestBigFloat_ZeroOptimizations(t *testing.T) {

--- a/values/complex.go
+++ b/values/complex.go
@@ -129,8 +129,11 @@ func (p *Complex) Subtract(o Number) Number {
 //
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Complex) Multiply(o Number) Number {
-	if o.IsZero() {
-		return o
+	if o.IsZero() && p.IsFinite() {
+		return multiplyResultForZero(o, p)
+	}
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *Complex:

--- a/values/float.go
+++ b/values/float.go
@@ -129,8 +129,11 @@ func (p *Float) Subtract(o Number) Number {
 // x is inexact. Zero is an exact value when the result is mathematically
 // unambiguous. This implementation follows Chez Scheme's behavior.
 func (p *Float) Multiply(o Number) Number {
-	if o.IsZero() {
-		return o
+	if o.IsZero() && p.IsFinite() {
+		return multiplyResultForZero(o, p)
+	}
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *Integer:
@@ -335,10 +338,14 @@ func (p *Float) IsVoid() bool {
 }
 
 // EqualTo returns true if both floats have the same value.
+// Handles comparison with both Float and BigFloat types for symmetry.
 func (p *Float) EqualTo(v Value) bool {
-	other, ok := v.(*Float)
-	if ok {
+	switch other := v.(type) {
+	case *Float:
 		return p.Value == other.Value
+	case *BigFloat:
+		vf := new(big.Float).SetFloat64(p.Value)
+		return vf.Cmp(other.BigFloatValue()) == 0
 	}
 	return false
 }

--- a/values/foreign_error.go
+++ b/values/foreign_error.go
@@ -105,6 +105,7 @@ var (
 	ErrInvalidFormat         = NewStaticError("invalid number format")
 	ErrUnknownOpCode         = NewStaticError("unknown op code")
 	ErrNotAMatch             = NewStaticError("not a match")
+	ErrNotAPromptTag         = NewStaticError("not a prompt tag")
 	ErrTypeConversion        = NewStaticError("type conversion failed")
 	ErrIndexOutOfRange       = NewStaticError("index out of range")
 )

--- a/values/integer.go
+++ b/values/integer.go
@@ -236,7 +236,10 @@ func (p *Integer) Subtract(o Number) Number {
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Integer) Multiply(o Number) Number {
 	if o.IsZero() {
-		return o
+		return multiplyResultForZero(o, p)
+	}
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *Integer:
@@ -466,13 +469,15 @@ func (p *Integer) IsVoid() bool {
 //
 // R7RS §6.2.6: The = procedure compares numerical values for equality.
 // This implements structural equality for the Integer type specifically.
-// Handles comparison with both Integer and BigInteger types.
+// Handles comparison with Integer, BigInteger, and Rational types for symmetry.
 func (p *Integer) EqualTo(v Value) bool {
 	switch other := v.(type) {
 	case *Integer:
 		return p.Value == other.Value
 	case *BigInteger:
 		return other.BigInt().Cmp(p.bigInt()) == 0
+	case *Rational:
+		return other.value.Cmp(new(big.Rat).SetInt64(p.Value)) == 0
 	}
 	return false
 }

--- a/values/numeric_exactness_regression_test.go
+++ b/values/numeric_exactness_regression_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package values
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestMultiply_ExactZeroDominates verifies R7RS §6.2.2 exact zero behavior.
+//
+// R7RS permits (* 0 x) to return exact 0 even when x is inexact.
+// This project follows Chez Scheme: exact zero always dominates.
+// If either operand is an exact zero, the result is exact zero.
+// If both operands are inexact, the result is inexact zero.
+func TestMultiply_ExactZeroDominates(t *testing.T) {
+	exactZero := NewInteger(0)
+
+	tcs := []struct {
+		nm  string
+		in0 Number
+		in1 Number
+		out Number
+	}{
+		// Exact zero (Integer) × inexact → exact zero
+		{
+			nm:  "Integer(0) * Float(5.0)",
+			in0: NewInteger(0),
+			in1: NewFloat(5.0),
+			out: exactZero,
+		},
+		{
+			nm:  "Float(5.0) * Integer(0)",
+			in0: NewFloat(5.0),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+		{
+			nm:  "Integer(0) * BigFloat(5.0)",
+			in0: NewInteger(0),
+			in1: NewBigFloatFromFloat64(5.0),
+			out: exactZero,
+		},
+		{
+			nm:  "BigFloat(5.0) * Integer(0)",
+			in0: NewBigFloatFromFloat64(5.0),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+		{
+			nm:  "Integer(0) * Complex(1+2i)",
+			in0: NewInteger(0),
+			in1: NewComplex(complex(1, 2)),
+			out: exactZero,
+		},
+		{
+			nm:  "Complex(1+2i) * Integer(0)",
+			in0: NewComplex(complex(1, 2)),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+		// Exact zero (BigInteger) × inexact → exact zero
+		{
+			nm:  "BigInteger(0) * Float(5.0)",
+			in0: NewBigIntegerFromInt64(0),
+			in1: NewFloat(5.0),
+			out: exactZero,
+		},
+		{
+			nm:  "Float(5.0) * BigInteger(0)",
+			in0: NewFloat(5.0),
+			in1: NewBigIntegerFromInt64(0),
+			out: exactZero,
+		},
+		// Exact zero (Rational) × inexact → exact zero
+		{
+			nm:  "Rational(0) * Float(5.0)",
+			in0: NewRational(0, 1),
+			in1: NewFloat(5.0),
+			out: exactZero,
+		},
+		{
+			nm:  "Float(5.0) * Rational(0)",
+			in0: NewFloat(5.0),
+			in1: NewRational(0, 1),
+			out: exactZero,
+		},
+		// Exact × exact → exact zero
+		{
+			nm:  "Integer(0) * Integer(5)",
+			in0: NewInteger(0),
+			in1: NewInteger(5),
+			out: exactZero,
+		},
+		{
+			nm:  "Integer(5) * Integer(0)",
+			in0: NewInteger(5),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+		{
+			nm:  "BigInteger(0) * Rational(1/3)",
+			in0: NewBigIntegerFromInt64(0),
+			in1: NewRational(1, 3),
+			out: exactZero,
+		},
+		{
+			nm:  "Rational(1/3) * Integer(0)",
+			in0: NewRational(1, 3),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+		// Inexact × inexact → inexact zero (contagion preserved)
+		{
+			nm:  "Float(0.0) * Float(5.0)",
+			in0: NewFloat(0.0),
+			in1: NewFloat(5.0),
+			out: NewFloat(0.0),
+		},
+		{
+			nm:  "Float(5.0) * Float(0.0)",
+			in0: NewFloat(5.0),
+			in1: NewFloat(0.0),
+			out: NewFloat(0.0),
+		},
+		{
+			nm:  "Complex(0+0i) * Complex(1+2i)",
+			in0: NewComplex(complex(0, 0)),
+			in1: NewComplex(complex(1, 2)),
+			out: NewComplex(complex(0, 0)),
+		},
+		{
+			nm:  "BigFloat(0.0) * BigFloat(5.0)",
+			in0: NewBigFloatFromFloat64(0.0),
+			in1: NewBigFloatFromFloat64(5.0),
+			out: NewBigFloatFromFloat64(0.0),
+		},
+		// Cross-type: exact zero × BigComplex → exact zero
+		{
+			nm:  "Integer(0) * BigComplex(1+2i)",
+			in0: NewInteger(0),
+			in1: NewBigComplexFromBigFloats(NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0)),
+			out: exactZero,
+		},
+		{
+			nm:  "BigComplex(1+2i) * Integer(0)",
+			in0: NewBigComplexFromBigFloats(NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0)),
+			in1: NewInteger(0),
+			out: exactZero,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.nm, func(t *testing.T) {
+			result := tc.in0.Multiply(tc.in1)
+			qt.Assert(t, result, SchemeEquals, tc.out)
+			// Verify exactness is correct
+			qt.Assert(t, result.IsExact(), qt.Equals, tc.out.IsExact(),
+				qt.Commentf("exactness mismatch: got %T (exact=%v), want %T (exact=%v)",
+					result, result.IsExact(), tc.out, tc.out.IsExact()))
+		})
+	}
+}
+
+// TestMultiply_ExactZeroCommutativity verifies that multiplication by zero
+// is commutative in both value and exactness.
+func TestMultiply_ExactZeroCommutativity(t *testing.T) {
+	tcs := []struct {
+		nm string
+		a  Number
+		b  Number
+	}{
+		{"Integer(0) * Float(5.0)", NewInteger(0), NewFloat(5.0)},
+		{"Integer(0) * BigFloat(5.0)", NewInteger(0), NewBigFloatFromFloat64(5.0)},
+		{"Integer(0) * Complex(1+2i)", NewInteger(0), NewComplex(complex(1, 2))},
+		{"BigInteger(0) * Float(5.0)", NewBigIntegerFromInt64(0), NewFloat(5.0)},
+		{"Rational(0) * Float(5.0)", NewRational(0, 1), NewFloat(5.0)},
+		{"Float(0.0) * Float(5.0)", NewFloat(0.0), NewFloat(5.0)},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.nm, func(t *testing.T) {
+			ab := tc.a.Multiply(tc.b)
+			ba := tc.b.Multiply(tc.a)
+			qt.Assert(t, ab, SchemeEquals, ba,
+				qt.Commentf("a*b=%v (%T), b*a=%v (%T)", ab, ab, ba, ba))
+			qt.Assert(t, ab.IsExact(), qt.Equals, ba.IsExact(),
+				qt.Commentf("exactness differs: a*b exact=%v, b*a exact=%v",
+					ab.IsExact(), ba.IsExact()))
+		})
+	}
+}
+
+// TestEqualTo_NumericSymmetry verifies that EqualTo is symmetric across
+// all cross-type numeric pairs that we handle.
+func TestEqualTo_NumericSymmetry(t *testing.T) {
+	tcs := []struct {
+		nm  string
+		in0 Value
+		in1 Value
+		out bool
+	}{
+		// Float ↔ BigFloat
+		{
+			nm:  "Float(3.0) == BigFloat(3.0)",
+			in0: NewFloat(3.0),
+			in1: NewBigFloatFromFloat64(3.0),
+			out: true,
+		},
+		{
+			nm:  "BigFloat(3.0) == Float(3.0)",
+			in0: NewBigFloatFromFloat64(3.0),
+			in1: NewFloat(3.0),
+			out: true,
+		},
+		{
+			nm:  "Float(3.0) == BigFloat(4.0)",
+			in0: NewFloat(3.0),
+			in1: NewBigFloatFromFloat64(4.0),
+			out: false,
+		},
+		{
+			nm:  "BigFloat(4.0) == Float(3.0)",
+			in0: NewBigFloatFromFloat64(4.0),
+			in1: NewFloat(3.0),
+			out: false,
+		},
+		// Rational ↔ Integer
+		{
+			nm:  "Rational(10/2) == Integer(5)",
+			in0: NewRational(10, 2),
+			in1: NewInteger(5),
+			out: true,
+		},
+		{
+			nm:  "Integer(5) == Rational(10/2)",
+			in0: NewInteger(5),
+			in1: NewRational(10, 2),
+			out: true,
+		},
+		{
+			nm:  "Rational(1/3) == Integer(0)",
+			in0: NewRational(1, 3),
+			in1: NewInteger(0),
+			out: false,
+		},
+		// Rational ↔ BigInteger
+		{
+			nm:  "Rational(14/2) == BigInteger(7)",
+			in0: NewRational(14, 2),
+			in1: NewBigIntegerFromInt64(7),
+			out: true,
+		},
+		{
+			nm:  "BigInteger(7) == Rational(14/2)",
+			in0: NewBigIntegerFromInt64(7),
+			in1: NewRational(14, 2),
+			out: true,
+		},
+		// Integer ↔ BigInteger (pre-existing, verify still works)
+		{
+			nm:  "Integer(42) == BigInteger(42)",
+			in0: NewInteger(42),
+			in1: NewBigIntegerFromInt64(42),
+			out: true,
+		},
+		{
+			nm:  "BigInteger(42) == Integer(42)",
+			in0: NewBigIntegerFromInt64(42),
+			in1: NewInteger(42),
+			out: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.nm, func(t *testing.T) {
+			forward := tc.in0.EqualTo(tc.in1)
+			reverse := tc.in1.EqualTo(tc.in0)
+			qt.Assert(t, forward, qt.Equals, tc.out)
+			qt.Assert(t, reverse, qt.Equals, tc.out,
+				qt.Commentf("asymmetric: %T.EqualTo(%T)=%v but %T.EqualTo(%T)=%v",
+					tc.in0, tc.in1, forward, tc.in1, tc.in0, reverse))
+		})
+	}
+}
+
+// TestPair_EqualTo_CircularList verifies that Pair.EqualTo terminates
+// and returns correct results for circular lists.
+func TestPair_EqualTo_CircularList(t *testing.T) {
+	t.Run("identical circular lists are equal", func(t *testing.T) {
+		// Build circular list: (1 2 3 1 2 3 ...)
+		a := NewCons(NewInteger(1),
+			NewCons(NewInteger(2),
+				NewCons(NewInteger(3), EmptyList)))
+		// Make it circular: last cdr points back to head
+		a[1].(*Pair)[1].(*Pair)[1] = a
+
+		b := NewCons(NewInteger(1),
+			NewCons(NewInteger(2),
+				NewCons(NewInteger(3), EmptyList)))
+		b[1].(*Pair)[1].(*Pair)[1] = b
+
+		qt.Assert(t, a.EqualTo(b), qt.IsTrue)
+	})
+
+	t.Run("different circular lists are not equal", func(t *testing.T) {
+		a := NewCons(NewInteger(1),
+			NewCons(NewInteger(2), EmptyList))
+		a[1].(*Pair)[1] = a
+
+		b := NewCons(NewInteger(1),
+			NewCons(NewInteger(99), EmptyList))
+		b[1].(*Pair)[1] = b
+
+		qt.Assert(t, a.EqualTo(b), qt.IsFalse)
+	})
+
+	t.Run("self-referential pair is equal to itself", func(t *testing.T) {
+		a := NewCons(NewInteger(1), EmptyList)
+		a[1] = a
+
+		qt.Assert(t, a.EqualTo(a), qt.IsTrue)
+	})
+
+	t.Run("top-level EqualTo also handles circular lists", func(t *testing.T) {
+		a := NewCons(NewInteger(1),
+			NewCons(NewInteger(2), EmptyList))
+		a[1].(*Pair)[1] = a
+
+		b := NewCons(NewInteger(1),
+			NewCons(NewInteger(2), EmptyList))
+		b[1].(*Pair)[1] = b
+
+		qt.Assert(t, EqualTo(a, b), qt.IsTrue)
+	})
+}

--- a/values/numeric_tower.go
+++ b/values/numeric_tower.go
@@ -18,6 +18,23 @@ import (
 	"math/big"
 )
 
+// multiplyResultForZero returns the correct result when one operand is zero
+// in a multiplication, following R7RS §6.2.2 and Chez Scheme behavior.
+//
+// R7RS permits (* 0 x) to return exact 0 even when x is inexact.
+// Rule: if either operand is exact, return exact zero (Integer 0).
+// If both operands are inexact, return the zero operand unchanged.
+//
+// Callers must ensure `other` is finite before calling this function.
+// IEEE 754 requires 0 * inf = NaN and 0 * NaN = NaN, so the exact-zero
+// rule does not apply when the non-zero operand is infinite or NaN.
+func multiplyResultForZero(zero, other Number) Number {
+	if zero.IsExact() || other.IsExact() {
+		return NewInteger(0)
+	}
+	return zero
+}
+
 // floatToExact converts a float64 to its exact Number representation.
 // Returns Integer or BigInteger if the float is integral, Rational otherwise.
 func floatToExact(f float64) Number {

--- a/values/pair.go
+++ b/values/pair.go
@@ -184,6 +184,7 @@ func Must(v Value, err error) {
 }
 
 // EqualTo checks if the Pair is equal to another Value o.
+// Delegates to the cycle-aware pairEqualToDeep to handle circular lists.
 func (p *Pair) EqualTo(o Value) bool {
 	v, ok := o.(*Pair)
 	if !ok {
@@ -192,32 +193,7 @@ func (p *Pair) EqualTo(o Value) bool {
 	if p == v {
 		return true
 	}
-	p0 := p
-	v0 := v
-	for {
-		if !EqualTo(p0[0], v0[0]) {
-			return false
-		}
-		// nil/void cdr: a pair constructed with nil cdr (instead of EmptyList)
-		// is malformed but must be handled. Two nil cdrs are equal; a nil cdr
-		// and a non-nil cdr are not.
-		if IsVoid(p0[1]) || IsVoid(v0[1]) {
-			if IsVoid(p0[1]) && IsVoid(v0[1]) {
-				return true
-			}
-			return p0[1] == v0[1]
-		}
-		if p0[1] == v0[1] {
-			return true
-		}
-		pv0, _ := p0[1].(*Pair)
-		vv0, _ := v0[1].(*Pair)
-		if pv0 == nil || vv0 == nil {
-			return p0[1].EqualTo(v0[1])
-		}
-		p0 = pv0
-		v0 = vv0
-	}
+	return pairEqualToDeep(p, v, make(map[equalPairKey]bool))
 }
 
 // IsVoid checks if the Pair is void (nil).

--- a/values/rational.go
+++ b/values/rational.go
@@ -180,7 +180,10 @@ func (p *Rational) Subtract(o Number) Number {
 //nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Rational) Multiply(o Number) Number {
 	if o.IsZero() {
-		return o
+		return multiplyResultForZero(o, p)
+	}
+	if p.IsZero() && o.IsFinite() {
+		return multiplyResultForZero(p, o)
 	}
 	switch v := o.(type) {
 	case *Rational:
@@ -389,10 +392,16 @@ func (p *Rational) IsVoid() bool {
 }
 
 // EqualTo returns true if the rationals have equal values.
+// Handles comparison with Integer and BigInteger for symmetry with
+// whole-valued rationals (e.g., 5/1 == 5).
 func (p *Rational) EqualTo(v Value) bool {
-	other, ok := v.(*Rational)
-	if ok {
+	switch other := v.(type) {
+	case *Rational:
 		return p.value.Cmp(other.value) == 0
+	case *Integer:
+		return p.value.Cmp(new(big.Rat).SetInt64(other.Value)) == 0
+	case *BigInteger:
+		return p.value.Cmp(new(big.Rat).SetInt(other.BigInt())) == 0
 	}
 	return false
 }

--- a/values/utils.go
+++ b/values/utils.go
@@ -106,6 +106,12 @@ func EqualTo(a, b Value) bool {
 // equalToDeep dispatches compound types to cycle-aware helpers,
 // and delegates everything else to a.EqualTo(b).
 func equalToDeep(a, b Value, visited map[equalPairKey]bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.IsVoid() || b.IsVoid() {
+		return a.IsVoid() == b.IsVoid()
+	}
 	switch pa := a.(type) {
 	case *Pair:
 		pb, ok := b.(*Pair)


### PR DESCRIPTION
## Summary
- Fix 3 bugs: tokenizer digs table initialization, OperationLoadLiteralInteger nil store, prompt tag error type
- Implement R7RS §6.2.2 exact-zero multiplication with IEEE 754 infinity/NaN exception
- Fix EqualTo symmetry across Float↔BigFloat, Integer↔Rational, BigInteger↔Rational
- Fix Pair.EqualTo circular list infinite loop via cycle-aware comparison
- Extract shared helpers: ExtractInteger, ExtractReal, NumericChainCompareReal, port helpers (-185 lines in io)
- Add 41 regression tests for exact-zero, numeric equality symmetry, and circular lists

## Test plan
- [x] `make test` passes (Go + Scheme)
- [x] All 41 new regression tests pass
- [x] `0 * +inf.0` correctly returns NaN (IEEE 754)
- [x] `(* 0 5.0)` correctly returns exact 0 (R7RS/Chez)
- [x] BigComplex exact arithmetic (square, divide) works with zero parts
- [x] Circular list equality terminates

🤖 Generated with [Claude Code](https://claude.com/claude-code)