### PR TITLE
add copy-on-write for env frame keys and shallow binding copies

### DIFF
--- a/environment/binding.go
+++ b/environment/binding.go
@@ -15,8 +15,6 @@
 package environment
 
 import (
-	"slices"
-
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 )
@@ -130,19 +128,15 @@ func (p *Binding) EqualTo(o values.Value) bool {
 	return p.value.EqualTo(v.value) && p.bindingType == v.bindingType
 }
 
-// Copy creates a deep copy of this binding, including the scopes slice.
+// Copy creates a copy of this binding. Scopes and source are shared by
+// reference because they are immutable at runtime — SetScopes is only
+// called during compilation/expansion, never during VM execution.
 func (p *Binding) Copy() values.Value {
-	// Copy the scopes slice to avoid shared references
-	var scopesCopy []*syntax.Scope
-	if p.scopes != nil {
-		scopesCopy = slices.Clone(p.scopes)
-	}
-
 	q := &Binding{
 		value:       p.value,
 		bindingType: p.bindingType,
-		scopes:      scopesCopy,
-		source:      p.source, // Source context is immutable, no need to copy
+		scopes:      p.scopes,
+		source:      p.source,
 	}
 	return q
 }

--- a/environment/binding_test.go
+++ b/environment/binding_test.go
@@ -150,12 +150,12 @@ func TestBinding_Copy(t *testing.T) {
 	qt.Assert(t, b2.BindingType(), qt.Equals, b1.BindingType())
 	qt.Assert(t, b2.Scopes(), qt.HasLen, 2)
 
-	// Check that scopes slice is a deep copy (different slices, same scope objects)
+	// Scopes are shared by reference (immutable at runtime), same scope objects
 	qt.Assert(t, b2.Scopes()[0], qt.Equals, scope1)
 	qt.Assert(t, b2.Scopes()[1], qt.Equals, scope2)
 
-	// Modify original scopes slice - copy should not be affected
-	b1.Scopes()[0] = syntax.NewScope()
+	// SetScopes on original replaces the whole slice — copy is unaffected
+	b1.SetScopes([]*syntax.Scope{syntax.NewScope()})
 	qt.Assert(t, b2.Scopes()[0], qt.Equals, scope1) // Copy unchanged
 
 	// Test copy with nil scopes

--- a/environment/environment_bench_test.go
+++ b/environment/environment_bench_test.go
@@ -140,6 +140,23 @@ func BenchmarkFrameCreation(b *testing.B) {
 	}
 }
 
+// BenchmarkLocalFrameCopyShared measures Copy() on a frame that was itself produced
+// by Copy(). This exercises the shared-keys path where the keys map is already
+// a reference rather than an owned map.
+func BenchmarkLocalFrameCopyShared(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 25, 50} {
+		b.Run(fmt.Sprintf("bindings=%d", n), func(b *testing.B) {
+			env, _ := setupLocalEnv(n)
+			// First copy: produces a frame with keysShared=true
+			shared := env.LocalEnvironment().Copy().(*LocalEnvironmentFrame)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = shared.Copy()
+			}
+		})
+	}
+}
+
 // BenchmarkFrameCopyAndCreate measures Copy + NewEnvironmentFrameWithParent combined.
 // This simulates what happens in Apply for non-tail calls: the closure's environment
 // is copied and a new frame is created with the copy.

--- a/environment/local_environment_frame.go
+++ b/environment/local_environment_frame.go
@@ -16,7 +16,6 @@ package environment
 
 import (
 	"maps"
-	"slices"
 
 	"github.com/aalpar/wile/values"
 )
