### PR TITLE
Address staff review: fix quasiquote panic, add test coverage

### DIFF
--- a/environment/environment_coverage_test.go
+++ b/environment/environment_coverage_test.go
@@ -215,6 +215,100 @@ func TestGetBindingWithScopes_GlobalPhase_Coverage(t *testing.T) {
 	c.Assert(binding.Value().SchemeString(), qt.Equals, "42")
 }
 
+// GetLocalIndexWithScopes — maximality algorithm
+
+func TestGetLocalIndexWithScopes_Maximality(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("maximal scope count wins among competing candidates", func(t *testing.T) {
+		topLevel := NewTopLevelEnvironment()
+		env := topLevel.Runtime()
+
+		scope1 := syntax.NewScope()
+		scope2 := syntax.NewScope()
+		scope3 := syntax.NewScope()
+
+		sym := env.InternSymbol(values.NewSymbol("x"))
+
+		// Build 3-level chain: parentEnv ← middleEnv ← innerEnv
+		parentEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), env)
+		parentEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, nil) // 0 scopes
+
+		middleEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), parentEnv)
+		middleEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scope1}) // 1 scope
+
+		innerEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), middleEnv)
+		innerEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scope1, scope2}) // 2 scopes
+
+		// Reference has all 3 scopes — all bindings match, but inner (2 scopes) is maximal
+		result := innerEnv.GetLocalIndexWithScopes(sym, []*syntax.Scope{scope1, scope2, scope3})
+		c.Assert(result, qt.IsNotNil)
+		// Inner binding is at depth 0 (the frame we call from)
+		c.Assert(result[1], qt.Equals, 0, qt.Commentf("should select innermost binding (depth 0)"))
+	})
+
+	t.Run("same scope count tie-break favors innermost", func(t *testing.T) {
+		topLevel := NewTopLevelEnvironment()
+		env := topLevel.Runtime()
+
+		scopeA := syntax.NewScope()
+		scopeB := syntax.NewScope()
+
+		sym := env.InternSymbol(values.NewSymbol("x"))
+
+		// Parent: binding with [scopeA] (1 scope)
+		parentEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), env)
+		parentEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scopeA})
+
+		// Child: binding with [scopeB] (1 scope)
+		childEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), parentEnv)
+		childEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scopeB})
+
+		// Reference has both — both candidates match with scopeCount=1
+		// First candidate collected is depth 0 (child), wins by first-encountered
+		result := childEnv.GetLocalIndexWithScopes(sym, []*syntax.Scope{scopeA, scopeB})
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result[1], qt.Equals, 0, qt.Commentf("should select child binding (depth 0) on tie"))
+	})
+
+	t.Run("perfect match returns immediately", func(t *testing.T) {
+		topLevel := NewTopLevelEnvironment()
+		env := topLevel.Runtime()
+
+		scope1 := syntax.NewScope()
+		scope2 := syntax.NewScope()
+
+		sym := env.InternSymbol(values.NewSymbol("x"))
+
+		childEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), env)
+		childEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scope1, scope2})
+
+		// Reference exactly matches binding scopes — triggers fast path
+		result := childEnv.GetLocalIndexWithScopes(sym, []*syntax.Scope{scope1, scope2})
+		c.Assert(result, qt.IsNotNil)
+		c.Assert(result[1], qt.Equals, 0)
+	})
+
+	t.Run("superset binding rejected", func(t *testing.T) {
+		topLevel := NewTopLevelEnvironment()
+		env := topLevel.Runtime()
+
+		scope1 := syntax.NewScope()
+		scope2 := syntax.NewScope()
+		scope3 := syntax.NewScope()
+
+		sym := env.InternSymbol(values.NewSymbol("x"))
+
+		childEnv := NewEnvironmentFrameWithParent(NewLocalEnvironment(0), env)
+		// Binding has 3 scopes, but reference only has 2
+		childEnv.MaybeCreateLocalBindingWithScopes(sym, BindingTypeVariable, []*syntax.Scope{scope1, scope2, scope3})
+
+		// Reference is a strict subset of binding scopes — NOT a match
+		result := childEnv.GetLocalIndexWithScopes(sym, []*syntax.Scope{scope1, scope2})
+		c.Assert(result, qt.IsNil)
+	})
+}
+
 // MaybeCreateLocalBinding
 
 func TestMaybeCreateLocalBinding_Existing_Coverage(t *testing.T) {

--- a/environment/top_level_environment_test.go
+++ b/environment/top_level_environment_test.go
@@ -15,6 +15,7 @@
 package environment
 
 import (
+	"sync"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -94,6 +95,72 @@ func TestTopLevelEnvironment_SymbolInternCount(t *testing.T) {
 	// Interning the same symbol again shouldn't increase the count
 	topLevel.InternSymbol(values.NewSymbol("a"))
 	c.Assert(topLevel.SymbolInternCount(), qt.Equals, 2)
+}
+
+func TestInternSymbol_Stress(t *testing.T) {
+	c := qt.New(t)
+
+	topLevel := NewTopLevelEnvironment()
+	const count = 10000
+
+	// Intern 10,000 unique symbols
+	symbols := make([]*values.Symbol, count)
+	for i := 0; i < count; i++ {
+		sym := values.NewSymbol("stress-sym-" + string(rune(i/256+1)) + string(rune(i%256+1)))
+		symbols[i] = topLevel.InternSymbol(sym)
+	}
+	c.Assert(topLevel.SymbolInternCount(), qt.Equals, count)
+
+	// Re-interning all returns same pointers
+	for i := 0; i < count; i++ {
+		again := topLevel.InternSymbol(values.NewSymbol(symbols[i].Datum()))
+		c.Assert(again, qt.Equals, symbols[i],
+			qt.Commentf("re-intern of symbol %d should return same pointer", i))
+	}
+	c.Assert(topLevel.SymbolInternCount(), qt.Equals, count,
+		qt.Commentf("count should not increase after re-interning"))
+}
+
+func TestInternSymbol_Concurrent(t *testing.T) {
+	c := qt.New(t)
+
+	topLevel := NewTopLevelEnvironment()
+	const goroutines = 10
+	const perGoroutine = 1000
+
+	// 100 shared names + 900 unique per goroutine = 100 + 9000 = 9100 total
+	var wg sync.WaitGroup
+	results := make([][perGoroutine]*values.Symbol, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gIdx int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				var name string
+				if i < 100 {
+					// Shared names across all goroutines
+					name = "shared-" + string(rune(i+1))
+				} else {
+					// Unique per goroutine
+					name = "g" + string(rune(gIdx+1)) + "-" + string(rune(i+1))
+				}
+				results[gIdx][i] = topLevel.InternSymbol(values.NewSymbol(name))
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Shared symbols: all goroutines should get the same pointer
+	for i := 0; i < 100; i++ {
+		for g := 1; g < goroutines; g++ {
+			c.Assert(results[g][i], qt.Equals, results[0][i],
+				qt.Commentf("shared symbol %d should be identical across goroutines", i))
+		}
+	}
+
+	// Total count: 100 shared + 900*10 unique = 9100
+	c.Assert(topLevel.SymbolInternCount(), qt.Equals, 9100)
 }
 
 func TestTopLevelEnvironment_Phases(t *testing.T) {

--- a/internal/extensions/threads/prim_threads_test.go
+++ b/internal/extensions/threads/prim_threads_test.go
@@ -17,6 +17,7 @@ package threads_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/aalpar/wile"
 	extexceptions "github.com/aalpar/wile/internal/extensions/exceptions"
@@ -712,4 +713,68 @@ func TestMutexAbandonedOnTermination(t *testing.T) {
 			c.Assert(result.Internal(), qt.Equals, tc.want)
 		})
 	}
+}
+
+// =============================================================================
+// Context Cancellation Integration Tests
+// =============================================================================
+
+// TestThreadParentContextCancellation verifies that cancelling the parent
+// context propagates to a running thread's derived context, causing the
+// thread's VM loop to terminate via context.Canceled.
+func TestThreadParentContextCancellation(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run scheme code in a goroutine: starts an infinite-loop thread, then joins it.
+	// The join blocks until the thread terminates.
+	errCh := make(chan error, 1)
+	go func() {
+		// Note: engine.Eval is the Scheme interpreter's eval, not JavaScript eval.
+		// It compiles and runs Scheme source code on the Wile VM.
+		_, err := engine.Eval(ctx,
+			`(let ((th (make-thread (lambda () (let loop () (loop))))))
+			   (thread-start! th)
+			   (thread-join! th))`)
+		errCh <- err
+	}()
+
+	// Give the thread time to start and enter its loop
+	time.Sleep(200 * time.Millisecond)
+
+	// Cancel the parent context — should propagate to thread's derived context
+	cancel()
+
+	select {
+	case err := <-errCh:
+		c.Assert(err, qt.IsNotNil)
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheme evaluation did not return after context cancellation")
+	}
+}
+
+// TestThreadRespectsParentTimeout verifies that a thread running an infinite
+// loop terminates when the parent context's deadline expires.
+func TestThreadRespectsParentTimeout(t *testing.T) {
+	c := qt.New(t)
+	engine := newEngine(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	// Note: engine.Eval is the Scheme interpreter's eval, not JavaScript eval.
+	// It compiles and runs Scheme source code on the Wile VM.
+	_, err := engine.Eval(ctx,
+		`(let ((th (make-thread (lambda () (let loop () (loop))))))
+		   (thread-start! th)
+		   (thread-join! th))`)
+	elapsed := time.Since(start)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(elapsed < 2*time.Second, qt.IsTrue,
+		qt.Commentf("should terminate within timeout window, took %v", elapsed))
 }

--- a/machine/compile_quasisyntax.go
+++ b/machine/compile_quasisyntax.go
@@ -271,7 +271,7 @@ func (p *CompileTimeContinuation) expandQuasisyntaxList(ctx context.Context, pai
 		return nil
 	})
 	if err != nil {
-		panic(err)
+		panic(values.WrapForeignErrorf(err, "quasisyntax: error scanning list at %s", srcCtx.SchemeString()))
 	}
 	// Note: For improper lists, the tail won't be an empty list.
 	// That's fine - improper lists can't have splices in their tail anyway.

--- a/machine/compile_time_continuation.go
+++ b/machine/compile_time_continuation.go
@@ -817,7 +817,10 @@ func (p *CompileTimeContinuation) expandQuasiquoteList(ctx context.Context, pair
 	// Check if any element is ,@ at depth 1
 	hasSplice := false
 	current := pair
-	v, err := current.SyntaxForEach(ctx, func(_ context.Context, _ int, _ bool, carSyntax syntax.SyntaxValue) error {
+	// Scan for unquote-splicing at the current depth. For improper lists,
+	// SyntaxForEach returns the dotted tail — that's fine, the expansion
+	// logic below handles improper lists via expandQuasiquoteImproperList.
+	_, err := current.SyntaxForEach(ctx, func(_ context.Context, _ int, _ bool, carSyntax syntax.SyntaxValue) error {
 		carPair, ok := carSyntax.(*syntax.SyntaxPair)
 		if ok {
 			carSymName, ok := p.getSymbolName(carPair.SyntaxCar())
@@ -830,13 +833,8 @@ func (p *CompileTimeContinuation) expandQuasiquoteList(ctx context.Context, pair
 		}
 		return nil
 	})
-	if !errors.Is(err, values.ErrStopIteration) {
-		// Normal termination of iteration
-		if err != nil {
-			panic(err)
-		} else if !syntax.IsSyntaxEmptyList(v) {
-			panic(values.ErrNotAList)
-		}
+	if err != nil && !errors.Is(err, values.ErrStopIteration) {
+		panic(values.WrapForeignErrorf(err, "quasiquote: error scanning list at %s", srcCtx.SchemeString()))
 	}
 	if !hasSplice {
 		// Simple case: (list elem1 elem2 ...)

--- a/machine/coverage_fullruntime_test.go
+++ b/machine/coverage_fullruntime_test.go
@@ -2783,6 +2783,41 @@ func TestCoverageQuasiquoteImproper(t *testing.T) {
 	qt.Assert(t, mc.GetValue(), qt.IsNotNil)
 }
 
+// TestCoverageQuasiquoteImproperWithUnquote tests quasiquote with an improper
+// list that also contains unquoted expressions. This exercises the splice-check
+// phase of expandQuasiquoteList with a dotted tail, which previously panicked
+// with ErrNotAList instead of falling through to expandQuasiquoteImproperList.
+func TestCoverageQuasiquoteImproperWithUnquote(t *testing.T) {
+	t.Run("unquote before dotted tail", func(t *testing.T) {
+		env := newFullRuntimeEnv(t)
+		mc, err := runSchemeExprs(t, env,
+			"(define x 10)",
+			"`(a ,x . c)",
+		)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+			values.NewCons(
+				values.NewSymbol("a"),
+				values.NewCons(values.NewInteger(10), values.NewSymbol("c")),
+			))
+	})
+
+	t.Run("multiple unquotes before dotted tail", func(t *testing.T) {
+		env := newFullRuntimeEnv(t)
+		mc, err := runSchemeExprs(t, env,
+			"(define x 1)",
+			"(define y 2)",
+			"`(,x ,y . z)",
+		)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+			values.NewCons(
+				values.NewInteger(1),
+				values.NewCons(values.NewInteger(2), values.NewSymbol("z")),
+			))
+	})
+}
+
 // TestCoverageQuasiquoteSplicingInList tests unquote-splicing in middle of list.
 // Exercises expandQuasiquote list traversal paths.
 func TestCoverageQuasiquoteSplicingInList(t *testing.T) {

--- a/plans/STAFF_REVIEW_2026_02.md
+++ b/plans/STAFF_REVIEW_2026_02.md
@@ -1,0 +1,278 @@
+# Staff Software Engineer — Codebase Review (February 2026)
+
+**Scope:** Full codebase review of Wile (R7RS Scheme in Go)
+**Codebase:** 134K lines Go, 605 files (292 test), 33 packages
+**Test Status:** All passing (Go + Scheme), zero failures
+**Overall Grade:** A-
+
+---
+
+## Executive Summary
+
+Wile is a well-engineered R7RS Scheme interpreter/compiler suitable for production embedding. The architecture is sound, the code is consistent, and the test coverage is thorough. The main areas for improvement are a handful of compile-time panics, some documentation gaps in the public API, and minor test coverage gaps in the hygiene algorithm.
+
+---
+
+## 1. Architecture (Grade: A)
+
+The pipeline (`Source → Tokenizer → Parser → SyntaxValue → Expander → Compiler → NativeTemplate → VM → Value`) is clean and well-layered.
+
+**Strengths:**
+- PC-based bytecode VM with straightforward instruction dispatch
+- Immutable `NativeTemplate` operations (never modified after creation)
+- 36 operation types, each implementing `Apply(ctx, mc) (*MachineContext, error)`
+- Clean separation: `values/` → `environment/` → `internal/*` → `machine/` → `registry/` → `wile/`
+- Public API is minimal: `wile/`, `values/`, `registry/`
+
+**Package sizes:**
+- `machine/` — ~131 files, 14.4K source + 21.5K test (1.49x test ratio)
+- `registry/core/` — ~145 files
+- `values/` — ~94 files
+
+**Compiler organization:**
+- 25 `compile_*.go` files, one per special form — well-justified despite file count
+- `SyntaxCompiler` dispatcher with registry-based form dispatch
+- Low coupling between compiler files; no circular dependencies
+
+---
+
+## 2. VM & Continuations (Grade: A)
+
+**MachineContext** (`machine_context.go`) is the execution hub:
+- `Run()` loop checks `ctx.Done()` every iteration (proper preemption)
+- Context cancellation properly threaded through (fixed in commit `4fcf675`)
+- Debugger nullable and properly guarded
+
+**Continuations are exemplary:**
+- `MachineContinuation` captures immutable state `(env, template, value, evals, pc, parent)`
+- `DeepCopy()` for re-invocation is correctly implemented
+- Critical invariant maintained: `Restore()` copies evals stack, `PopContinuation()` does not (single-use)
+- Composable continuations validate thread-ID to prevent cross-thread invocation
+
+**Dynamic-wind (R7RS §6.10):**
+- Thunks always called (even on exception/continuation escape)
+- Sub-contexts isolate thunk execution
+- Proper stack slicing with capacity limits to prevent aliasing
+- Textbook correct continuation-safe unwinding
+
+---
+
+## 3. Concurrency (Grade: A)
+
+**Production-ready.** All critical paths verified:
+
+| Component | Mechanism | Status |
+|---|---|---|
+| Symbol interning | Per-TopLevelEnvironment, RWMutex + double-checked locking | Correct |
+| Global environment | RWMutex with copy semantics | Correct |
+| Thread state (SRFI-18) | sync.Mutex for all state transitions | Correct |
+| Thread context | `context.WithCancel(parentCtx)` derivation | Correct (fixed 4fcf675) |
+| Thread sub-context | `CaptureSubContextParams()` avoids goroutine data races | Correct |
+| Mutex ownership tracking | Separate `mutexMu` (no lock ordering issues) | Correct |
+| Condition variables | `sync.Cond` with waiter count tracking | Correct |
+| Registry loading | RWMutex; primitives installed once at Engine creation | Correct |
+| VM loop | Context cancellation checked every iteration | Correct |
+
+**No goroutine leaks detected.** Proper cleanup on thread exit via defer.
+
+**Documented limitation:** `LoadPathStack` is per-VM not per-thread; concurrent `(load ...)` calls could corrupt LIFO ordering. Low impact — concurrent loading is uncommon.
+
+**Deferred items (low priority per architectural review criteria):**
+- L15: `thread-sleep!` ignores context cancellation
+- L11: `eval` doesn't inherit dynamic context
+- L3: `ChannelSelect` busy-spins (could use `reflect.Select`)
+
+---
+
+## 4. Error Handling (Grade: B+)
+
+**Two-layer convention (sentinel + wrap) well established:**
+- 90+ static sentinels in `values/foreign_error.go`
+- 59 files use `WrapForeignErrorf()` for context-aware wrapping
+- Zero instances of `err == X` or `err != X` comparisons
+- 79 documented uses of `errors.Is()`/`errors.As()` across 28 files
+
+**Recovery boundaries are correct:**
+- FFI boundary (`ffi.go:876-891`): Re-panics non-ForeignErrors
+- VM ForeignFunction call (`operation_foreign_function_call.go:68-82`): Wraps with `ErrPanicRecovery`
+- Thread execution (`values/thread.go:236-248`): Captures as `ErrThreadPanic`
+
+### Panic Issues
+
+**P0 — FIXED in this review session:**
+- `compile_time_continuation.go:838` — `panic(values.ErrNotAList)` on quasiquoted improper lists with unquotes. Reachable via e.g. `` `(a ,b . c) ``. Fixed by removing the improper-list panic from the splice-check phase (the expansion code below already handles improper lists correctly).
+
+**P0 — Unreachable but poor pattern:**
+- `compile_time_continuation.go:836` — `panic(err)` where callback never returns unexpected errors
+- `compile_quasisyntax.go:274` — `panic(err)` where callback always returns nil
+
+**P1 — Intentional invariant checks (stack):**
+- `stack.go:39,50,91` — Stack underflow panics. Only fire on compiler bugs (mismatched push/pop). Internal-only, not user-facing.
+
+**P1 — String panics that could escape to embedders:**
+- `environment/load_path_stack.go:51` — `panic("LoadPathStack.Push: path must be absolute: " + absPath)` — Should return error
+- `values/big_complex.go` — 10 string panics for internal type invariant violations (`"BigComplex parts must be..."`) — Should use sentinel errors
+
+### Ignored Errors (acceptable)
+
+- File close in defer (`cmd/scheme/main.go:171`): Can't propagate from defer
+- Port closure in `call-with-output-file`: Must close even if procedure failed
+- `big.Float` accuracy (not an error, just precision info)
+- Debug column parsing: Optional, defaults to 0
+
+---
+
+## 5. Public API & Embedding (Grade: A-)
+
+**API design is minimal and well-focused:**
+- `NewEngine()` with functional options (`WithExtension`, `WithRegistry`)
+- `Eval`/`Compile`/`Run` pipeline with proper context threading
+- `RegisterFunc` FFI is impressive: pre-computed converters for int64, float64, string, bool, []byte, []T, map[K]V, structs, func callbacks, wile.Value, context.Context
+- Three-level error hierarchy: `Error` (init), `CompilationError` (parse/expand), `RuntimeError` (execution with Condition, Source, StackTrace)
+
+### Issues
+
+**P1 — Missing documentation:**
+- No goroutine-safety documentation on `Engine` (is it safe for concurrent use?)
+- `CompiledCode` bound to its Engine — not documented
+- `RuntimeError.Condition` can be nil — not documented
+- `RegisterFunc` callback synchronicity requirement needs clearer docs
+- No API stability guarantee document
+
+**P1 — Internal types in public API:**
+- `Engine.Environment()` and `Engine.TopLevelEnvironment()` return `environment.*` types marked "advanced use" — could leak internal API changes to embedders
+
+**P2 — API completeness:**
+- No `Registry.FindPrimitive(name)` or `HasPrimitive(name)` query methods
+- `PushLoadPath` panics on relative paths — should return error
+- `PrimitiveSpec` lacks metadata (Doc, ParamNames, Category) for auto-generated docs
+- No `Engine.Close()` method (acceptable since Engine holds no OS resources, but extensions may spawn goroutines)
+
+**P2 — Error type improvements:**
+- No distinction between Scheme exceptions (Condition != nil) and VM/primitive errors
+- `RuntimeError.Cause` can contain internal `machine.*` types — document as logging-only
+
+---
+
+## 6. Values & Numeric Tower (Grade: A-)
+
+**Comprehensive 7-type system:**
+
+| Type | File | Precision | Exact? |
+|---|---|---|---|
+| Integer | integer.go | int64 | yes |
+| BigInteger | big_integer.go | arbitrary | yes |
+| Rational | rational.go | math/big.Rat | yes |
+| Float | float.go | float64 | no |
+| BigFloat | big_float.go | arbitrary | no |
+| Complex | complex.go | complex128 | no |
+| BigComplex | big_complex.go | arbitrary | no |
+
+**R7RS exactness contagion correctly implemented:**
+- All 7 Multiply methods handle exact zero exception consistently
+- `multiplyResultForZero()` helper used across all types
+- `(* 0 +inf.0)` is implementation-defined per R7RS §6.2.2
+
+**Panic convention for arithmetic is correct by design:**
+- `Number` interface methods return `Number`, not `(Number, error)`
+- Panics are recovered at the VM boundary (`operation_foreign_function_call.go`)
+- This is the established contract, matching R7RS exception semantics
+
+**Minor:**
+- `Complex.Multiply` has a minor inconsistency (skips `multiplyResultForZero` helper) but is semantically correct since Complex is always inexact
+
+---
+
+## 7. Environment & Scoping (Grade: A)
+
+**Binding model is sound:**
+- Two-phase lookup: local first (O(1) map per frame), then global (RWMutex-protected)
+- `LocalIndex` uses `[slot, depth]` pairs for correct parent-chain traversal
+- No shadowing bugs: locals searched before globals
+
+**Symbol interning (R7RS §6.5 compliant):**
+- Per-TopLevelEnvironment (enables multiple isolated VMs)
+- Child environments delegate to parent (preserves symbol identity across boundaries)
+- Double-checked locking: RLock fast path, Lock slow path with double-check
+
+**Phase separation (clean and correct):**
+- `PhaseRegistry` with `map[int]*EnvironmentFrame`
+- Each phase gets isolated global bindings but shares symbol interning
+- Phase environments parent to runtime frame (siblings, not children)
+
+**Scope sets (Flatt 2016 — correctly integrated):**
+- Bindings carry `scopes []*syntax.Scope`
+- `scopesCompatible()` checks subset relationship
+- `GetLocalIndexWithScopes()` implements maximal resolution (most specific binding wins)
+- Pre-hygiene bindings (no scopes) treated as universally compatible
+
+**Test gap:** No explicit test for the "maximal" algorithm with multiple scope-bearing candidates. Low risk since hygiene is well-tested at the macro level.
+
+---
+
+## 8. Test Infrastructure (Grade: A-)
+
+- Test-to-code ratio: 1.49x in machine/ (21.5K test : 14.4K source)
+- Table-driven tests with quicktest (`qt`) + `SchemeEquals` throughout
+- Full bootstrap integration tests (library_scheme_test.go)
+- Comprehensive concurrency tests (global_environment_frame_concurrency_test.go)
+- Coverage improvement tests exist as explicit files
+
+**Gaps:**
+- No test for scope-maximality algorithm with competing candidates
+- No stress test for symbol interning with many symbols
+- No integration test for context cancellation during thread execution
+- Limited tests for `GetLocalIndexWithScopes()` edge cases
+
+---
+
+## Prioritized Recommendations
+
+### P0 — Ship-blocking (DONE)
+
+- [x] **Fix quasiquote panic on improper lists with unquotes** — `compile_time_continuation.go:838`. Fixed in this session. Regression test added.
+
+### P1 — Should fix
+
+- [ ] **Convert `LoadPathStack.Push` panic to error return** — `environment/load_path_stack.go:51`
+- [ ] **Convert BigComplex string panics to sentinel errors** — `values/big_complex.go` (10 sites)
+- [ ] **Document Engine goroutine-safety** — Is it safe for concurrent use?
+- [ ] **Document CompiledCode binding to Engine** — Running on wrong Engine is undefined
+- [ ] **Add `RuntimeError.IsSchemeException()` method** for distinguishing Scheme exceptions from VM errors
+
+### P2 — Should improve
+
+- [ ] **Add Registry query methods** — `FindPrimitive(name)`, `HasPrimitive(name)`
+- [ ] **Add scope-maximality unit test** for `GetLocalIndexWithScopes()`
+- [ ] **Structure long FFI docstrings** with Go doc subheadings
+- [ ] **Add API stability statement** to README
+- [ ] **Document RuntimeError.Condition nil semantics**
+- [ ] **Document callback synchronicity requirement** in RegisterFunc
+
+### P3 — Nice to have
+
+- [ ] **Add Engine.Close()** for extensions that spawn goroutines
+- [ ] **Add PrimitiveSpec metadata** (Doc, ParamNames, Category) for auto-generated docs
+- [ ] **Extract machine/ subpackages** (operations/, compiler/, expander/) — optional organizational improvement
+- [ ] **Add recursion depth limit** — configurable via Engine, prevents DoS
+- [ ] **Deferred concurrency items**: thread-sleep context cancellation (L15), eval dynamic context (L11), ChannelSelect busy-spin (L3)
+
+---
+
+## Changes Made in This Review
+
+### Fix: quasiquote panic on improper lists with unquotes
+
+**Files changed:**
+- `machine/compile_time_continuation.go` — 6-line fix replacing 8-line panic block
+- `machine/coverage_fullruntime_test.go` — 35-line regression test
+
+**Bug:** `expandQuasiquoteList` panicked with `ErrNotAList` during the splice-checking phase when encountering an improper (dotted) list containing unquotes (e.g., `` `(a ,b . c) ``). The `SyntaxForEach` returns the dotted tail for improper lists, and line 838 treated any non-empty-list termination as an error — even though the expansion logic below (`expandQuasiquoteImproperList`) already handles improper lists correctly.
+
+**Root cause:** The splice-check phase was stricter than the expansion phase. The quasisyntax version in `compile_quasisyntax.go` correctly ignores improper tails during splice-checking (line 276: "For improper lists, the tail won't be an empty list. That's fine"), but the quasiquote version panicked instead.
+
+**Hidden by optimization:** `compileQuasiquoteDatum` checks `quasiquoteNeedsRuntime` first, and quasiquoted improper lists *without* unquotes take the literal-emission fast path, never reaching `expandQuasiquoteList`. Only improper lists *with* unquotes (which force runtime evaluation) trigger the bug.
+
+**Fix:** Changed `v, err :=` to `_, err :=` (discard unused tail value), replaced nested panic block with `if err != nil && !errors.Is(err, values.ErrStopIteration) { panic(err) }`.
+
+**Test:** Added `TestCoverageQuasiquoteImproperWithUnquote` with two subcases: single unquote before dotted tail, and multiple unquotes before dotted tail.


### PR DESCRIPTION
## Summary

- Fix reachable panic in `expandQuasiquoteList` when quasiquoted improper lists contain unquotes (e.g. `` `(a ,b . c) ``)
- Improve error wrapping in quasiquote and quasisyntax list scanners
- Add tests for four coverage gaps from the February 2026 staff review (Section 8):
  - Scope-maximality algorithm with competing candidates and edge cases
  - Symbol interning stress (10k symbols) and concurrency (10 goroutines)
  - Context cancellation propagation to threads (cancel + timeout)
- Add staff review document (`plans/STAFF_REVIEW_2026_02.md`)

## Test plan

- [x] `go test -v -run TestGetLocalIndexWithScopes_Maximality ./environment/`
- [x] `go test -v -run "TestInternSymbol_Stress|TestInternSymbol_Concurrent" ./environment/`
- [x] `go test -v -run "TestThreadParentContextCancellation|TestThreadRespectsParentTimeout" ./internal/extensions/threads/`
- [x] `go test -race` on concurrency tests — no races
- [x] `make test` — full suite passes