### PR TITLE
refactor: make pattern compiler and analyzer syntax-native

### DIFF
--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -450,47 +450,6 @@ func countRemainingSyntaxElements(pr syntax.SyntaxTuple) int {
 	return count
 }
 
-// valueToSyntaxValue converts a values.Value to syntax.SyntaxValue.
-// Used by the pattern compiler to wrap raw values as syntax for bytecode instructions.
-func valueToSyntaxValue(v values.Value) syntax.SyntaxValue {
-	if v == nil {
-		return nil
-	}
-
-	// Already a syntax value
-	sv, ok := v.(syntax.SyntaxValue)
-	if ok {
-		return sv
-	}
-
-	// Check for empty list before Tuple (EmptyList implements Tuple but needs special handling)
-	if values.IsEmptyList(v) {
-		return syntax.SyntaxEmptyList
-	}
-
-	switch t := v.(type) {
-	case values.Tuple:
-		return valueTupleToSyntaxPair(t)
-	case *values.Symbol:
-		return syntax.NewSyntaxSymbolForSymbol(t, nil)
-	default:
-		return syntax.NewSyntaxObject(v, nil)
-	}
-}
-
-// valueTupleToSyntaxPair converts a values.Tuple to syntax.SyntaxPair recursively.
-// Used by valueToSyntaxValue for nested tuple structures.
-// Precondition: tuple is not nil, not void, and not empty list (checked by caller).
-func valueTupleToSyntaxPair(tuple values.Tuple) *syntax.SyntaxPair {
-	if tuple == nil || values.IsVoid(tuple) {
-		return nil
-	}
-
-	car := valueToSyntaxValue(tuple.Car())
-	cdr := valueToSyntaxValue(tuple.Cdr())
-	return syntax.NewSyntaxCons(car, cdr, nil)
-}
-
 // syntaxValuesEqualForMatch compares two syntax values for pattern matching purposes.
 // For symbols, compares by key (value equality, not pointer equality).
 // For other values, uses the underlying value comparison.

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -19,12 +19,6 @@ import (
 	"github.com/aalpar/wile/values"
 )
 
