### PR TITLE
docs: add RELEASE_1_3_0.md to plan index

### DIFF
--- a/plans/CLAUDE.md
+++ b/plans/CLAUDE.md
@@ -32,6 +32,7 @@ When investigating R7RS conformance issues:
 
 | File | Purpose | Status |
 |------|---------|--------|
+| `RELEASE_1_3_0.md` | v1.3.0 release checklist | Complete |
 | `TOKENIZER_CONSOLIDATION_PLAN.md` | Tokenizer consolidation (~325 LOC saved; `readUreal` deferred as documented debt) | Complete |
 
 ### Proposed Designs (Future)


### PR DESCRIPTION
## Summary

- Add `RELEASE_1_3_0.md` to the completed section in `plans/CLAUDE.md`

Post-release housekeeping for v1.3.0.