### PR TITLE
test: expand prim_read_write.go coverage from 55.2% to 91.1%

### DIFF
--- a/internal/extensions/io/prim_read_write_test.go
+++ b/internal/extensions/io/prim_read_write_test.go
@@ -17,6 +17,7 @@ package io
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -1287,6 +1288,10 @@ func TestReadU8Coverage(t *testing.T) {
 // Phase 4 — Cache lifecycle
 // =============================================================================
 
+// NOTE: TestParserCacheEviction accesses package-level state (cacheMu, Parsers,
+// Tokenizers) and must NOT use t.Parallel(). Go tests within the same package
+// run sequentially by default, so no additional synchronization is needed
+// beyond the existing cacheMu locking.
 func TestParserCacheEviction(t *testing.T) {
 	c := qt.New(t)
 	engine := newEngine(t)
@@ -1344,9 +1349,17 @@ func TestParserCacheEviction(t *testing.T) {
 
 // TestDefaultOutputPort exercises the "no port arg" code path where
 // write/display/newline/write-char/write-simple/write-shared/flush-output-port
-// fall through to the current output port. These write to stdout as a
-// side effect but the code coverage gain justifies the noise.
+// fall through to the current output port.
+//
+// NOTE: This test modifies global state (current output port) and must NOT
+// use t.Parallel(). Go tests within the same package run sequentially by
+// default, so no additional synchronization is needed.
 func TestDefaultOutputPort(t *testing.T) {
+	// Redirect the current output port to io.Discard to avoid polluting
+	// test output while still exercising the default port code path.
+	SetCurrentOutputPort(values.NewCharacterOutputPortFromWriter(io.Discard))
+	defer ResetCurrentOutputPort()
+
 	engine := newEngine(t)
 
 	// Each of these calls the function without a port argument,
@@ -1382,6 +1395,10 @@ func TestDefaultInputPortCharReady(t *testing.T) {
 
 // TestDefaultInputPortRead exercises the "no port arg" path for read-char
 // by redirecting the current input port to a string reader.
+//
+// NOTE: This test modifies global state (current input port) and must NOT
+// use t.Parallel(). Go tests within the same package run sequentially by
+// default, so no additional synchronization is needed.
 func TestDefaultInputPortRead(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary

- Adds ~110 test cases across 22 test functions to `internal/extensions/io/prim_read_write_test.go`, raising statement coverage from **55.2% → 91.1%** (target was ≥90%)
- Previously 14 of 28 exported functions had 0% coverage; all now have ≥80%
- Exercises default-port paths, closed-port error branches, cache lifecycle eviction, and binary/textual port type enforcement

## Motivation

`prim_read_write.go` had the lowest test coverage among core packages and was flagged HIGH priority by architectural review because I/O is a system boundary — the exact place where M10/M11 bugs originated. The existing tests only covered allocation limits (M11) and concurrent cache access (T1).

## What's tested

| Phase | Functions | Cases |
|-------|-----------|-------|
| 1 — 0% functions | read, write, display, newline, peek-char, peek-u8 | ~40 |
| 2 — Remaining 0% | write-simple, write-shared, read-token, read-syntax, char-ready?, u8-ready?, flush-output-port | ~25 |
| 3 — Partial coverage | read-line, read-char, write-char, read-string, write-string, write-u8, write-bytevector, read-u8 | ~35 |
| 4 — Cache lifecycle | parser/tokenizer eviction on EOF | 3 |
| Supplementary | Default port paths, no-arg binary port errors | ~10 |

## Discoveries

- `read-token` returns `*tokenizer.SimpleToken`, not regular Scheme values — `equal?` comparisons fail
- `write`/`display`/`write-char` accept binary output ports (shared `OutputPort` interface)
- `read` on incomplete input `"("` returns eof-object, not a parse error
- Closed-port reads produce non-EOF errors, enabling error branch coverage
- Remaining ~9% uncovered: VM-internal type invariants + Write/Flush error branches on in-memory ports (unreachable without fault injection)

## Test plan

- [x] `go test -v ./internal/extensions/io/...` — all pass
- [x] `make test` — no regressions
- [x] `make lint` — 0 issues
- [x] Coverage: `go test -coverprofile` confirms 91.1% on `prim_read_write.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)