@@ -27,8 +26,9 @@ import (
 // Note: LocalEnvironmentFrame has no hierarchy of its own; the hierarchy is
 // managed by EnvironmentFrame via its parent field.
 type LocalEnvironmentFrame struct {
-	keys     map[values.Symbol]int
-	bindings []*Binding
+	keys       map[values.Symbol]int
+	bindings   []*Binding
+	keysShared bool // true when keys map is shared with another frame (CoW)
 }
 
 // NewLocalEnvironment creates a new local environment frame with pre-allocated
@@ -63,10 +63,20 @@ func (p *LocalEnvironmentFrame) Keys() map[values.Symbol]int {
 // EnsureLocalBinding returns the local binding for the given key, creating it if
 // it does not already exist. Returns (index, true) if a new binding was created,
 // or (index, false) if the binding already existed.
+//
+// If the keys map is shared (from Copy), it is cloned before mutation (CoW).
+// In practice, EnsureLocalBinding is only called during compilation, never at
+// runtime, so the CoW path is a safety net rather than a hot path.
 func (p *LocalEnvironmentFrame) EnsureLocalBinding(key *values.Symbol, bt BindingType) (*LocalIndex, bool) {
 	i, ok := p.keys[*key]
 	if ok {
 		return &LocalIndex{i, 0}, false
+	}
+	if p.keysShared {
+		owned := make(map[values.Symbol]int, len(p.keys)+1)
+		maps.Copy(owned, p.keys)
+		p.keys = owned
+		p.keysShared = false
 	}
 	i = len(p.bindings)
 	p.keys[*key] = i
@@ -128,19 +138,29 @@ func (p *LocalEnvironmentFrame) EqualTo(o values.Value) bool {
 	return true
 }
 
-// Copy creates a deep copy of this local environment frame.
+// Copy creates a copy of this local environment frame. The keys map is shared
+// by reference (copy-on-write) since it is only mutated during compilation.
+// Bindings are allocated as a single contiguous block to reduce GC pressure,
+// and each binding's scopes slice is shared (immutable at runtime).
 func (p *LocalEnvironmentFrame) Copy() values.Value {
 	if p == nil {
 		return (*LocalEnvironmentFrame)(nil)
 	}
-	q := &LocalEnvironmentFrame{}
-	q.bindings = slices.Clone(p.bindings)
-	for i := range p.bindings {
-		q.bindings[i] = p.bindings[i].Copy().(*Binding)
+	n := len(p.bindings)
+	block := make([]Binding, n)
+	ptrs := make([]*Binding, n)
+	for i, b := range p.bindings {
+		block[i] = Binding{
+			value:       b.value,
+			bindingType: b.bindingType,
+			scopes:      b.scopes,
+			source:      b.source,
+		}
+		ptrs[i] = &block[i]
 	}
-	if p.keys != nil {
-		q.keys = make(map[values.Symbol]int, len(p.keys))
-		maps.Copy(q.keys, p.keys)
+	return &LocalEnvironmentFrame{
+		keys:       p.keys,
+		keysShared: true,
+		bindings:   ptrs,
 	}
-	return q
 }

--- a/machine/counters.go
+++ b/machine/counters.go
@@ -34,6 +34,7 @@ type VMCounters struct {
 	StackPoolReleases        uint64
 	SubContextPoolReleases   uint64
 	ContinuationPoolReleases uint64
+	KeysShared               uint64
 }
 
 // String returns a tabular summary of all counters.
@@ -51,7 +52,8 @@ func (c VMCounters) String() string {
 			"sub_contexts_created:         %d\n"+
 			"stack_pool_releases:          %d\n"+
 			"sub_context_pool_releases:    %d\n"+
-			"continuation_pool_releases:   %d",
+			"continuation_pool_releases:   %d\n"+
+			"keys_shared:                  %d",
 		c.OpsExecuted,
 		c.ClosuresApplied,
 		c.EnvsCopied,
@@ -65,5 +67,6 @@ func (c VMCounters) String() string {
 		c.StackPoolReleases,
 		c.SubContextPoolReleases,
 		c.ContinuationPoolReleases,
+		c.KeysShared,
 	)
 }

--- a/machine/machine_context.go
+++ b/machine/machine_context.go
@@ -314,6 +314,7 @@ func (p *MachineContext) Apply(mcls *MachineClosure, vs ...values.Value) (*Machi
 	p.counters.ClosuresApplied++
 	p.counters.EnvsCopied++
 	p.counters.BindingsCopied += uint64(len(bnds))
+	p.counters.KeysShared++
 	l := tpl.ParameterCount()
 	if !tpl.IsVariadic() {
 		if len(vs) != l {


### PR DESCRIPTION
## Summary

- **Copy-on-write keys map**: `LocalEnvironmentFrame.Copy()` shares the keys map by reference instead of cloning it. A `keysShared` flag triggers clone-on-write in `EnsureLocalBinding` (only called during compilation, not at runtime).
- **Shallow binding copies**: `Binding.Copy()` shares `scopes` and `source` by reference since both are immutable at runtime.
- **Contiguous binding allocation**: Bindings are allocated as a single `[]Binding` block with a separate `[]*Binding` pointer slice, reducing GC pressure from per-binding heap allocations.
- **New benchmark**: `BenchmarkLocalFrameCopyShared` exercises the shared-keys copy path.
- **New VM counter**: `KeysShared` tracks copy-on-write sharing events.

## Test plan

- [ ] Existing `binding_test.go` and `local_environment_frame_test.go` pass
- [ ] New `BenchmarkLocalFrameCopyShared` benchmark runs correctly
- [ ] Full `make test` passes
- [ ] `make lint` passes