### PR TITLE
fix: restore argument-role context in byte validation errors

### DIFF
--- a/registry/core/prim_byte_vectors.go
+++ b/registry/core/prim_byte_vectors.go
@@ -42,7 +42,7 @@ func PrimMakeBytevector(_ context.Context, mc *machine.MachineContext) error {
 			if !ok {
 				return values.WrapForeignErrorf(values.ErrNotAnInteger, "make-bytevector: fill must be an integer but got %T", fillVal)
 			}
-			err := helpers.ValidateByteValue(fillInt, "make-bytevector")
+			err := helpers.ValidateByteValue(fillInt, "make-bytevector", "fill")
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func PrimBytevector(ctx context.Context, mc *machine.MachineContext) error {
 		if !ok {
 			return values.WrapForeignErrorf(values.ErrNotAnInteger, "bytevector: expected an integer but got %T", v)
 		}
-		err := helpers.ValidateByteValue(intVal, "bytevector")
+		err := helpers.ValidateByteValue(intVal, "bytevector", "value")
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func PrimBytevectorU8Set(_ context.Context, mc *machine.MachineContext) error {
 			if err != nil {
 				return err
 			}
-			err = helpers.ValidateByteValue(byteVal, "bytevector-u8-set!")
+			err = helpers.ValidateByteValue(byteVal, "bytevector-u8-set!", "value")
 			if err != nil {
 				return err
 			}

--- a/registry/helpers/args.go
+++ b/registry/helpers/args.go
@@ -136,10 +136,10 @@ func ParseSubrange(rest values.Value, length int, name string) (int, int, error)
 
 // ValidateByteValue checks that an integer is in the byte range [0, 255].
 // Returns a wrapped ErrInvalidArgument error if the value is out of range.
-func ValidateByteValue(v *values.Integer, name string) error {
+func ValidateByteValue(v *values.Integer, name string, desc string) error {
 	if v.Value < 0 || v.Value > 255 {
 		return values.WrapForeignErrorf(values.ErrInvalidArgument,
-			"%s: value must be a byte (0-255)", name)
+			"%s: %s must be a byte (0-255)", name, desc)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `desc` parameter to `ValidateByteValue()` so call sites specify the argument role (e.g. "fill") instead of generic "value"
- Restores the `make-bytevector: fill must be a byte (0-255)` error message lost during the dedup in #243
- `bytevector` and `bytevector-u8-set!` continue to use "value" since that's appropriate there

Addresses [Greptile's inline review comment](https://github.com/aalpar/wile/pull/243#discussion_r2807942987) on PR #243.

## Test plan

- [x] All bytevector tests pass (`go test -v -run TestBytevector ./registry/core/...`)
- [x] `go_diagnostics` reports no errors
- [x] `goimports` clean