-// testList constructs a proper list from values, returning *values.Pair.
-// Used across match test files since values.List() now returns values.Tuple.
-func testList(vs ...values.Value) *values.Pair {
-	return values.List(vs...).(*values.Pair)
-}
-
 // testSyntaxInt creates a syntax-wrapped integer for test bytecode.
 func testSyntaxInt(v int64) syntax.SyntaxValue {
 	return syntax.NewSyntaxObject(values.NewInteger(v), nil)

--- a/internal/match/pattern_analyzer.go
+++ b/internal/match/pattern_analyzer.go
@@ -15,38 +15,34 @@
 package match
 
 import (
-	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/internal/syntax"
 )
 
 // PatternAnalysis holds analysis results for a pattern
 type PatternAnalysis struct {
-	// Maps each subtree (Pair) to whether it contains pattern variables
-	containsVariables map[*values.Pair]bool
+	// Maps each subtree (SyntaxPair) to whether it contains pattern variables
+	containsVariables map[*syntax.SyntaxPair]bool
 	// Maps each subtree to the set of variables it contains
-	variablesInSubtree map[*values.Pair]map[string]struct{}
+	variablesInSubtree map[*syntax.SyntaxPair]map[string]struct{}
 }
 
 // NewPatternAnalysis creates a new pattern analysis
 func NewPatternAnalysis() *PatternAnalysis {
 	return &PatternAnalysis{
-		containsVariables:  make(map[*values.Pair]bool),
-		variablesInSubtree: make(map[*values.Pair]map[string]struct{}),
+		containsVariables:  make(map[*syntax.SyntaxPair]bool),
+		variablesInSubtree: make(map[*syntax.SyntaxPair]map[string]struct{}),
 	}
 }
 
 // AnalyzePattern analyzes a pattern and returns analysis results
-func AnalyzePattern(pattern *values.Pair, variables map[string]struct{}) *PatternAnalysis {
+func AnalyzePattern(pattern *syntax.SyntaxPair, variables map[string]struct{}) *PatternAnalysis {
 	analysis := NewPatternAnalysis()
-	// Use the provided variables directly
-	// In a full implementation, these would be determined from syntax-rules literals
-
-	// Analyze which subtrees contain variables
 	analyzeRecursive(pattern, variables, analysis)
 	return analysis
 }
 
 // AnalyzePatternWithLiterals analyzes a pattern determining variables from literals
-func AnalyzePatternWithLiterals(pattern *values.Pair, literals map[string]struct{}, isKeyword bool) *PatternAnalysis {
+func AnalyzePatternWithLiterals(pattern *syntax.SyntaxPair, literals map[string]struct{}, isKeyword bool) *PatternAnalysis {
 	analysis := NewPatternAnalysis()
 	// Determine pattern variables first
 	variables := make(map[string]struct{})
@@ -59,40 +55,40 @@ func AnalyzePatternWithLiterals(pattern *values.Pair, literals map[string]struct
 
 // collectPatternVariables walks the pattern and identifies all pattern variables.
 // Uses the default ellipsis identifier ("...").
-func collectPatternVariables(v values.Value, literals map[string]struct{}, isFirst bool, variables map[string]struct{}) {
+func collectPatternVariables(v syntax.SyntaxValue, literals map[string]struct{}, isFirst bool, variables map[string]struct{}) {
 	collectPatternVariablesWithEllipsis(v, literals, isFirst, variables, DefaultEllipsis)
 }
 
 // collectPatternVariablesWithEllipsis walks the pattern and identifies all pattern variables,
 // using the specified ellipsis identifier.
-func collectPatternVariablesWithEllipsis(v values.Value, literals map[string]struct{}, isFirst bool, variables map[string]struct{}, ellipsis string) {
+func collectPatternVariablesWithEllipsis(v syntax.SyntaxValue, literals map[string]struct{}, isFirst bool, variables map[string]struct{}, ellipsis string) {
 	switch t := v.(type) {
-	case *values.Symbol:
+	case *syntax.SyntaxSymbol:
 		// Skip if it's a keyword (first element), literal, or ellipsis
-		if !isFirst && t.Key != ellipsis {
-			_, isLiteral := literals[t.Key]
+		if !isFirst && t.Sym.Key != ellipsis {
+			_, isLiteral := literals[t.Sym.Key]
 			if !isLiteral {
-				variables[t.Key] = struct{}{}
+				variables[t.Sym.Key] = struct{}{}
 			}
 		}
-	case *values.Pair:
-		if !values.IsEmptyList(t) {
+	case *syntax.SyntaxPair:
+		if !syntax.IsSyntaxEmptyList(t) {
 			// First element in a pattern is the keyword
-			collectPatternVariablesWithEllipsis(t.Car(), literals, isFirst, variables, ellipsis)
+			collectPatternVariablesWithEllipsis(t.SyntaxCar(), literals, isFirst, variables, ellipsis)
 			// Rest of the pattern
-			collectPatternVariablesWithEllipsis(t.Cdr(), literals, false, variables, ellipsis)
+			collectPatternVariablesWithEllipsis(t.SyntaxCdr(), literals, false, variables, ellipsis)
 		}
 	}
 }
 
 // analyzeRecursive analyzes which subtrees contain pattern variables
-func analyzeRecursive(v values.Value, variables map[string]struct{}, analysis *PatternAnalysis) bool {
+func analyzeRecursive(v syntax.SyntaxValue, variables map[string]struct{}, analysis *PatternAnalysis) bool {
 	switch t := v.(type) {
-	case *values.Symbol:
-		_, isVar := variables[t.Key]
+	case *syntax.SyntaxSymbol:
+		_, isVar := variables[t.Sym.Key]
 		return isVar
-	case *values.Pair:
-		if values.IsEmptyList(t) {
+	case *syntax.SyntaxPair:
+		if syntax.IsSyntaxEmptyList(t) {
 			return false
 		}
 
@@ -100,18 +96,18 @@ func analyzeRecursive(v values.Value, variables map[string]struct{}, analysis *P
 		varsInSubtree := make(map[string]struct{})
 
 		// Check car (first element)
-		carHasVars := analyzeRecursive(t.Car(), variables, analysis)
+		carHasVars := analyzeRecursive(t.SyntaxCar(), variables, analysis)
 		if carHasVars {
 			// If car is a symbol variable, add it
-			sym, ok := t.Car().(*values.Symbol)
+			sym, ok := t.SyntaxCar().(*syntax.SyntaxSymbol)
 			if ok {
-				_, isVar := variables[sym.Key]
+				_, isVar := variables[sym.Sym.Key]
 				if isVar {
-					varsInSubtree[sym.Key] = struct{}{}
+					varsInSubtree[sym.Sym.Key] = struct{}{}
 				}
 			}
 			// If car is a pair, merge its variables
-			carPair, ok := t.Car().(*values.Pair)
+			carPair, ok := t.SyntaxCar().(*syntax.SyntaxPair)
 			if ok {
 				carVars, exists := analysis.variablesInSubtree[carPair]
 				if exists {
@@ -123,10 +119,10 @@ func analyzeRecursive(v values.Value, variables map[string]struct{}, analysis *P
 		}
 
 		// Check cdr (rest)
-		cdrHasVars := analyzeRecursive(t.Cdr(), variables, analysis)
+		cdrHasVars := analyzeRecursive(t.SyntaxCdr(), variables, analysis)
 		if cdrHasVars {
 			// If cdr is a pair, merge its variables
-			cdrPair, ok := t.Cdr().(*values.Pair)
+			cdrPair, ok := t.SyntaxCdr().(*syntax.SyntaxPair)
 			if ok {
 				cdrVars, exists := analysis.variablesInSubtree[cdrPair]
 				if exists {
@@ -149,7 +145,7 @@ func analyzeRecursive(v values.Value, variables map[string]struct{}, analysis *P
 }
 
 // ContainsVariables returns whether a subtree contains pattern variables
-func (p *PatternAnalysis) ContainsVariables(pair *values.Pair) bool {
+func (p *PatternAnalysis) ContainsVariables(pair *syntax.SyntaxPair) bool {
 	if pair == nil {
 		return false
 	}
@@ -157,7 +153,7 @@ func (p *PatternAnalysis) ContainsVariables(pair *values.Pair) bool {
 }
 
 // GetVariables returns the set of variables in a subtree
-func (p *PatternAnalysis) GetVariables(pair *values.Pair) map[string]struct{} {
+func (p *PatternAnalysis) GetVariables(pair *syntax.SyntaxPair) map[string]struct{} {
 	if pair == nil {
 		return nil
 	}

--- a/internal/match/pattern_analyzer_test.go
+++ b/internal/match/pattern_analyzer_test.go
@@ -17,25 +17,24 @@ package match
 import (
 	"testing"
 
-	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/internal/syntax"
 
 	qt "github.com/frankban/quicktest"
 )
 
 func TestAnalyzePatternWithLiterals(t *testing.T) {
-	list := func(vs ...values.Value) *values.Pair { return values.List(vs...).(*values.Pair) }
 	tcs := []struct {
 		name      string
-		pattern   *values.Pair
+		pattern   *syntax.SyntaxPair
 		literals  map[string]struct{}
 		isKeyword bool
 	}{
 		{
 			name: "Simple pattern with literals",
-			pattern: list(
-				values.NewSymbol("define"),
-				values.NewSymbol("x"),
-				values.NewSymbol("y"),
+			pattern: testSyntaxList(
+				testSyntaxSym("define"),
+				testSyntaxSym("x"),
+				testSyntaxSym("y"),
 			),
 			literals: map[string]struct{}{
 				"define": {},
@@ -44,21 +43,21 @@ func TestAnalyzePatternWithLiterals(t *testing.T) {
 		},
 		{
 			name: "Pattern with no literals",
-			pattern: list(
-				values.NewSymbol("foo"),
-				values.NewSymbol("a"),
-				values.NewSymbol("b"),
+			pattern: testSyntaxList(
+				testSyntaxSym("foo"),
+				testSyntaxSym("a"),
+				testSyntaxSym("b"),
 			),
 			literals:  map[string]struct{}{},
 			isKeyword: true,
 		},
 		{
 			name: "Pattern with multiple literals",
-			pattern: list(
-				values.NewSymbol("let"),
-				values.NewSymbol("name"),
-				values.NewSymbol("else"),
-				values.NewSymbol("x"),
+			pattern: testSyntaxList(
+				testSyntaxSym("let"),
+				testSyntaxSym("name"),
+				testSyntaxSym("else"),
+				testSyntaxSym("x"),
 			),
 			literals: map[string]struct{}{
 				"let":  {},
@@ -81,16 +80,16 @@ func TestAnalyzePatternWithLiterals(t *testing.T) {
 func TestCollectPatternVariables(t *testing.T) {
 	tcs := []struct {
 		name         string
-		pattern      values.Value
+		pattern      syntax.SyntaxValue
 		literals     map[string]struct{}
 		isFirst      bool
 		expectedVars map[string]struct{}
 	}{
 		{
 			name: "Simple symbol pattern",
-			pattern: values.List(
-				values.NewSymbol("define"),
-				values.NewSymbol("x"),
+			pattern: testSyntaxList(
+				testSyntaxSym("define"),
+				testSyntaxSym("x"),
 			),
 			literals: map[string]struct{}{
 				"define": {},
@@ -102,10 +101,10 @@ func TestCollectPatternVariables(t *testing.T) {
 		},
 		{
 			name: "Pattern with ellipsis",
-			pattern: values.List(
-				values.NewSymbol("let"),
-				values.NewSymbol("x"),
-				values.NewSymbol("..."),
+			pattern: testSyntaxList(
+				testSyntaxSym("let"),
+				testSyntaxSym("x"),
+				testSyntaxSym("..."),
 			),
 			literals: map[string]struct{}{
 				"let": {},
@@ -117,10 +116,10 @@ func TestCollectPatternVariables(t *testing.T) {
 		},
 		{
 			name: "Nested pattern",
-			pattern: values.List(
-				values.NewSymbol("lambda"),
-				values.List(values.NewSymbol("x"), values.NewSymbol("y")),
-				values.NewSymbol("body"),
+			pattern: testSyntaxList(
+				testSyntaxSym("lambda"),
+				testSyntaxList(testSyntaxSym("x"), testSyntaxSym("y")),
+				testSyntaxSym("body"),
 			),
 			literals: map[string]struct{}{
 				"lambda": {},
@@ -144,11 +143,11 @@ func TestCollectPatternVariables(t *testing.T) {
 }
 
 func TestContainsVariables(t *testing.T) {
-	pattern := values.List(
-		values.NewSymbol("define"),
-		values.NewSymbol("x"),
-		values.NewInteger(42),
-	).(*values.Pair)
+	pattern := testSyntaxList(
+		testSyntaxSym("define"),
+		testSyntaxSym("x"),
+		testSyntaxInt(42),
+	)
 	variables := map[string]struct{}{
 		"x": {},
 	}
@@ -163,11 +162,11 @@ func TestContainsVariables(t *testing.T) {
 }
 
 func TestGetVariables(t *testing.T) {
-	pattern := values.List(
-		values.NewSymbol("define"),
-		values.NewSymbol("x"),
-		values.NewSymbol("y"),
-	).(*values.Pair)
+	pattern := testSyntaxList(
+		testSyntaxSym("define"),
+		testSyntaxSym("x"),
+		testSyntaxSym("y"),
+	)
 	variables := map[string]struct{}{
 		"x": {},
 		"y": {},

--- a/internal/match/syntax_adapter.go
+++ b/internal/match/syntax_adapter.go
@@ -701,77 +701,6 @@ func (p *SyntaxMatcher) expandEscapedSyntaxTemplate(
 	}
 }
 
-// syntaxToValue recursively unwraps syntax objects to raw values.Value types.
-//
-// This is the "datum" extraction from R7RS syntax->datum. It strips away:
-//   - Source location information (file, line, column)
-//   - Scope sets (used for hygiene)
-//
-// Used by CompileSyntaxPatternWithLiterals to convert syntax patterns to
-// raw values.Pair for the pattern compiler, which operates on values.Pair.
-func syntaxToValue(stx syntax.SyntaxValue) values.Value {
-	if stx == nil {
-		return nil
-	}
-
-	switch s := stx.(type) {
-	case *syntax.SyntaxPair:
-		if s == nil || s.IsEmptyList() {
-			return values.EmptyList
-		}
-		// Recursively unwrap car and cdr
-		var car values.Value
-		carVal := s.Car()
-		if carVal != nil {
-			carSyntax, ok := carVal.(syntax.SyntaxValue)
-			if ok {
-				car = syntaxToValue(carSyntax)
-			} else {
-				// If it's already a value, use it directly
-				car = carVal
-			}
-		}
-
-		var cdr values.Value
-		cdrVal := s.SyntaxCdr()
-		if cdrVal != nil {
-			cdrSyntax := cdrVal
-			cdr = syntaxToValue(cdrSyntax)
-			// } else {
-			// If it's already a value, use it directly
-			//	cdr = cdrVal.(values.wrt)
-			//}
-		}
-
-		// nil: syntax node had no cdr; EmptyList: proper list terminator
-		if cdr == nil || values.IsEmptyList(cdr) {
-			return values.NewCons(car, values.EmptyList)
-		}
-		cdrPair, ok := cdr.(*values.Pair)
-		if ok {
-			return values.NewCons(car, cdrPair)
-		}
-		// Improper list
-		return values.NewCons(car, cdr)
-
-	case *syntax.SyntaxSymbol:
-		return s.Unwrap()
-
-	case *syntax.SyntaxObject:
-		return s.Unwrap()
-
-	default:
-		// For other syntax types, try to unwrap
-		unwrapper, ok := stx.(interface{ Unwrap() values.Value })
-		if ok {
-			return unwrapper.Unwrap()
-		}
-		// If it's already a value, return as-is
-		val := stx
-		return val
-	}
-}
-
 // CompiledPattern contains the compiled bytecode and ellipsis variable mapping.
 type CompiledPattern struct {
 	Codes        []SyntaxCommand
@@ -814,11 +743,8 @@ func CompileSyntaxPatternWithLiterals(ctx context.Context, pattern syntax.Syntax
 		ellipsisID = DefaultEllipsis
 	}
 
-	// Convert syntax pattern to raw values
-	rawPattern := syntaxToValue(pattern)
-
-	// Ensure it's a pair
-	pair, ok := rawPattern.(*values.Pair)
+	// Pattern must be a syntax pair
+	pair, ok := pattern.(*syntax.SyntaxPair)
 	if !ok {
 		return nil, values.WrapForeignErrorf(values.ErrNotAList, "CompileSyntaxPatternWithLiterals: pattern must be a list")
 	}

--- a/internal/match/syntax_adapter_test.go
+++ b/internal/match/syntax_adapter_test.go
@@ -63,9 +63,9 @@ func TestSyntaxMatcher(t *testing.T) {
 		}
 
 		// Compile pattern: (define x)
-		pattern := testList(
-			values.NewSymbol("define"),
-			values.NewSymbol("x"),
+		pattern := testSyntaxList(
+			testSyntaxSym("define"),
+			testSyntaxSym("x"),
 		)
 
 		compiler := NewSyntaxCompiler()
@@ -117,9 +117,9 @@ func TestSyntaxMatcher(t *testing.T) {
 			"x": {},
 		}
 
-		pattern := testList(
-			values.NewSymbol("define"),
-			values.NewSymbol("x"),
+		pattern := testSyntaxList(
+			testSyntaxSym("define"),
+			testSyntaxSym("x"),
 		)
 
 		compiler := NewSyntaxCompiler()
@@ -216,59 +216,6 @@ func TestCompileSyntaxPattern(t *testing.T) {
 	})
 }
 
-func TestSyntaxToValue(t *testing.T) {
-	t.Run("SyntaxSymbol to Sym", func(t *testing.T) {
-		srcCtx := syntax.NewSourceContext("", "", syntax.SourceIndexes{}, syntax.SourceIndexes{})
-		stx := syntax.NewSyntaxSymbol("foo", srcCtx)
-
-		val := syntaxToValue(stx)
-		sym, ok := val.(*values.Symbol)
-		qt.Assert(t, ok, qt.IsTrue)
-		qt.Assert(t, sym.Key, qt.Equals, "foo")
-	})
-
-	t.Run("SyntaxPair to Pair", func(t *testing.T) {
-		srcCtx := syntax.NewSourceContext("", "", syntax.SourceIndexes{}, syntax.SourceIndexes{})
-		stx := syntax.NewSyntaxCons(
-			syntax.NewSyntaxSymbol("a", srcCtx),
-			syntax.NewSyntaxCons(
-				syntax.NewSyntaxSymbol("b", srcCtx),
-				syntax.NewSyntaxEmptyList(srcCtx),
-				srcCtx,
-			),
-			srcCtx,
-		)
-
-		val := syntaxToValue(stx)
-		pair, ok := val.(*values.Pair)
-		qt.Assert(t, ok, qt.IsTrue)
-		qt.Assert(t, pair, qt.IsNotNil)
-	})
-
-	t.Run("SyntaxObject to underlying value", func(t *testing.T) {
-		srcCtx := syntax.NewSourceContext("", "", syntax.SourceIndexes{}, syntax.SourceIndexes{})
-		stx := syntax.NewSyntaxObject(values.NewInteger(42), srcCtx)
-
-		val := syntaxToValue(stx)
-		num, ok := val.(*values.Integer)
-		qt.Assert(t, ok, qt.IsTrue)
-		qt.Assert(t, num.Value, qt.Equals, int64(42))
-	})
-
-	t.Run("nil syntax", func(t *testing.T) {
-		val := syntaxToValue(nil)
-		qt.Assert(t, val, qt.IsNil)
-	})
-
-	t.Run("Empty list", func(t *testing.T) {
-		srcCtx := syntax.NewSourceContext("", "", syntax.SourceIndexes{}, syntax.SourceIndexes{})
-		stx := syntax.NewSyntaxEmptyList(srcCtx)
-
-		val := syntaxToValue(stx)
-		qt.Assert(t, values.IsEmptyList(val), qt.IsTrue)
-	})
-}
-
 // TestExpandWithUseSite verifies that ExpandWithUseSite uses the use-site
 // source context for newly created syntax objects instead of the template's context.
 func TestExpandWithUseSite(t *testing.T) {
@@ -279,9 +226,9 @@ func TestExpandWithUseSite(t *testing.T) {
 		"x": {},
 	}
 
-	pattern := testList(
-		values.NewSymbol("macro"),
-		values.NewSymbol("x"),
+	pattern := testSyntaxList(
+		testSyntaxSym("macro"),
+		testSyntaxSym("x"),
 	)
 
 	compiler := NewSyntaxCompiler()
@@ -310,7 +257,7 @@ func TestExpandWithUseSite(t *testing.T) {
 		useSiteSc,
 	)
 
-	// Match the input
+	// Match
 	matcher := NewSyntaxMatcher(compiler.variables, compiler.codes)
 	err = matcher.Match(context.Background(), input)
 	c.Assert(err, qt.IsNil)
@@ -366,9 +313,9 @@ func TestExpandWithUseSite_PreservesPatternVars(t *testing.T) {
 		"x": {},
 	}
 
-	pattern := testList(
-		values.NewSymbol("test"),
-		values.NewSymbol("x"),
+	pattern := testSyntaxList(
+		testSyntaxSym("test"),
+		testSyntaxSym("x"),
 	)
 
 	compiler := NewSyntaxCompiler()
@@ -429,7 +376,7 @@ func TestExpandWithUseSite_NilUseSite(t *testing.T) {
 
 	variables := map[string]struct{}{}
 
-	pattern := testList(values.NewSymbol("test"))
+	pattern := testSyntaxList(testSyntaxSym("test"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -469,7 +416,7 @@ func TestExpandWithOrigin(t *testing.T) {
 	c := qt.New(t)
 
 	// Set up pattern: (test)
-	pattern := testList(values.NewSymbol("test"))
+	pattern := testSyntaxList(testSyntaxSym("test"))
 	compiler := NewSyntaxCompiler()
 	compiler.variables = map[string]struct{}{}
 	err := compiler.Compile(context.TODO(), pattern)
@@ -516,7 +463,7 @@ func TestExpandWithOrigin_ChainedOrigins(t *testing.T) {
 	c := qt.New(t)
 
 	// Set up pattern: (test)
-	pattern := testList(values.NewSymbol("test"))
+	pattern := testSyntaxList(testSyntaxSym("test"))
 	compiler := NewSyntaxCompiler()
 	compiler.variables = map[string]struct{}{}
 	err := compiler.Compile(context.TODO(), pattern)
@@ -567,9 +514,9 @@ func TestExpandWithOrigin_PreservesPatternVars(t *testing.T) {
 	c := qt.New(t)
 
 	// Set up pattern: (test x) where x is a pattern variable
-	pattern := testList(
-		values.NewSymbol("test"),
-		values.NewSymbol("x"),
+	pattern := testSyntaxList(
+		testSyntaxSym("test"),
+		testSyntaxSym("x"),
 	)
 	compiler := NewSyntaxCompiler()
 	compiler.variables = map[string]struct{}{"x": {}}

--- a/internal/match/syntax_compiler.go
+++ b/internal/match/syntax_compiler.go
@@ -62,10 +62,10 @@ var (
 )
 
 type syntaxCompilerStackEntry struct {
-	mark             int          // position in instructions in which loops will return to
-	lastElementStart int          // position where the last element's bytecode starts
-	lastElement      values.Value // the actual last element value for analysis lookup
-	pr               *values.Pair
+	mark             int                // position in instructions in which loops will return to
+	lastElementStart int                // position where the last element's bytecode starts
+	lastElement      syntax.SyntaxValue // the actual last element value for analysis lookup
+	pr               *syntax.SyntaxPair
 	variables        map[string]struct{}
 	vararg           bool
 }
@@ -123,16 +123,15 @@ func (p *SyntaxCompiler) SetSkipMacroKeyword(skip bool) {
 }
 
 // Compile compiles a pattern pair into bytecode.
-func (p *SyntaxCompiler) Compile(ctx context.Context, pr *values.Pair) error {
+func (p *SyntaxCompiler) Compile(ctx context.Context, pr *syntax.SyntaxPair) error {
 	// Analyze pattern first to identify which subtrees contain variables
-	// Use the pre-set variables for now (from test setup)
 	p.analysis = AnalyzePattern(pr, p.variables)
 
 	compile(ctx, p, pr)
 	return nil
 }
 
-func compile(ctx context.Context, vis *SyntaxCompiler, v0 *values.Pair) bool {
+func compile(ctx context.Context, vis *SyntaxCompiler, v0 *syntax.SyntaxPair) bool {
 	stack := []syntaxCompilerStackEntry{
 		{pr: v0, variables: map[string]struct{}{}},
 	}
@@ -147,9 +146,9 @@ func compile(ctx context.Context, vis *SyntaxCompiler, v0 *values.Pair) bool {
 // Returns the updated stack (with current level popped and Done emitted).
 func compileCurrentLevel(ctx context.Context, vis *SyntaxCompiler, stack []syntaxCompilerStackEntry) []syntaxCompilerStackEntry { //nolint:unparam
 	l := len(stack)
-	for !values.IsEmptyList(stack[l-1].pr) && !values.IsVoid(stack[l-1].pr) {
+	for !syntax.IsSyntaxEmptyList(stack[l-1].pr) && !stack[l-1].pr.IsVoid() {
 		elementStart := len(vis.codes)
-		element := stack[l-1].pr.Car()
+		element := stack[l-1].pr.SyntaxCar()
 
 		// Process the current element and get updated stack
 		var shouldContinue bool
@@ -173,7 +172,7 @@ func compileCurrentLevel(ctx context.Context, vis *SyntaxCompiler, stack []synta
 
 // compileElement compiles a single element (car of current pair).
 // Returns the updated stack and whether the main loop should continue (skip CDR handling).
-func compileElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, element values.Value, elementStart int) ([]syntaxCompilerStackEntry, bool) {
+func compileElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, element syntax.SyntaxValue, elementStart int) ([]syntaxCompilerStackEntry, bool) {
 	l := len(stack)
 
 	// R7RS §4.3.2: The first subform of each pattern is the keyword of the macro
@@ -186,32 +185,32 @@ func compileElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, eleme
 	}
 
 	// Handle pair elements (nested lists)
-	pr, ok := element.(*values.Pair)
+	pr, ok := element.(*syntax.SyntaxPair)
 	if ok {
 		return compilePairElement(vis, stack, pr, element, elementStart)
 	}
 
 	// Handle symbol elements
-	sym, ok := element.(*values.Symbol)
+	sym, ok := element.(*syntax.SyntaxSymbol)
 	if ok {
 		skipCdr := compileSymbolElement(vis, &stack[l-1], sym)
 		return stack, skipCdr
 	}
 
-	// Handle literal values (numbers, strings, etc.)
-	vis.codes = append(vis.codes, ByteCodeCompareCar{Value: valueToSyntaxValue(element)})
+	// Handle literal values (numbers, strings, etc.) — already syntax
+	vis.codes = append(vis.codes, ByteCodeCompareCar{Value: element})
 	return stack, false
 }
 
 // compilePairElement handles when the current element is a pair (nested list).
 // For empty pairs, emits RequireCarEmpty. For non-empty, emits VisitCar and pushes to stack.
-func compilePairElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, pr *values.Pair, element values.Value, elementStart int) ([]syntaxCompilerStackEntry, bool) {
+func compilePairElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, pr *syntax.SyntaxPair, element syntax.SyntaxValue, elementStart int) ([]syntaxCompilerStackEntry, bool) {
 	l := len(stack)
 
-	if values.IsEmptyList(pr) {
+	if syntax.IsSyntaxEmptyList(pr) {
 		// Empty pair pattern () - verify input car is also empty
 		vis.codes = append(vis.codes, ByteCodeRequireCarEmpty{})
-		stack[l-1].pr, _ = stack[l-1].pr.Cdr().(*values.Pair)
+		stack[l-1].pr, _ = stack[l-1].pr.SyntaxCdr().(*syntax.SyntaxPair)
 		stack[l-1].lastElement = element
 		stack[l-1].lastElementStart = elementStart
 		return stack, true
@@ -219,7 +218,7 @@ func compilePairElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, p
 
 	// Non-empty nested pair - descend into it
 	vis.codes = append(vis.codes, ByteCodeVisitCar{})
-	stack[l-1].pr, _ = stack[l-1].pr.Cdr().(*values.Pair)
+	stack[l-1].pr, _ = stack[l-1].pr.SyntaxCdr().(*syntax.SyntaxPair)
 	stack[l-1].lastElement = element
 	stack[l-1].lastElementStart = elementStart
 
@@ -233,16 +232,16 @@ func compilePairElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, p
 
 // compileSymbolElement handles symbol elements: ellipsis, wildcards, variables, and literals.
 // Returns true if CDR handling should be skipped (e.g., for ellipsis-in-middle patterns).
-func compileSymbolElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, sym *values.Symbol) bool {
+func compileSymbolElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, sym *syntax.SyntaxSymbol) bool {
 	// Check for ellipsis (custom or default)
-	if sym.Key == vis.ellipsis {
+	if sym.Sym.Key == vis.ellipsis {
 		return compileEllipsis(vis, entry)
 	}
 	// Check for wildcard
 	// R7RS §4.3.2: The identifier _ is a wildcard that matches any input, unless
 	// it appears in the list of literals, in which case it is matched literally.
-	if sym.Key == "_" {
-		_, isLiteral := vis.literals[sym.Key]
+	if sym.Sym.Key == "_" {
+		_, isLiteral := vis.literals[sym.Sym.Key]
 		if !isLiteral {
 			// Wildcard - matches anything but doesn't bind (no bytecode emitted)
 			return false
@@ -255,14 +254,14 @@ func compileSymbolElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, 
 }
 
 // compileSymbolOrLiteral handles a symbol that's either a pattern variable or a literal.
-func compileSymbolOrLiteral(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, sym *values.Symbol) {
-	if _, isVar := vis.variables[sym.Key]; isVar {
+func compileSymbolOrLiteral(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, sym *syntax.SyntaxSymbol) {
+	if _, isVar := vis.variables[sym.Sym.Key]; isVar {
 		// Pattern variable - capture it
-		vis.codes = append(vis.codes, ByteCodeCaptureCar{Binding: sym.Key})
-		entry.variables[sym.Key] = struct{}{}
+		vis.codes = append(vis.codes, ByteCodeCaptureCar{Binding: sym.Sym.Key})
+		entry.variables[sym.Sym.Key] = struct{}{}
 	} else {
 		// Literal symbol - compare exactly
-		vis.codes = append(vis.codes, ByteCodeCompareCar{Value: syntax.NewSyntaxSymbolForSymbol(sym, nil)})
+		vis.codes = append(vis.codes, ByteCodeCompareCar{Value: syntax.NewSyntaxSymbol(sym.Sym.Key, nil)})
 	}
 }
 
@@ -304,7 +303,7 @@ func compileEllipsis(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry) bool 
 	// 3. We just need to update entry.pr to point to the tail pattern elements
 	if tailCount > 0 {
 		// Advance entry.pr past the ellipsis to the tail elements
-		entry.pr, _ = entry.pr.Cdr().(*values.Pair)
+		entry.pr, _ = entry.pr.SyntaxCdr().(*syntax.SyntaxPair)
 		return true
 	}
 	return false
@@ -312,17 +311,17 @@ func compileEllipsis(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry) bool 
 
 // countPatternTailElements counts the number of pattern elements that follow
 // the ellipsis. This is used for ellipsis-in-middle patterns like (a ... b c).
-func countPatternTailElements(ellipsisPair *values.Pair) int {
+func countPatternTailElements(ellipsisPair *syntax.SyntaxPair) int {
 	// ellipsisPair car is "...", ellipsisPair cdr is the rest
-	cdr := ellipsisPair.Cdr()
+	cdr := ellipsisPair.SyntaxCdr()
 	count := 0
 	for {
-		pr, ok := cdr.(*values.Pair)
-		if !ok || values.IsEmptyList(pr) {
+		pr, ok := cdr.(*syntax.SyntaxPair)
+		if !ok || syntax.IsSyntaxEmptyList(pr) {
 			break
 		}
 		count++
-		cdr = pr.Cdr()
+		cdr = pr.SyntaxCdr()
 	}
 	return count
 }
@@ -333,13 +332,13 @@ func previousElementHasVariables(vis *SyntaxCompiler, entry *syntaxCompilerStack
 		return false
 	}
 
-	prevPair, ok := entry.lastElement.(*values.Pair)
+	prevPair, ok := entry.lastElement.(*syntax.SyntaxPair)
 	if ok {
 		return vis.analysis.ContainsVariables(prevPair)
 	}
-	prevSym, ok := entry.lastElement.(*values.Symbol)
+	prevSym, ok := entry.lastElement.(*syntax.SyntaxSymbol)
 	if ok {
-		_, isVar := vis.variables[prevSym.Key]
+		_, isVar := vis.variables[prevSym.Sym.Key]
 		return isVar
 	}
 	return false
@@ -349,17 +348,17 @@ func previousElementHasVariables(vis *SyntaxCompiler, entry *syntaxCompilerStack
 func collectCapturedVariables(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry) map[string]struct{} {
 	capturedVars := make(map[string]struct{})
 
-	if prevPair, ok := entry.lastElement.(*values.Pair); ok {
+	if prevPair, ok := entry.lastElement.(*syntax.SyntaxPair); ok {
 		vars := vis.analysis.GetVariables(prevPair)
 		for v := range vars {
 			capturedVars[v] = struct{}{}
 		}
 	} else {
-		prevSym, ok := entry.lastElement.(*values.Symbol)
+		prevSym, ok := entry.lastElement.(*syntax.SyntaxSymbol)
 		if ok {
-			_, isVar := vis.variables[prevSym.Key]
+			_, isVar := vis.variables[prevSym.Sym.Key]
 			if isVar {
-				capturedVars[prevSym.Key] = struct{}{}
+				capturedVars[prevSym.Sym.Key] = struct{}{}
 			}
 		}
 	}
@@ -454,10 +453,10 @@ func isPairPattern(codes []SyntaxCommand) bool {
 
 // advanceToNextElement handles CDR advancement after processing an element.
 // Returns false if at end of list (should break from loop).
-func advanceToNextElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, element values.Value, elementStart int) bool {
-	cdr := entry.pr.Cdr()
-	cdrPair, ok := cdr.(*values.Pair)
-	if ok && !values.IsEmptyList(cdrPair) {
+func advanceToNextElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, element syntax.SyntaxValue, elementStart int) bool {
+	cdr := entry.pr.SyntaxCdr()
+	cdrPair, ok := cdr.(*syntax.SyntaxPair)
+	if ok && !syntax.IsSyntaxEmptyList(cdrPair) {
 		// Normal case: more elements in proper list
 		vis.codes = append(vis.codes, ByteCodeVisitCdr{})
 		entry.lastElementStart = elementStart
@@ -468,15 +467,15 @@ func advanceToNextElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, 
 	}
 
 	// Check for improper list pattern: (_ a . rest) where rest is a pattern variable
-	sym, ok := cdr.(*values.Symbol)
+	sym, ok := cdr.(*syntax.SyntaxSymbol)
 	if ok {
-		if _, isVar := vis.variables[sym.Key]; isVar {
+		if _, isVar := vis.variables[sym.Sym.Key]; isVar {
 			// The CDR is a pattern variable - emit CaptureCdr to capture the rest
-			vis.codes = append(vis.codes, ByteCodeCaptureCdr{Binding: sym.Key})
-			entry.variables[sym.Key] = struct{}{}
+			vis.codes = append(vis.codes, ByteCodeCaptureCdr{Binding: sym.Sym.Key})
+			entry.variables[sym.Sym.Key] = struct{}{}
 		} else {
 			// The CDR is a literal symbol - compare it
-			vis.codes = append(vis.codes, ByteCodeCompareCdr{Value: syntax.NewSyntaxSymbolForSymbol(sym, nil)})
+			vis.codes = append(vis.codes, ByteCodeCompareCdr{Value: syntax.NewSyntaxSymbol(sym.Sym.Key, nil)})
 		}
 	}
 

--- a/internal/match/syntax_compiler_test.go
+++ b/internal/match/syntax_compiler_test.go
@@ -20,21 +20,10 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/internal/syntax"
-	"github.com/aalpar/wile/values"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
 )
-
-// testSyntaxIntC creates a syntax-wrapped integer for test bytecode in compiler tests.
-func testSyntaxIntC(v int64) syntax.SyntaxValue {
-	return syntax.NewSyntaxObject(values.NewInteger(v), nil)
-}
-
-// testSyntaxSymC creates a syntax-wrapped symbol for test bytecode in compiler tests.
-func testSyntaxSymC(key string) syntax.SyntaxValue {
-	return syntax.NewSyntaxSymbol(key, nil)
-}
 
 // bytecodeEqual compares two bytecode slices by their string representation.
 // This avoids issues with qt.DeepEquals not being able to compare unexported fields.
@@ -60,16 +49,16 @@ type UtilsMatcherSuite struct{}
 func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 	tcs := []struct {
 		variables map[string]struct{}
-		in        *values.Pair
+		in        *syntax.SyntaxPair
 		out       []SyntaxCommand
 	}{
 		{
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in: testList(values.NewInteger(10), values.NewSymbol("a")),
+			in: testSyntaxList(testSyntaxInt(10), testSyntaxSym("a")),
 			out: []SyntaxCommand{
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
 				ByteCodeVisitCdr{},
 				ByteCodeCaptureCar{Binding: "a"},
 				ByteCodeDone{},
@@ -77,12 +66,12 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 		},
 		{
 			variables: map[string]struct{}{},
-			in:        testList(values.List(values.NewInteger(10)), values.NewInteger(20)),
+			in:        testSyntaxList(testSyntaxList(testSyntaxInt(10)), testSyntaxInt(20)),
 			out: []SyntaxCommand{
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
 				ByteCodeDone{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(20)},
+				ByteCodeCompareCar{Value: testSyntaxInt(20)},
 				ByteCodeDone{},
 			},
 		},
@@ -90,47 +79,47 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in: testList(values.NewInteger(10), values.List(values.NewSymbol("a"), values.NewSymbol("b")), values.NewInteger(40)),
+			in: testSyntaxList(testSyntaxInt(10), testSyntaxList(testSyntaxSym("a"), testSyntaxSym("b")), testSyntaxInt(40)),
 			out: []SyntaxCommand{
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
 				ByteCodeVisitCdr{},
 				ByteCodeVisitCar{},
 				ByteCodeCaptureCar{Binding: "a"},
 				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeDone{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(40)},
-				ByteCodeDone{},
-			},
-		},
-		{
-			variables: map[string]struct{}{},
-			in:        testList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
-			out: []SyntaxCommand{
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
-				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(20)},
-				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(30)},
+				ByteCodeCompareCar{Value: testSyntaxInt(40)},
 				ByteCodeDone{},
 			},
 		},
 		{
 			variables: map[string]struct{}{},
-			in: testList(
-				values.NewInteger(10), values.NewInteger(20), values.List(
-					values.NewSymbol("a"), values.NewSymbol("b")), values.NewSymbol("...")),
+			in:        testSyntaxList(testSyntaxInt(10), testSyntaxInt(20), testSyntaxInt(30)),
 			out: []SyntaxCommand{
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
 				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(20)},
+				ByteCodeCompareCar{Value: testSyntaxInt(20)},
+				ByteCodeVisitCdr{},
+				ByteCodeCompareCar{Value: testSyntaxInt(30)},
+				ByteCodeDone{},
+			},
+		},
+		{
+			variables: map[string]struct{}{},
+			in: testSyntaxList(
+				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
+					testSyntaxSym("a"), testSyntaxSym("b")), testSyntaxSym("...")),
+			out: []SyntaxCommand{
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
+				ByteCodeVisitCdr{},
+				ByteCodeCompareCar{Value: testSyntaxInt(20)},
 				ByteCodeVisitCdr{},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("a")},
+				ByteCodeCompareCar{Value: testSyntaxSym("a")},
 				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeDone{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("...")},
+				ByteCodeCompareCar{Value: testSyntaxSym("...")},
 				ByteCodeDone{},
 			},
 		},
@@ -138,13 +127,13 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in: testList(
-				values.NewInteger(10), values.NewInteger(20), values.List(
-					values.NewSymbol("a"), values.NewSymbol("b")), values.NewSymbol("...")),
+			in: testSyntaxList(
+				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
+					testSyntaxSym("a"), testSyntaxSym("b")), testSyntaxSym("...")),
 			out: []SyntaxCommand{
-				ByteCodeCompareCar{Value: testSyntaxIntC(10)},
+				ByteCodeCompareCar{Value: testSyntaxInt(10)},
 				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxIntC(20)},
+				ByteCodeCompareCar{Value: testSyntaxInt(20)},
 				ByteCodeVisitCdr{},
 				// SkipIfEmpty checks for empty list before executing loop body
 				ByteCodeSkipIfEmpty{Offset: 9},
@@ -153,7 +142,7 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeCaptureCar{Binding: "a"},
 				ByteCodeVisitCdr{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeDone{},
 				ByteCodePopContext{},
 				ByteCodeJump{Offset: -8},
@@ -162,7 +151,7 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 		},
 	}
 	for i, tc := range tcs {
-		c.Run(fmt.Sprintf("%d: %s", i, tc.in.SchemeString()), func(c *qt.C) {
+		c.Run(fmt.Sprintf("%d", i), func(c *qt.C) {
 			vst := NewSyntaxCompiler()
 			vst.variables = tc.variables
 			vst.Compile(context.TODO(), tc.in) //nolint:errcheck
@@ -175,7 +164,7 @@ func (UtilsMatcherSuite) TestMatchCompile(c *qt.C) {
 func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 	tcs := []struct {
 		variables map[string]struct{}
-		in        *values.Pair
+		in        *syntax.SyntaxPair
 		target    *syntax.SyntaxPair
 		matches   bool
 	}{
@@ -183,13 +172,13 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in:      testList(values.NewInteger(10), values.NewSymbol("a")),
+			in:      testSyntaxList(testSyntaxInt(10), testSyntaxSym("a")),
 			target:  testSyntaxList(testSyntaxInt(10), testSyntaxInt(20)),
 			matches: true,
 		},
 		{
 			variables: map[string]struct{}{},
-			in:        testList(values.List(values.NewInteger(10)), values.NewInteger(20)),
+			in:        testSyntaxList(testSyntaxList(testSyntaxInt(10)), testSyntaxInt(20)),
 			target:    testSyntaxList(testSyntaxList(testSyntaxInt(10)), testSyntaxInt(20)),
 			matches:   true,
 		},
@@ -197,10 +186,10 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in: testList(
-				values.NewInteger(10), values.List(
-					values.NewSymbol("a"), values.NewSymbol("b"),
-				), values.NewInteger(40),
+			in: testSyntaxList(
+				testSyntaxInt(10), testSyntaxList(
+					testSyntaxSym("a"), testSyntaxSym("b"),
+				), testSyntaxInt(40),
 			),
 			target: testSyntaxList(
 				testSyntaxInt(10), testSyntaxList(
@@ -211,15 +200,15 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 		},
 		{
 			variables: map[string]struct{}{},
-			in:        testList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
+			in:        testSyntaxList(testSyntaxInt(10), testSyntaxInt(20), testSyntaxInt(30)),
 			target:    testSyntaxList(testSyntaxInt(10), testSyntaxInt(20), testSyntaxInt(30)),
 			matches:   true,
 		},
 		{
 			variables: map[string]struct{}{},
-			in: testList(
-				values.NewInteger(10), values.NewInteger(20), values.List(
-					values.NewSymbol("a"), values.NewSymbol("b")), values.NewSymbol("...")),
+			in: testSyntaxList(
+				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
+					testSyntaxSym("a"), testSyntaxSym("b")), testSyntaxSym("...")),
 			target: testSyntaxList(
 				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
 					testSyntaxSym("a"), testSyntaxSym("b")), testSyntaxSym("...")),
@@ -229,10 +218,10 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 			variables: map[string]struct{}{
 				"a": {},
 			},
-			in: testList(
-				values.NewInteger(10), values.NewInteger(20), values.List(
-					values.NewSymbol("a"), values.NewSymbol("b"),
-				), values.NewSymbol("..."),
+			in: testSyntaxList(
+				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
+					testSyntaxSym("a"), testSyntaxSym("b"),
+				), testSyntaxSym("..."),
 			),
 			target: testSyntaxList(
 				testSyntaxInt(10), testSyntaxInt(20), testSyntaxList(
@@ -246,7 +235,7 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 		},
 	}
 	for i, tc := range tcs {
-		c.Run(fmt.Sprintf("%d: %s", i, tc.in.SchemeString()), func(c *qt.C) {
+		c.Run(fmt.Sprintf("%d", i), func(c *qt.C) {
 			vst := NewSyntaxCompiler()
 			vst.variables = tc.variables
 			err := vst.Compile(context.TODO(), tc.in)
@@ -254,9 +243,9 @@ func (UtilsMatcherSuite) TestMatchExecute(c *qt.C) {
 			mtc := NewMatcher(vst.variables, vst.codes)
 			err = mtc.MatchSyntax(context.Background(), tc.target)
 			if tc.matches {
-				c.Assert(err, qt.IsNil, qt.Commentf("expected match for %s", tc.in.SchemeString()))
+				c.Assert(err, qt.IsNil, qt.Commentf("expected match"))
 			} else {
-				c.Assert(err, qt.ErrorIs, ErrNotAMatch, qt.Commentf("expected no match for %s", tc.in.SchemeString()))
+				c.Assert(err, qt.ErrorIs, ErrNotAMatch, qt.Commentf("expected no match"))
 			}
 		})
 	}
@@ -274,7 +263,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -283,7 +272,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -294,7 +283,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -303,7 +292,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeDone{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -314,7 +303,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -323,7 +312,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeJump{Offset: +3},
 				ByteCodeDone{},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -334,7 +323,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -343,7 +332,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeJump{Offset: +3},
 				ByteCodeVisitCar{},
 				ByteCodeDone{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -3},
 				ByteCodeVisitCar{},
 			},
@@ -354,7 +343,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -362,7 +351,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeDone{},
 				ByteCodeJump{Offset: -3},
 				ByteCodeVisitCar{},
@@ -374,7 +363,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -382,7 +371,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeDone{},
 				ByteCodeVisitCar{},
@@ -394,7 +383,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 			},
@@ -402,7 +391,7 @@ func (UtilsMatcherSuite) TestInsert(c *qt.C) {
 				ByteCodeVisitCar{},
 				ByteCodeJump{Offset: +2},
 				ByteCodeVisitCar{},
-				ByteCodeCompareCar{Value: testSyntaxSymC("b")},
+				ByteCodeCompareCar{Value: testSyntaxSym("b")},
 				ByteCodeJump{Offset: -2},
 				ByteCodeVisitCar{},
 				ByteCodeDone{},

--- a/internal/match/syntax_expand_test.go
+++ b/internal/match/syntax_expand_test.go
@@ -206,13 +206,13 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		inputVal values.Value
+		inputVal syntax.SyntaxValue
 		template syntax.SyntaxValue
 		checkFn  func(c *qt.C, result syntax.SyntaxValue)
 	}{
 		{
 			name:     "variable substitution yields captured integer",
-			inputVal: values.NewInteger(42),
+			inputVal: syntax.NewSyntaxObject(values.NewInteger(42), nil),
 			template: syntax.NewSyntaxSymbol("x", nil),
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				obj, ok := result.(*syntax.SyntaxObject)
@@ -222,7 +222,7 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 		},
 		{
 			name:     "variable substitution yields captured symbol",
-			inputVal: values.NewSymbol("hello"),
+			inputVal: syntax.NewSyntaxSymbol("hello", nil),
 			template: syntax.NewSyntaxSymbol("x", nil),
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				sym, ok := result.(*syntax.SyntaxSymbol)
@@ -232,7 +232,7 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 		},
 		{
 			name:     "non-variable symbol returned with hygiene",
-			inputVal: values.NewInteger(42),
+			inputVal: syntax.NewSyntaxObject(values.NewInteger(42), nil),
 			template: syntax.NewSyntaxSymbol("other", nil),
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				sym, ok := result.(*syntax.SyntaxSymbol)
@@ -242,7 +242,7 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 		},
 		{
 			name:     "empty list template returns empty list",
-			inputVal: values.NewInteger(42),
+			inputVal: syntax.NewSyntaxObject(values.NewInteger(42), nil),
 			template: syntax.NewSyntaxEmptyList(nil),
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				pr, ok := result.(*syntax.SyntaxPair)
@@ -255,7 +255,7 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 	for _, tc := range tcs {
 		c.Run(tc.name, func(c *qt.C) {
 			variables := map[string]struct{}{"x": {}}
-			pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+			pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 			compiler := NewSyntaxCompiler()
 			compiler.variables = variables
@@ -265,7 +265,7 @@ func TestSyntaxExpandSimpleSubstitution(t *testing.T) {
 			input := syntax.NewSyntaxCons(
 				syntax.NewSyntaxSymbol("macro", nil),
 				syntax.NewSyntaxCons(
-					valueToSyntaxValue(tc.inputVal),
+					tc.inputVal,
 					syntax.NewSyntaxEmptyList(nil),
 					nil,
 				),
@@ -325,7 +325,7 @@ func TestSyntaxExpandWithIntroScope(t *testing.T) {
 	for _, tc := range tcs {
 		c.Run(tc.name, func(c *qt.C) {
 			variables := map[string]struct{}{"x": {}}
-			pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+			pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 			compiler := NewSyntaxCompiler()
 			compiler.variables = variables
@@ -360,7 +360,7 @@ func TestSyntaxExpandPairTemplate(t *testing.T) {
 	c := qt.New(t)
 
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -412,12 +412,12 @@ func TestSyntaxExpandEllipsis(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		inputVal []values.Value
+		inputVal []syntax.SyntaxValue
 		checkFn  func(c *qt.C, result syntax.SyntaxValue)
 	}{
 		{
 			name:     "zero repetitions yields empty list",
-			inputVal: []values.Value{},
+			inputVal: []syntax.SyntaxValue{},
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				pr, ok := result.(*syntax.SyntaxPair)
 				c.Assert(ok, qt.IsTrue)
@@ -426,7 +426,7 @@ func TestSyntaxExpandEllipsis(t *testing.T) {
 		},
 		{
 			name:     "single repetition",
-			inputVal: []values.Value{values.NewInteger(1)},
+			inputVal: []syntax.SyntaxValue{syntax.NewSyntaxObject(values.NewInteger(1), nil)},
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				pr, ok := result.(*syntax.SyntaxPair)
 				c.Assert(ok, qt.IsTrue)
@@ -438,10 +438,10 @@ func TestSyntaxExpandEllipsis(t *testing.T) {
 		},
 		{
 			name: "multiple repetitions",
-			inputVal: []values.Value{
-				values.NewInteger(10),
-				values.NewInteger(20),
-				values.NewInteger(30),
+			inputVal: []syntax.SyntaxValue{
+				syntax.NewSyntaxObject(values.NewInteger(10), nil),
+				syntax.NewSyntaxObject(values.NewInteger(20), nil),
+				syntax.NewSyntaxObject(values.NewInteger(30), nil),
 			},
 			checkFn: func(c *qt.C, result syntax.SyntaxValue) {
 				// Walk the list and collect unwrapped values
@@ -488,9 +488,7 @@ func TestSyntaxExpandEllipsis(t *testing.T) {
 
 			// Build input: (_ val1 val2 ...)
 			inputElems := []syntax.SyntaxValue{syntax.NewSyntaxSymbol("_", nil)}
-			for _, v := range tc.inputVal {
-				inputElems = append(inputElems, valueToSyntaxValue(v))
-			}
+			inputElems = append(inputElems, tc.inputVal...)
 			input := testSyntaxList(inputElems...)
 
 			sm := NewSyntaxMatcherWithEllipsisVars(variables, compiled.Codes, compiled.EllipsisVars)
@@ -526,7 +524,7 @@ func TestSyntaxExpandPreservesPatternVarScopes(t *testing.T) {
 	c := qt.New(t)
 
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -573,7 +571,7 @@ func TestSyntaxExpandScopeAwareSubstitution(t *testing.T) {
 	// Test that pattern variable substitution respects scope compatibility
 	// when patternVarSyntax is provided.
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -612,7 +610,7 @@ func TestSyntaxExpandScopeAwareNoSubstitution(t *testing.T) {
 	// When template symbol has extra scopes vs pattern variable, substitution
 	// should NOT occur (nested macro hygiene).
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -655,7 +653,7 @@ func TestSyntaxExpandEscapedTemplate(t *testing.T) {
 	c := qt.New(t)
 
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -740,7 +738,7 @@ func TestSyntaxExpandVectorTemplate(t *testing.T) {
 	c := qt.New(t)
 
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables
@@ -788,7 +786,7 @@ func TestSyntaxExpandNilTemplate(t *testing.T) {
 	c := qt.New(t)
 
 	variables := map[string]struct{}{"x": {}}
-	pattern := testList(values.NewSymbol("macro"), values.NewSymbol("x"))
+	pattern := testSyntaxList(testSyntaxSym("macro"), testSyntaxSym("x"))
 
 	compiler := NewSyntaxCompiler()
 	compiler.variables = variables


### PR DESCRIPTION
## Summary

- Eliminates the `syntaxToValue()` / `valueToSyntaxValue()` round-trip in the pattern matching adapter layer. The compiler and analyzer now walk `*syntax.SyntaxPair` directly instead of converting to/from `*values.Pair`.
- Deletes ~105 lines of conversion code (`syntaxToValue`, `valueToSyntaxValue`, `valueTupleToSyntaxPair`) that existed solely to bridge between syntax and raw value types.
- Net result: 9 files changed, 222 insertions, 415 deletions (−193 lines).

No changes to the Matcher VM, bytecode types, template expansion, public API signatures, or external callers in `machine/`.

Ref: `plans/ARCHITECTURAL_REVIEW_STAFF.md` — "Pattern Matching Adapter Layer: Two Separate Conversions for Syntax ↔ Raw Values"

## Test plan

- [x] `go build ./internal/match/...` — compilation
- [x] `go test -v ./internal/match/...` — all 71 unit tests pass
- [x] `golangci-lint run ./internal/match/...` — 0 issues
- [x] `make test` — full Go + Scheme test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)