### PR TITLE
refactor: deduplicate validator prologues with formPrologue helper

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -171,6 +171,51 @@ func collectList(pair *syntax.SyntaxPair) ([]syntax.SyntaxValue, bool) {
 	}
 }
 
+// formPrologue collects list elements, validates the list is proper,
+// and checks argument count (excluding the form keyword at elements[0]).
+// minArgs and maxArgs define acceptable argument counts.
+// Use maxArgs < 0 for unlimited.
+func formPrologue(
+	pair *syntax.SyntaxPair,
+	formName string,
+	minArgs, maxArgs int,
+	result *ValidationResult,
+) (*syntax.SourceContext, []syntax.SyntaxValue, bool) {
+	source := pair.SourceContext()
+
+	elements, improper := collectList(pair)
+	if improper {
+		result.addError(source, formName, formName+" form must be a proper list")
+		return nil, nil, false
+	}
+
+	argCount := len(elements) - 1
+
+	if minArgs == maxArgs && maxArgs >= 0 {
+		if argCount != minArgs {
+			result.addErrorf(source, formName,
+				"%s requires exactly %d argument(s), got %d",
+				formName, minArgs, argCount)
+			return nil, nil, false
+		}
+	} else {
+		if argCount < minArgs {
+			result.addErrorf(source, formName,
+				"%s requires at least %d argument(s), got %d",
+				formName, minArgs, argCount)
+			return nil, nil, false
+		}
+		if maxArgs >= 0 && argCount > maxArgs {
+			result.addErrorf(source, formName,
+				"%s requires at most %d argument(s), got %d",
+				formName, maxArgs, argCount)
+			return nil, nil, false
+		}
+	}
+
+	return source, elements, true
+}
+
 // getSourceContext extracts SourceContext from a SyntaxValue if available
 func getSourceContext(v syntax.SyntaxValue) *syntax.SourceContext {
 	switch sv := v.(type) {

--- a/internal/validate/validate_begin.go
+++ b/internal/validate/validate_begin.go
@@ -23,16 +23,11 @@ import (
 
 // validateBegin validates (begin expr...)
 func validateBegin(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "begin", "begin form must be a proper list")
+	source, elements, ok := formPrologue(pair, "begin", 0, -1, result)
+	if !ok {
 		return nil
 	}
 
-	// elements[0] is 'begin', can have zero or more expressions
 	// R7RS allows (begin) with no expressions (returns unspecified value)
 	var body []ValidatedExpr
 	for i := 1; i < len(elements); i++ {

--- a/internal/validate/validate_case_lambda.go
+++ b/internal/validate/validate_case_lambda.go
@@ -24,18 +24,8 @@ import (
 // validateCaseLambda validates (case-lambda [clause] ...)
 // Each clause is (params body...) like a lambda without the 'lambda' keyword
 func validateCaseLambda(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "case-lambda", "case-lambda form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'case-lambda', need at least one clause
-	if len(elements) < 2 {
-		result.addError(source, "case-lambda", "case-lambda requires at least one clause")
+	source, elements, ok := formPrologue(pair, "case-lambda", 1, -1, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_define.go
+++ b/internal/validate/validate_define.go
@@ -25,18 +25,8 @@ import (
 // validateDefine validates both forms:
 // (define name expr) and (define (name params...) body...)
 func validateDefine(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "define", "define form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'define', need at least name and value/body
-	if len(elements) < 3 {
-		result.addErrorf(source, "define", "define requires at least 2 arguments, got %d", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "define", 2, -1, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_dynamic_wind.go
+++ b/internal/validate/validate_dynamic_wind.go
@@ -27,20 +27,8 @@ import (
 // Before is called whenever execution enters the dynamic extent of the call to thunk,
 // and after is called whenever it exits.
 func validateDynamicWind(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice for easier validation
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "dynamic-wind", "dynamic-wind form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'dynamic-wind' symbol, actual args start at [1]
-	argCount := len(elements) - 1
-
-	if argCount != 3 {
-		result.addErrorf(source, "dynamic-wind", "dynamic-wind requires exactly 3 arguments, got %d", argCount)
+	source, elements, ok := formPrologue(pair, "dynamic-wind", 3, 3, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_if.go
+++ b/internal/validate/validate_if.go
@@ -23,25 +23,8 @@ import (
 
 // validateIf validates (if test conseq [alt])
 func validateIf(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice for easier validation
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "if", "if form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'if' symbol, actual args start at [1]
-	argCount := len(elements) - 1
-
-	if argCount < 2 {
-		result.addErrorf(source, "if", "if requires at least 2 arguments, got %d", argCount)
-		return nil
-	}
-
-	if argCount > 3 {
-		result.addErrorf(source, "if", "if requires at most 3 arguments, got %d", argCount)
+	source, elements, ok := formPrologue(pair, "if", 2, 3, result)
+	if !ok {
 		return nil
 	}
 
@@ -50,12 +33,12 @@ func validateIf(ctx context.Context, env *environment.EnvironmentFrame, pair *sy
 	conseq := validateExpr(ctx, env, elements[2], result)
 
 	var alt ValidatedExpr
-	if argCount == 3 {
+	if len(elements)-1 == 3 {
 		alt = validateExpr(ctx, env, elements[3], result)
 	}
 
 	// If any sub-validation failed, don't return a valid form
-	if test == nil || conseq == nil || (argCount == 3 && alt == nil) {
+	if test == nil || conseq == nil || (len(elements)-1 == 3 && alt == nil) {
 		return nil
 	}
 

--- a/internal/validate/validate_lambda.go
+++ b/internal/validate/validate_lambda.go
@@ -23,18 +23,8 @@ import (
 
 // validateLambda validates (lambda (params...) body...)
 func validateLambda(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "lambda", "lambda form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'lambda', need params and at least one body expr
-	if len(elements) < 3 {
-		result.addErrorf(source, "lambda", "lambda requires parameters and at least one body expression, got %d parts", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "lambda", 2, -1, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_macro.go
+++ b/internal/validate/validate_macro.go
@@ -26,23 +26,14 @@ import (
 // Returns a ValidatedLiteral wrapping the original form since the compiler
 // has specialized handling for this.
 func validateDefineSyntax(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "define-syntax", "define-syntax form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'define-syntax', need keyword and transformer
-	if len(elements) != 3 {
-		result.addErrorf(source, "define-syntax", "define-syntax requires exactly 2 arguments (keyword and transformer), got %d", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "define-syntax", 2, 2, result)
+	if !ok {
 		return nil
 	}
 
 	// Second element must be a symbol (the keyword to bind)
-	_, ok := asSyntaxSymbol(elements[1])
-	if !ok {
+	_, isSym := asSyntaxSymbol(elements[1])
+	if !isSym {
 		result.addError(getSourceContext(elements[1]), "define-syntax", "define-syntax keyword must be a symbol")
 		return nil
 	}
@@ -58,17 +49,8 @@ func validateDefineSyntax(_ context.Context, env *environment.EnvironmentFrame, 
 // validateSyntaxRules validates (syntax-rules (literals...) clause...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateSyntaxRules(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "syntax-rules", "syntax-rules form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'syntax-rules', need at least literals list
-	if len(elements) < 2 {
-		result.addError(source, "syntax-rules", "syntax-rules requires at least a literals list")
+	source, elements, ok := formPrologue(pair, "syntax-rules", 1, -1, result)
+	if !ok {
 		return nil
 	}
 
@@ -122,17 +104,8 @@ func validateSyntaxRules(ctx context.Context, env *environment.EnvironmentFrame,
 // validateImport validates (import import-set...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateImport(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "import", "import form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'import', need at least one import set
-	if len(elements) < 2 {
-		result.addError(source, "import", "import requires at least one import-set")
+	source, elements, ok := formPrologue(pair, "import", 1, -1, result)
+	if !ok {
 		return nil
 	}
 
@@ -153,11 +126,8 @@ func validateImport(_ context.Context, env *environment.EnvironmentFrame, pair *
 // validateExport validates (export export-spec...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateExport(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "export", "export form must be a proper list")
+	source, elements, ok := formPrologue(pair, "export", 0, -1, result)
+	if !ok {
 		return nil
 	}
 
@@ -185,17 +155,8 @@ func validateExport(_ context.Context, env *environment.EnvironmentFrame, pair *
 // validateDefineLibrary validates (define-library (name...) declaration...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateDefineLibrary(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "define-library", "define-library form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'define-library', need at least library name
-	if len(elements) < 2 {
-		result.addError(source, "define-library", "define-library requires a library name")
+	source, elements, ok := formPrologue(pair, "define-library", 1, -1, result)
+	if !ok {
 		return nil
 	}
 
@@ -237,17 +198,8 @@ func validateDefineLibrary(ctx context.Context, env *environment.EnvironmentFram
 // validateInclude validates (include filename...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateInclude(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "include", "include form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'include', need at least one filename
-	if len(elements) < 2 {
-		result.addError(source, "include", "include requires at least one filename")
+	source, elements, ok := formPrologue(pair, "include", 1, -1, result)
+	if !ok {
 		return nil
 	}
 
@@ -269,11 +221,8 @@ func validateInclude(_ context.Context, env *environment.EnvironmentFrame, pair 
 // validateCondExpand validates (cond-expand clause...)
 // Returns a ValidatedLiteral wrapping the original form.
 func validateCondExpand(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "cond-expand", "cond-expand form must be a proper list")
+	source, elements, ok := formPrologue(pair, "cond-expand", 0, -1, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_quote.go
+++ b/internal/validate/validate_quote.go
@@ -23,18 +23,8 @@ import (
 
 // validateQuote validates (quote datum)
 func validateQuote(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "quote", "quote form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'quote', need exactly one datum
-	if len(elements) != 2 {
-		result.addErrorf(source, "quote", "quote requires exactly 1 argument, got %d", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "quote", 1, 1, result)
+	if !ok {
 		return nil
 	}
 
@@ -50,18 +40,8 @@ func validateQuote(_ context.Context, env *environment.EnvironmentFrame, pair *s
 // Note: The template is not deeply validated here because quasiquote
 // has complex runtime semantics with nested unquote/unquote-splicing
 func validateQuasiquote(_ context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "quasiquote", "quasiquote form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'quasiquote', need exactly one template
-	if len(elements) != 2 {
-		result.addErrorf(source, "quasiquote", "quasiquote requires exactly 1 argument, got %d", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "quasiquote", 1, 1, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_set.go
+++ b/internal/validate/validate_set.go
@@ -23,18 +23,8 @@ import (
 
 // validateSetBang validates (set! name expr)
 func validateSetBang(ctx context.Context, env *environment.EnvironmentFrame, pair *syntax.SyntaxPair, result *ValidationResult) ValidatedExpr {
-	source := pair.SourceContext()
-
-	// Collect all elements into a slice
-	elements, improper := collectList(pair)
-	if improper {
-		result.addError(source, "set!", "set! form must be a proper list")
-		return nil
-	}
-
-	// elements[0] is 'set!', need exactly name and value
-	if len(elements) != 3 {
-		result.addErrorf(source, "set!", "set! requires exactly 2 arguments, got %d", len(elements)-1)
+	source, elements, ok := formPrologue(pair, "set!", 2, 2, result)
+	if !ok {
 		return nil
 	}
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -37,6 +37,100 @@ type validationTestCase struct {
 	wantOk bool
 }
 
+// TestFormPrologue tests the formPrologue helper directly
+func TestFormPrologue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   values.Value
+		form    string
+		minArgs int
+		maxArgs int
+		wantOk  bool
+		wantLen int // expected len(elements) when ok
+	}{
+		{
+			name:    "proper list exact arity match",
+			input:   values.List(values.NewSymbol("quote"), values.NewSymbol("x")),
+			form:    "quote",
+			minArgs: 1, maxArgs: 1,
+			wantOk: true, wantLen: 2,
+		},
+		{
+			name:    "proper list exact arity mismatch",
+			input:   values.List(values.NewSymbol("quote"), values.NewSymbol("x"), values.NewSymbol("y")),
+			form:    "quote",
+			minArgs: 1, maxArgs: 1,
+			wantOk: false,
+		},
+		{
+			name:    "proper list min arity satisfied",
+			input:   values.List(values.NewSymbol("begin"), values.NewInteger(1), values.NewInteger(2)),
+			form:    "begin",
+			minArgs: 1, maxArgs: -1,
+			wantOk: true, wantLen: 3,
+		},
+		{
+			name:    "proper list min arity not met",
+			input:   values.List(values.NewSymbol("lambda"), values.EmptyList),
+			form:    "lambda",
+			minArgs: 2, maxArgs: -1,
+			wantOk: false,
+		},
+		{
+			name:    "range arity within bounds",
+			input:   values.List(values.NewSymbol("if"), values.TrueValue, values.NewInteger(1)),
+			form:    "if",
+			minArgs: 2, maxArgs: 3,
+			wantOk: true, wantLen: 3,
+		},
+		{
+			name:    "range arity above max",
+			input:   values.List(values.NewSymbol("if"), values.TrueValue, values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+			form:    "if",
+			minArgs: 2, maxArgs: 3,
+			wantOk: false,
+		},
+		{
+			name:    "no arity check",
+			input:   values.List(values.NewSymbol("begin")),
+			form:    "begin",
+			minArgs: 0, maxArgs: -1,
+			wantOk: true, wantLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			syntaxVal := makeSyntax(tt.input)
+			pair := syntaxVal.(*syntax.SyntaxPair)
+			result := &ValidationResult{}
+
+			source, elements, ok := formPrologue(pair, tt.form, tt.minArgs, tt.maxArgs, result)
+			c.Assert(ok, qt.Equals, tt.wantOk)
+			if tt.wantOk {
+				c.Assert(source, qt.IsNotNil)
+				c.Assert(len(elements), qt.Equals, tt.wantLen)
+			} else {
+				c.Assert(len(result.Errors) > 0, qt.IsTrue)
+			}
+		})
+	}
+}
+
+// TestFormPrologueImproperList tests formPrologue with an improper list
+func TestFormPrologueImproperList(t *testing.T) {
+	c := qt.New(t)
+	syntaxVal := makeSyntax(values.NewCons(values.NewSymbol("if"), values.NewInteger(42)))
+	pair := syntaxVal.(*syntax.SyntaxPair)
+	result := &ValidationResult{}
+
+	_, _, ok := formPrologue(pair, "if", 2, 3, result)
+	c.Assert(ok, qt.IsFalse)
+	c.Assert(len(result.Errors), qt.Equals, 1)
+	c.Assert(result.Errors[0].Message, qt.Contains, "proper list")
+}
+
 // TestValidateIf tests the if form validator
 func TestValidateIf(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Extracts `formPrologue()` helper that consolidates `collectList` + improper-list check + arity guard into a single call
- Converts 16 of 18 validator prologues (4-8 lines each → 3 lines each)
- Two non-standard validators (`validateCall`, `validateCaseLambdaClause`) keep inline prologues — their `elements[0]` is not a form keyword
- Adds 8 unit tests for the helper covering all arity shapes (exact, min-only, range, no-check) and improper lists

## Stats

| Metric | Before | After |
|--------|--------|-------|
| Prologue sites | 16 duplicated | 1 helper + 16 calls |
| Lines per prologue | 4-8 | 3 |
| Error message templates | ~16 wordings | 3 standardized |
| Net lines | | -6 |

## Files changed (11)
- `validate.go` — add `formPrologue` helper
- `validate_test.go` — add `TestFormPrologue` + `TestFormPrologueImproperList`
- `validate_if.go`, `validate_set.go`, `validate_quote.go`, `validate_begin.go`, `validate_dynamic_wind.go`, `validate_lambda.go`, `validate_define.go`, `validate_case_lambda.go`, `validate_macro.go` — convert prologues

## Test plan
- [x] `go test -v ./internal/validate/...` — 39/39 pass
- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass (integration skip expected in worktree)
- [x] `grep collectList validate_*.go` — only in validate_call.go, validate_case_lambda.go, validate_macro.go (clause sub-validation)