### PR TITLE
refactor: move ValidateByteValue to values/byte.go, use ErrNotAByte sentinel

### DIFF
--- a/internal/extensions/io/prim_read_write.go
+++ b/internal/extensions/io/prim_read_write.go
@@ -585,8 +585,9 @@ func PrimWriteU8(_ context.Context, mc *machine.MachineContext) error {
 	var b byte
 	switch v := byteVal.(type) {
 	case *values.Integer:
-		if v.Value < 0 || v.Value > 255 {
-			return values.WrapForeignErrorf(values.ErrInvalidArgument, "write-u8: byte must be an exact integer in the range 0-255")
+		err := values.ValidateByteValue(v, "write-u8", "byte")
+		if err != nil {
+			return err
 		}
 		b = byte(v.Value)
 	default:

--- a/internal/extensions/io/prim_read_write_test.go
+++ b/internal/extensions/io/prim_read_write_test.go
@@ -17,6 +17,7 @@ package io
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"sync"
@@ -1188,6 +1189,24 @@ func TestWriteU8Coverage(t *testing.T) {
 	for _, tc := range errs {
 		t.Run(tc.name, func(t *testing.T) {
 			evalExpectError(t, engine, tc.code)
+		})
+	}
+}
+
+func TestWriteU8_ByteRangeSentinel(t *testing.T) {
+	engine := newEngine(t)
+	tcs := []struct {
+		name string
+		code string
+	}{
+		{"byte 256", `(write-u8 256 (open-output-bytevector))`},
+		{"byte -1", `(write-u8 -1 (open-output-bytevector))`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := engine.Eval(context.Background(), tc.code)
+			qt.Assert(t, err, qt.IsNotNil)
+			qt.Assert(t, errors.Is(err, values.ErrNotAByte), qt.IsTrue)
 		})
 	}
 }

--- a/plans/ARCHITECTURAL_REVIEW_REFACTORING.md
+++ b/plans/ARCHITECTURAL_REVIEW_REFACTORING.md
@@ -54,9 +54,13 @@ The `expandCompileExecute` helper was already extracted previously.
 
 ### ~~3.3 Byte Validation Duplication~~ ✅ COMPLETE
 
-**Completed.** Extracted `ValidateByteValue()` helper in `registry/helpers/args.go`.
-Three call sites in `registry/core/prim_byte_vectors.go` (`PrimMakeBytevector`,
-`PrimBytevector`, `PrimBytevectorU8Set`) now delegate to the shared helper.
+`ValidateByteValue()` moved to `values/byte.go` (was `registry/helpers/args.go`) using
+`ErrNotAByte` sentinel. Five call sites now delegate to the shared helper:
+`PrimMakeBytevector`, `PrimBytevector`, `PrimBytevectorU8Set` (registry/core),
+`PrimWriteU8` (internal/extensions/io), `NewByteVectorFromIntegers` (values).
+
+**Intentionally not converted:** `internal/parser/parser.go` `readByteVector` — uses
+`NewParserErrorWithWrapf` (different error constructor with token position context).
 
 ---
 

--- a/registry/core/prim_byte_vector_test.go
+++ b/registry/core/prim_byte_vector_test.go
@@ -15,6 +15,7 @@
 package core_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aalpar/wile/values"
@@ -559,6 +560,27 @@ func TestBytevectorU8Set_EdgeCases(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
 			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+		})
+	}
+}
+
+func TestByteRangeValidation_Sentinel(t *testing.T) {
+	tcs := []struct {
+		name string
+		code string
+	}{
+		{"make-bytevector fill > 255", `(make-bytevector 3 256)`},
+		{"make-bytevector fill < 0", `(make-bytevector 3 -1)`},
+		{"bytevector element > 255", `(bytevector 1 256 3)`},
+		{"bytevector element < 0", `(bytevector 1 -1 3)`},
+		{"bytevector-u8-set! value > 255", `(bytevector-u8-set! (bytevector 1 2 3) 0 256)`},
+		{"bytevector-u8-set! value < 0", `(bytevector-u8-set! (bytevector 1 2 3) 0 -1)`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runSchemeCode(t, tc.code)
+			qt.Assert(t, err, qt.IsNotNil)
+			qt.Assert(t, errors.Is(err, values.ErrNotAByte), qt.IsTrue)
 		})
 	}
 }

