### PR TITLE
docs: remove resolved items from architectural review, update plan index

### DIFF
--- a/plans/ARCHITECTURAL_REVIEW.md
+++ b/plans/ARCHITECTURAL_REVIEW.md
@@ -1,6 +1,6 @@
 # Architectural Code Review
 
-**Date:** 2026-02-12
+**Date:** 2026-02-14
 **Scope:** Full codebase review across values/, machine/, tokenizer/parser/syntax, registry/core/, extensions, and public API.
 
 ---
@@ -13,19 +13,11 @@ LOW priority: 18 of 19 fixed/resolved, 1 documented (L10), 1 deferred (L19).
 
 ---
 
-## Resolved LOW Items
-
-| # | Location | Issue | Resolution |
-|---|----------|-------|------------|
-| L3 | `values/channel.go` | `ChannelSelect` busy-spins without `reflect.Select` | **Debunked** — implementation uses `reflect.Select` (line 296); no busy-spin exists |
-| L11 | `internal/extensions/eval/prim_eval.go` | `eval` doesn't inherit dynamic context | **Fixed** — commit `a722464` added `SetThread` propagation to eval/load sub-contexts |
-| L15 | `internal/extensions/threads/prim_threads.go` | `thread-sleep!` ignores context cancellation | **Debunked** — lines 243-246 properly handle `ctx.Done()` via select |
-
 ## Open LOW Items
 
 | # | Location | Issue | Status |
 |---|----------|-------|--------|
-| L19 | `internal/tokenizer/tokenizer.go:2294` | `isExtendedExponentMarkerForRadix` ignores radix | Deferred (exotic edge case) |
+| L19 | `internal/tokenizer/tokenizer.go:2060` | `isExtendedExponentMarker` ignores radix | Deferred (exotic edge case) |
 
 ### Deferral Criteria
 

--- a/plans/CLAUDE.md
+++ b/plans/CLAUDE.md
@@ -44,8 +44,8 @@ When investigating R7RS conformance issues:
 | `ARCHITECTURAL_REVIEW.md` | 1 deferred LOW item (L19); all others resolved | Tracking |
 | `ARCHITECTURAL_REVIEW_FIXES.md` | Complete fix history (EXEMPT from cleanup) | Reference |
 | `ARCHITECTURAL_REVIEW_STAFF.md` | Full-codebase tech debt; all HIGH/MEDIUM resolved, LOW items remain | Reference |
-| `ARCHITECTURAL_REVIEW_REFACTORING.md` | Open refactoring opportunities (Tiers 2-4; §2.2 resolved) | Reference |
-| `STRUCTURAL_ANALYSIS.md` | Dependency metrics, type precision; ExpandOptions resolved | Reference |
+| `ARCHITECTURAL_REVIEW_REFACTORING.md` | Open refactoring opportunities (Tiers 2-4) | Reference |
+| `STRUCTURAL_ANALYSIS.md` | Dependency metrics, type precision | Reference |
 
 ### Testing & Methodology
 


### PR DESCRIPTION
## Summary

- Delete resolved LOW items (L3 debunked, L11 fixed, L15 debunked) from `ARCHITECTURAL_REVIEW.md`
- Update L19 location: `isExtendedExponentMarkerForRadix` → `isExtendedExponentMarker` (line 2294 → 2060) after tokenizer consolidation
- Remove stale "§2.2 resolved" and "ExpandOptions resolved" references from `plans/CLAUDE.md` index

## Test plan

- [ ] Documentation only — no code changes