### PR TITLE
add environment diagram and ER macro transformer plan

### DIFF
--- a/docs/dev/ENVIRONMENT_DIAGRAM.md
+++ b/docs/dev/ENVIRONMENT_DIAGRAM.md
@@ -1,0 +1,231 @@
+# Environment Relationship Diagram
+
+Visual map of all environment types, their relationships, and how they flow through the compilation/expansion/execution pipeline.
+
+See [ENVIRONMENT_SYSTEM.md](ENVIRONMENT_SYSTEM.md) for detailed API documentation.
+
+---
+
+## Ownership Hierarchy
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                         Engine (wile/engine.go)                               │
+│  topLevel ──→ TopLevelEnvironment                                             │
+│  env ────────→ runtime EnvironmentFrame (phase 0)                             │
+│  registry ──→ Registry (Go-side primitive registration)                       │
+└───────────────────────────────────────────────────────────────────────────────┘
+                    │
+                    │ owns
+                    ▼
+┌───────────────────────────────────────────────────────────────────────────────┐
+│              TopLevelEnvironment (root, one per VM)                           │
+│                                                                               │
+│  symbolInterns ─── map[Symbol]*Symbol   ← thread-safe, canonical identity     │
+│  syntaxInterns ─── map[Value]SyntaxValue ← thread-safe                        │
+│  loadPathStack ─── *LoadPathStack        ← shared across all children         │
+│  libraryRegistry ─ any                   ← *machine.LibraryRegistry           │
+│  phases ────────── *PhaseRegistry        ← owns phase→env mapping             │
+│  runtime ──────── *EnvironmentFrame      ← the phase 0 env                    │
+│  parent ────────── nil (root)                                                 │
+└───────────────────────────────────────────────────────────────────────────────┘
+         │                                      │
+         │ phases registry                      │ NewChildTopLevelEnvironment()
+         │ (lazily created)                     │ (for R7RS (environment),
+         ▼                                      │  (null-environment))
+┌─────────────────────────────┐                 ▼
+│     PhaseRegistry           │    ┌──────────────────────────────────────────┐
+│                             │    │   Child TopLevelEnvironment              │
+│  envs:                      │    │                                          │
+│    0 → runtime EnvFrame ────┼──→ │  parent ──→ root TopLevelEnvironment     │
+│    1 → expand EnvFrame      │    │  symbolInterns ── nil (delegates up)     │
+│    2 → compile EnvFrame     │    │  syntaxInterns ── nil (delegates up)     │
+│   -1 → template EnvFrame    │    │  phases ────── own PhaseRegistry         │
+│   ...                       │    │  runtime ───── own EnvironmentFrame      │
+│                             │    │  libraryReg ── inherited (shared ptr)    │
+│  topLevelEnv → TLE          │    └──────────────────────────────────────────┘
+│  topLevelEnvFrm → runtime   │
+└─────────────────────────────┘
+```
+
+---
+
+## Phase Environments
+
+Each phase has its own `GlobalEnvironmentFrame` (isolated bindings) but shares the `PhaseRegistry`, `TopLevelEnvironment`, and parents to the runtime frame.
+
+```
+Phase -1 (Template)     Phase 0 (Runtime)     Phase 1 (Expand)     Phase 2 (Compile)
+┌──────────────┐       ┌──────────────┐       ┌──────────────┐    ┌──────────────┐
+│ EnvFrame     │       │ EnvFrame     │       │ EnvFrame     │    │ EnvFrame     │
+│              │       │              │       │              │    │              │
+│ parent: ─────┼──┐    │ parent: nil  │  ┌──→ │ parent: ─────┼─┐  │ parent: ─────┼─┐
+│ global: own  │  │    │ global: own  │  │    │ global: own  │ │  │ global: own  │ │
+│ local: nil   │  │    │ local: nil   │  │    │ local: nil   │ │  │ local: nil   │ │
+│ phaseLevel:-1│  │    │ phaseLevel:0 │  │    │ phaseLevel:1 │ │  │ phaseLevel:2 │ │
+└──────────────┘  │    └──────────────┘  │    └──────────────┘ │  └──────────────┘ │
+                  │           ▲          │           ▲         │          ▲        │
+                  └───────────┘          └───────────┘         └──────────┘        │
+                   parent→runtime         parent→runtime        parent→runtime     │
+                                                                                   │
+                  ┌────────────────────────────────────────────────────────────────┘
+                  └──→ runtime (parent→runtime)
+```
+
+**Key:** Phase environments parent to runtime, not to each other. The phase hierarchy is flat — each phase has its own `GlobalEnvironmentFrame` but falls back to runtime globals through the parent pointer.
+
+All phase environments share:
+- The same `*PhaseRegistry` (back-pointer)
+- The same `*TopLevelEnvironment` (for interning)
+
+---
+
+## Lexical Scope Chain (Runtime Execution)
+
+Created by `lambda`, `let`, `letrec`, etc. via `NewEnvironmentFrameWithParent`.
+
+```
+┌───────────────────┐    ┌───────────────────┐    ┌───────────────────┐
+│ Runtime (phase 0) │◄───│ Lambda body       │◄───│ Inner let         │
+│ EnvFrame          │    │ EnvFrame          │    │ EnvFrame          │
+│                   │    │                   │    │                   │
+│ parent: nil       │    │ parent: ──────────┘    │ parent: ──────────┘
+│ local: nil        │    │ local: params     │    │ local: let-vars   │
+│ global: ──────┐   │    │ global: ──────┐   │    │ global: ──────┐   │
+└───────────────┼───┘    └───────────────┼───┘    └───────────────┼───┘
+                │                        │                        │
+                └────────────────────────┴────────────────────────┘
+                              SHARED GlobalEnvironmentFrame
+                              (all frames at same phase share it)
+```
+
+Child frames inherit `global`, `phases`, and `topLevel` from the parent. Only `local` and `parent` differ.
+
+---
+
+## Library Environments
+
+Created by `TopLevelEnv.NewChildRuntime()`. Shares interning for R7RS §6.5 symbol identity but has isolated bindings and phases.
+
+```
+Root TopLevelEnvironment                Library environment
+┌──────────────────────┐               ┌──────────────────────┐
+│  symbolInterns: {...} │◄──────────────│  topLevel: ──────────┤ (same pointer!)
+│  syntaxInterns: {...} │  shared TLE   │  global: OWN         │ (isolated bindings)
+│  phases: rootPhases   │               │  phases: ownPhases   │ (isolated phases)
+│  runtime: rootEnv     │               │  parent: nil         │
+└──────────────────────┘               │  phaseLevel: 0       │
+      │                                 └──────────────────────┘
+      │ rootPhases                              │ ownPhases
+      ▼                                         ▼
+┌──────────┐                              ┌──────────┐
+│ 0:runtime │                              │ 0:libRT  │  ← library's own runtime
+│ 1:expand  │                              │ 1:libExp │  ← library's own expand
+│ 2:compile │                              │ 2:libCmp │  ← library's own compile
+└──────────┘                              └──────────┘
+```
+
+---
+
+## NewChildRuntime vs NewChildTopLevelEnvironment
+
+Both create isolated bindings with shared interning. They differ in what they return and how `TopLevelEnv()` resolves.
+
+```
+NewChildRuntime:                NewChildTopLevelEnvironment:
+
+  TopLevelEnvironment (shared)    Parent TLE        Child TLE
+  +------------------+            +----------+      +----------+
+  | runtime: envP    |            | runtime: |      | runtime: |
+  +------------------+            | envP     |      | envC     |
+          │                       +----------+      +----------+
+          │                                            │
+     ┌────┴────┐                                       ▼
+     ▼         ▼                           EnvironmentFrame (envC)
+   envP      envC ◄── new child            +---------------------+
+   (parent   (has own Global-              | topLevel: child TLE |
+    frame)    EnvFrame, but                +---------------------+
+              topLevel points
+              to shared TLE)
+
+  envC.TopLevelEnv() == parent    envC.TopLevelEnv() == child
+  TLE.Runtime() returns envP     child.Runtime() returns envC  ✓
+```
+
+| | `NewChildRuntime()` | `NewChildTopLevelEnvironment()` |
+|---|---|---|
+| **Returns** | `*EnvironmentFrame` | `*TopLevelEnvironment` |
+| **Use case** | Library loading (internal) | `(environment)`, `(null-environment)` (first-class) |
+| **`TopLevelEnv()`** | Parent's TLE | The child TLE itself |
+| **`Runtime()`** | N/A | Returns child's own frame |
+
+---
+
+## Compilation / Expansion Pipeline
+
+How environments flow through the pipeline stages.
+
+```
+CompileTimeContinuation          ExpanderTimeContinuation
+┌───────────────────────┐       ┌────────────────────────┐
+│ env: EnvironmentFrame │       │ env: EnvironmentFrame  │
+│      (phase 0)        │       │      (phase 0)         │
+│                       │       │                        │
+│ Uses:                 │       │ Uses:                  │
+│  env ─── runtime vars │       │  env ──── runtime vars │
+│  env.Expand() ── P1   │       │  env.Expand() ─── P1   │
+│  env.Compile() ─ P2   │       │                        │
+└───────────────────────┘       └────────────────────────┘
+          │                               │
+          │ define-syntax                  │ let-syntax / letrec-syntax
+          │ compiles transformer           │ creates local expand scope
+          ▼                                ▼
+┌────────────────────────┐     ┌───────────────────────────────┐
+│ env.Expand()           │     │ NewEnvironmentFrameWithParent │
+│ (phase 1 EnvFrame)     │     │ (localExpandEnv, p.env)       │
+│                        │     │                               │
+│ Stores macro bindings: │     │ parent: enclosing env         │
+│  BindingTypeSyntax     │     │ local: macro bindings         │
+│  with hygiene scopes   │     │ (NOT p.env.Expand()!)         │
+└────────────────────────┘     └───────────────────────────────┘
+```
+
+**Note:** `let-syntax` environments chain through the enclosing expander's env (`p.env`), not through `env.Expand()`. This preserves nested lexical scoping of macros — inner macros can reference outer macros through the parent chain.
+
+---
+
+## VM Execution (MachineContext)
+
+The VM holds the current environment and mutates it via opcodes.
+
+```
+MachineContext
+┌──────────────────────────────────────┐
+│ vmState.env ── current EnvFrame      │ ← mutated by opcodes
+│                                      │
+│ expanderCtx ── ExpanderContext       │
+│   .env ─── expand-time EnvFrame      │ ← used during macro expansion
+│   .introScope ── hygiene scope       │
+│   .useSiteScope ─ hygiene scope      │
+│                                      │
+│ Opcodes that change env:             │
+│   OpMakeClosure → new child env      │  (lambda captures env)
+│   OpPushEnv → extend with locals     │  (let/letrec)
+│   OpPopEnv → restore parent          │
+└──────────────────────────────────────┘
+```
+
+---
+
+## Summary of All Environment Kinds
+
+| Environment | Created by | Bindings | Interning | Phases | Use |
+|---|---|---|---|---|---|
+| Root TLE | `NewTopLevelEnvironment()` | Own | Own tables | Own registry | VM instance |
+| Child TLE | `NewChildTopLevelEnvironment()` | Own | Delegates to parent | Own registry | `(environment)`, `(null-environment)` |
+| Runtime frame | `TLE.Runtime()` | Phase 0 global | Via TLE | Shared | Normal execution |
+| Expand frame | `env.Expand()` / `AtPhase(1)` | Phase 1 global | Via TLE | Shared | Macro bindings |
+| Compile frame | `env.Compile()` / `AtPhase(2)` | Phase 2 global | Via TLE | Shared | Syntax compilers |
+| Lexical child | `NewEnvironmentFrameWithParent()` | Own local, shared global | Via TLE | Shared | `lambda`, `let`, `letrec` |
+| Library env | `TLE.NewChildRuntime()` | Own global + phases | Via shared TLE | Own registry | `(import ...)` |
+| let-syntax env | `NewEnvironmentFrameWithParent(local, p.env)` | Own local macros | Via TLE | Shared | `let-syntax`, `letrec-syntax`Z |

--- a/plans/ER_MACRO_TRANSFORMER.md
+++ b/plans/ER_MACRO_TRANSFORMER.md
@@ -1,0 +1,266 @@
+# Plan: `er-macro-transformer` (Explicit Renaming Macros)
+
+## Goal
+
+Add `er-macro-transformer` to Wile's macro system, providing a procedural
+macro facility that operates on raw s-expressions with opt-in hygiene via
+`rename` and `compare` closures.
+
+```scheme
+(define-syntax my-or
+  (er-macro-transformer
+    (lambda (form rename compare)
+      (let ((a (cadr form))
+            (b (caddr form)))
+        `(let ((,(rename 'tmp) ,a))
+           (if ,(rename 'tmp) ,(rename 'tmp) ,b))))))
+```
+
+## API Contract
+
+```
+(er-macro-transformer <lambda-expr>)
+```
+
+- `<lambda-expr>` must be a `(lambda (form rename compare) body...)` with
+  exactly 3 parameters
+- **form**: the complete macro invocation as a raw s-expression (unwrapped
+  from syntax objects), e.g. `(my-or a b)` as a plain list of symbols
+- **rename**: `(rename sym) → symbol` — returns a symbol that resolves to
+  the binding at the macro *definition* site. Calling `rename` on the same
+  symbol within one invocation always returns the same (eq?) renamed symbol.
+  This is how ER macros achieve hygiene.
+- **compare**: `(compare id1 id2) → boolean` — returns `#t` if the two
+  identifiers refer to the same binding (used for literal matching, like
+  checking if an identifier is `else` or `=>`)
+- **return**: a raw s-expression that is re-wrapped into syntax objects
+  with the use-site context, then recursively expanded
+
+## Architecture
+
+### Key Insight
+
+The existing `expandMacroInvocation` invokes *any* `MachineClosure` with
+a single argument (the input form as syntax). For ER macros, we need to:
+1. **Unwrap** the input form before passing it
+2. **Create** rename/compare closures (environment-capturing Go operations)
+3. **Pass 3 arguments** instead of 1
+4. **Re-wrap** the result back to syntax
+
+This is handled by detecting ER transformers in `expandMacroInvocation`
+via a marker type.
+
+### Scope-Sets Integration
+
+ER macros map cleanly onto Wile's Flatt scope-sets model:
+
+| ER concept | Scope-sets equivalent |
+|---|---|
+| `rename` returns "hygienic" symbol | Create `SyntaxSymbol` with definition-site scopes |
+| `compare` checks "same binding" | Resolve both symbols via `GetBindingWithScopes`, check equality |
+| Un-renamed symbol | Symbol with no special scopes (use-site resolution) |
+
+## Implementation Phases
+
+### Phase 1: Transformer Recognition + Compilation
+
+**File: `machine/compile_transformer.go`**
+
+Add `"er-macro-transformer"` case to `compileTransformerToMachineClosure`:
+
+```go
+case "er-macro-transformer":
+    return compileERMacroTransformer(ctx, env, transformerPair)
+```
+
+**New file: `machine/compile_er_macro.go`**
+
+`compileERMacroTransformer(ctx, env, expr)`:
+1. Extract the lambda expression from `(er-macro-transformer <lambda>)`
+2. Validate it has exactly 3 parameters
+3. Compile and evaluate the lambda via `compileAndEvalLambdaTransformer`
+   (reuse existing lambda compilation — the lambda is a normal 3-arg closure)
+4. Wrap the resulting `MachineClosure` in an `*ERMacroTransformer` marker struct:
+
+```go
+// ERMacroTransformer wraps a 3-arg MachineClosure to identify it as an
+// explicit-renaming transformer in expandMacroInvocation.
+type ERMacroTransformer struct {
+    closure *MachineClosure
+    defEnv  *environment.EnvironmentFrame // definition-site environment
+}
+```
+
+Store the `*ERMacroTransformer` as the binding value (it satisfies
+`values.Value` via embedding or a simple wrapper). The `defEnv` captures the
+environment at `define-syntax` time — needed by `rename` to resolve
+definition-site bindings.
+
+### Phase 2: ER Rename/Compare Operations
+
+**New file: `machine/operation_er_macro.go`**
+
+Two lightweight VM operations, each wrapped into a 1-param `MachineClosure`
+at invocation time:
+
+#### `OperationERRename`
+
+Captures: `defEnv *environment.EnvironmentFrame`, `cache map[string]*syntax.SyntaxSymbol`
+
+```
+rename(sym) → syntax-symbol
+```
+
+1. Get argument (a `*values.Symbol` or `*syntax.SyntaxSymbol`)
+2. Check cache — if already renamed in this invocation, return cached symbol
+3. Look up `sym` in `defEnv` to find its definition-site binding
+4. Create a `SyntaxSymbol` with the definition-site scopes:
+   - If found in expand env → use the binding's scopes
+   - If found in runtime env → use the binding's scopes
+   - If not found → create symbol with empty scopes (top-level)
+5. Set `ResolvedBinding` on the new `SyntaxSymbol` to the `GlobalIndex`
+   (same mechanism as `FreeIdResolution` in syntax-rules)
+6. Cache and return
+
+The rename cache ensures `(eq? (rename 'x) (rename 'x))` is `#t` within
+one macro invocation. This is required by the ER macro contract.
+
+#### `OperationERCompare`
+
+Captures: `useEnv *environment.EnvironmentFrame`
+
+```
+compare(id1, id2) → boolean
+```
+
+1. Get both arguments (symbols or syntax symbols)
+2. For each, resolve to a binding:
+   - If `SyntaxSymbol` with scopes, use `GetBindingWithScopes`
+   - If plain `Symbol`, use `GetBinding`
+3. Return `#t` if both resolve to the same binding (pointer equality on
+   `*Binding` or `*GlobalIndex`), or both resolve to no binding and have
+   the same symbol name
+
+### Phase 3: Expander Integration
+
+**File: `machine/expander_time_continuation.go`**
+
+Modify `expandMacroInvocation` to detect `*ERMacroTransformer`:
+
+```go
+func (p *ExpanderTimeContinuation) expandMacroInvocation(...) {
+    // Check if it's an ER transformer
+    if erTransformer, ok := bnd.Value().(*ERMacroTransformer); ok {
+        return p.expandERMacroInvocation(ctx, sym, expr, erTransformer)
+    }
+    // ... existing MachineClosure path ...
+}
+```
+
+New method `expandERMacroInvocation`:
+
+1. Build the input form: `(sym . expr)` as syntax, then `UnwrapAll()` to
+   get raw s-expression
+2. Create `rename` closure:
+   - Fresh `OperationERRename` with `erTransformer.defEnv` and empty cache
+   - Wrap in a 1-param `MachineClosure`
+3. Create `compare` closure:
+   - Fresh `OperationERCompare` with `p.env` (use-site)
+   - Wrap in a 2-param `MachineClosure`
+4. Create `MachineContext` from `erTransformer.closure`
+5. Apply with 3 arguments: `(form, rename, compare)`
+6. Run the VM
+7. Get the result (a raw s-expression)
+8. Re-wrap with `datumToSyntax(result, useSiteSourceContext)`
+   - Use the use-site source context so error messages point to the macro call
+   - Renamed symbols are already `SyntaxSymbol` with definition-site scopes;
+     `datumToSyntax` passes through existing `SyntaxValue`s unchanged
+9. Recursively expand: `p.ExpandExpression(ctx, wrapped)`
+
+### Phase 4: `let-syntax` / `letrec-syntax` Support
+
+**File: `machine/expander_time_continuation.go`**
+
+`expandLetSyntaxImpl` currently only accepts `syntax-rules`. Extend it to
+also accept `er-macro-transformer` (and `lambda`) by routing through
+`compileTransformerToMachineClosure` instead of hardcoding `CompileSyntaxRules`.
+
+This is a refactoring of lines ~344-360 in `expandLetSyntaxImpl`.
+
+### Phase 5: Primitive Expander Registration
+
+**File: `machine/primitive_expanders_registry.go`**
+
+Register `"er-macro-transformer"` as a pass-through primitive expander
+(like `syntax-case`, `quasiquote`) so the expander doesn't try to expand
+it as a procedure call. It should return unchanged since it's only
+meaningful inside `define-syntax`.
+
+### Phase 6: Tests
+
+**New file: `machine/compile_er_macro_test.go`**
+
+1. **Basic ER macro** — `my-or` from the example above
+2. **Hygiene via rename** — macro introduces a `tmp` variable that doesn't
+   capture user's `tmp`
+3. **Compare for literals** — macro that checks for `else` keyword
+4. **Rename caching** — `(eq? (rename 'x) (rename 'x))` returns `#t`
+5. **Nested ER macros** — ER macro expanding to another ER macro call
+6. **ER inside let-syntax** — local ER macro definitions
+7. **ER mixed with syntax-rules** — ER macro calling a syntax-rules macro
+8. **Un-renamed symbols** — verify they resolve at use site (intentional
+   hygiene breaking for anaphoric macros)
+
+**Integration test: `integration/er_macro_test.go`**
+
+End-to-end tests via `Engine.Eval`:
+- Chibi `optional.sld` compatibility (the library already has an
+  `er-macro-transformer` branch in its `cond-expand`)
+- Real-world patterns: `swap!`, `aif` (anaphoric if), `my-cond`
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `machine/compile_transformer.go` | Add `er-macro-transformer` case |
+| `machine/compile_er_macro.go` | **New** — compilation logic |
+| `machine/operation_er_macro.go` | **New** — rename/compare operations |
+| `machine/expander_time_continuation.go` | ER detection + `expandERMacroInvocation` |
+| `machine/primitive_expanders_registry.go` | Register `er-macro-transformer` |
+| `machine/compile_er_macro_test.go` | **New** — unit tests |
+| `integration/er_macro_test.go` | **New** — integration tests |
+
+## Design Decisions
+
+**Why marker type instead of bytecode flag?** The `*ERMacroTransformer`
+wrapper is explicit and type-safe. It avoids coupling to bytecode layout
+and makes the detection in `expandMacroInvocation` a simple type switch.
+
+**Why Go-implemented rename/compare instead of Scheme?** The rename and
+compare operations need direct access to environment frames and scope
+sets. Implementing them in Go avoids a complex bootstrapping problem and
+keeps the critical path simple.
+
+**Why not modify `expandMacroInvocation`'s calling convention?** We add
+a new method `expandERMacroInvocation` rather than adding conditionals
+to the existing one. This keeps the syntax-rules/lambda path untouched.
+
+**Re-wrapping uses `datumToSyntax` with use-site context.** This means
+un-renamed symbols get the use-site's source context (no scopes), and
+renamed symbols (already `SyntaxSymbol`) pass through with their
+definition-site scopes intact. This is correct: un-renamed symbols
+should resolve at the use site.
+
+## Open Questions
+
+1. **Should `rename` accept syntax symbols or only plain symbols?**
+   Chibi accepts both. Recommended: accept both, extract the key if
+   syntax symbol.
+
+2. **What about `syntax->datum` on renamed symbols?** A renamed symbol
+   is a `SyntaxSymbol`. `syntax->datum` would strip it to a plain symbol.
+   This matches expected behavior.
+
+3. **Should `er-macro-transformer` be available at phase 0 (as a runtime
+   value)?** No — it should only be valid inside `define-syntax`. Same
+   restriction as `syntax-rules`.


### PR DESCRIPTION
## Summary
- Add `docs/dev/ENVIRONMENT_DIAGRAM.md` — visual diagram of the environment system architecture
- Add `plans/ER_MACRO_TRANSFORMER.md` — design plan for the ER macro transformer

## Test plan
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)