--- a/registry/core/prim_byte_vectors.go
+++ b/registry/core/prim_byte_vectors.go
@@ -42,7 +42,7 @@ func PrimMakeBytevector(_ context.Context, mc *machine.MachineContext) error {
 			if !ok {
 				return values.WrapForeignErrorf(values.ErrNotAnInteger, "make-bytevector: fill must be an integer but got %T", fillVal)
 			}
-			err := helpers.ValidateByteValue(fillInt, "make-bytevector", "fill")
+			err := values.ValidateByteValue(fillInt, "make-bytevector", "fill")
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ func PrimBytevector(ctx context.Context, mc *machine.MachineContext) error {
 		if !ok {
 			return values.WrapForeignErrorf(values.ErrNotAnInteger, "bytevector: expected an integer but got %T", v)
 		}
-		err := helpers.ValidateByteValue(intVal, "bytevector", "value")
+		err := values.ValidateByteValue(intVal, "bytevector", "value")
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func PrimBytevectorU8Set(_ context.Context, mc *machine.MachineContext) error {
 			if err != nil {
 				return err
 			}
-			err = helpers.ValidateByteValue(byteVal, "bytevector-u8-set!", "value")
+			err = values.ValidateByteValue(byteVal, "bytevector-u8-set!", "value")
 			if err != nil {
 				return err
 			}

--- a/registry/helpers/args.go
+++ b/registry/helpers/args.go
@@ -133,13 +133,3 @@ func ParseSubrange(rest values.Value, length int, name string) (int, int, error)
 	}
 	return int(start), int(end), nil
 }
-
-// ValidateByteValue checks that an integer is in the byte range [0, 255].
-// Returns a wrapped ErrInvalidArgument error if the value is out of range.
-func ValidateByteValue(v *values.Integer, name string, desc string) error {
-	if v.Value < 0 || v.Value > 255 {
-		return values.WrapForeignErrorf(values.ErrInvalidArgument,
-			"%s: %s must be a byte (0-255)", name, desc)
-	}
-	return nil
-}

--- a/values/byte.go
+++ b/values/byte.go
@@ -60,3 +60,13 @@ func (p *Byte) EqualTo(v Value) bool {
 func (p *Byte) SchemeString() string {
 	return fmt.Sprintf("%d", p.Value)
 }
+
+// ValidateByteValue checks that an integer is in the byte range [0, 255].
+// Returns a wrapped ErrNotAByte error if the value is out of range.
+func ValidateByteValue(v *Integer, name string, desc string) error {
+	if v.Value < 0 || v.Value > 255 {
+		return WrapForeignErrorf(ErrNotAByte,
+			"%s: %s must be a byte (0-255)", name, desc)
+	}
+	return nil
+}

--- a/values/byte_vector.go
+++ b/values/byte_vector.go
@@ -58,11 +58,11 @@ func NewByteVectorFromIntegers(vs ...*Integer) (*ByteVector, error) {
 	bs := make([]*Byte, len(vs))
 	q := ByteVector(bs)
 	for i := range vs {
-		v := vs[i].Value
-		if v < 0 || v > 255 {
-			return nil, WrapForeignErrorf(ErrNotAByte, "NewByteVectorFromIntegers: integer %d is not a byte (0-255)", v)
+		err := ValidateByteValue(vs[i], "NewByteVectorFromIntegers", "element")
+		if err != nil {
+			return nil, err
 		}
-		b := NewByte(uint8(v))
+		b := NewByte(uint8(vs[i].Value))
 		q[i] = b
 	}
 	return &q, nil


### PR DESCRIPTION
## Summary

- Moved `ValidateByteValue` from `registry/helpers/args.go` to `values/byte.go`, co-located with the `Byte` type
- Changed sentinel from `ErrInvalidArgument` to `ErrNotAByte` for precise programmatic matching
- Updated all 5 call sites: `PrimMakeBytevector`, `PrimBytevector`, `PrimBytevectorU8Set`, `PrimWriteU8`, `NewByteVectorFromIntegers`
- Added sentinel-checking tests in `prim_byte_vector_test.go` and `prim_read_write_test.go`
- Intentionally left `internal/parser/readByteVector` unconverted (uses `NewParserErrorWithWrapf` with token position context)

## Test plan

- [x] Existing byte vector tests pass
- [x] New sentinel tests verify `errors.Is(err, values.ErrNotAByte)` for all converted call sites
- [x] `write-u8` sentinel tests verify the I/O path