### PR TITLE
perf: change LocalEnvironmentFrame.bindings from []*Binding to []Binding

### DIFF
--- a/environment/environment_frame.go
+++ b/environment/environment_frame.go
@@ -263,8 +263,8 @@ func (p *EnvironmentFrame) resolveLocal(
 	for env != nil && env.local != nil {
 		i, ok := env.local.keys[*key]
 		if ok {
-			binding := env.local.bindings[i]
-			if binding != nil && (!checkScopes || scopesCompatible(binding, scopes)) {
+			binding := &env.local.bindings[i]
+			if !checkScopes || scopesCompatible(binding, scopes) {
 				result := visitor(binding, i, depth)
 				if result != nil {
 					return result
@@ -400,15 +400,14 @@ func (p *EnvironmentFrame) MaybeCreateLocalBindingWithScopes(key *values.Symbol,
 	i, ok := p.local.keys[*key]
 	if ok {
 		// Binding already exists - update scopes if needed
-		binding := p.local.bindings[i]
-		if binding.Scopes() == nil && scopes != nil {
-			binding.SetScopes(scopes)
+		if p.local.bindings[i].Scopes() == nil && scopes != nil {
+			p.local.bindings[i].SetScopes(scopes)
 		}
 		return NewLocalIndex(i, 0), false
 	}
 	i = len(p.local.bindings)
 	p.local.keys[*key] = i
-	p.local.bindings = append(p.local.bindings, NewBindingWithScopes(values.Void, bt, scopes))
+	p.local.bindings = append(p.local.bindings, Binding{value: values.Void, bindingType: bt, scopes: scopes})
 	return NewLocalIndex(i, 0), true
 }
 
@@ -487,25 +486,23 @@ func (p *EnvironmentFrame) GetLocalIndexWithScopes(key *values.Symbol, scopes []
 	for env != nil && env.local != nil {
 		i, ok := env.local.keys[*key]
 		if ok {
-			binding := env.local.bindings[i]
-			if binding != nil {
-				bindingScopes := binding.Scopes()
-				// Check if scopes match
-				if len(bindingScopes) == 0 {
-					// Binding has no scopes (top-level or pre-hygiene)
-					// This is a valid candidate with scope count 0
-					candidates = append(candidates, candidate{NewLocalIndex(i, j), 0})
-				} else if syntax.ScopesMatch(scopes, bindingScopes) {
-					// Perfect match — maximally specific, no need to search further
-					if len(bindingScopes) == len(scopes) {
-						return NewLocalIndex(i, j)
-					}
-					// Scopes match - count how many scopes are in common
-					// (which equals len(bindingScopes) since it's a subset)
-					candidates = append(candidates, candidate{NewLocalIndex(i, j), len(bindingScopes)})
+			binding := &env.local.bindings[i]
+			bindingScopes := binding.Scopes()
+			// Check if scopes match
+			if len(bindingScopes) == 0 {
+				// Binding has no scopes (top-level or pre-hygiene)
+				// This is a valid candidate with scope count 0
+				candidates = append(candidates, candidate{NewLocalIndex(i, j), 0})
+			} else if syntax.ScopesMatch(scopes, bindingScopes) {
+				// Perfect match — maximally specific, no need to search further
+				if len(bindingScopes) == len(scopes) {
+					return NewLocalIndex(i, j)
 				}
-				// If scopes don't match, skip this binding
+				// Scopes match - count how many scopes are in common
+				// (which equals len(bindingScopes) since it's a subset)
+				candidates = append(candidates, candidate{NewLocalIndex(i, j), len(bindingScopes)})
 			}
+			// If scopes don't match, skip this binding
 		}
 		if env.IsTopLevel() {
 			break
@@ -544,16 +541,14 @@ func (p *EnvironmentFrame) GetLocalBinding(li *LocalIndex) *Binding {
 	if env.local == nil {
 		return nil
 	}
-	i := li[0]
-	q := env.local.bindings[i]
-	return q
+	return &env.local.bindings[li[0]]
 }
 
 // GetLocalBindingByIndex returns the local binding at the given index in the current local environment.
 // It does not search parent environments.
 // It returns nil if the binding does not exist.
 func (p *EnvironmentFrame) GetLocalBindingByIndex(i int) *Binding {
-	return p.local.bindings[i]
+	return &p.local.bindings[i]
 }
 
 // GetLocalBindingBySlotDepth returns the binding at the given slot and depth
@@ -570,7 +565,7 @@ func (p *EnvironmentFrame) GetLocalBindingBySlotDepth(slot, depth int) *Binding 
 	if env == nil || env.local == nil {
 		return nil
 	}
-	return env.local.bindings[slot]
+	return &env.local.bindings[slot]
 }
 
 // SetLocalValue sets the value of the binding for the given LocalIndex.
@@ -585,9 +580,7 @@ func (p *EnvironmentFrame) SetLocalValue(li *LocalIndex, v values.Value) error {
 	if env.local == nil {
 		return values.WrapForeignErrorf(values.ErrNoSuchBinding, "no such local binding %q", li)
 	}
-	i := li[0]
-	bd := env.local.bindings[i]
-	bd.value = v
+	env.local.bindings[li[0]].value = v
 	return nil
 }
 

--- a/environment/environment_frame_test.go
+++ b/environment/environment_frame_test.go
@@ -531,11 +531,11 @@ func TestEnvironmentFrame_SetLocalValue_NoLocal(t *testing.T) {
 func TestEnvironmentFrame_GetLocalBindingBySlotDepth(t *testing.T) {
 	parent := NewTopLevelEnvironmentFrame()
 	parent = NewEnvironmentFrameWithParent(NewLocalEnvironment(2), parent)
-	parent.local.bindings[0] = NewBinding(values.NewInteger(10), BindingTypeVariable)
-	parent.local.bindings[1] = NewBinding(values.NewInteger(20), BindingTypeVariable)
+	parent.local.bindings[0] = Binding{value: values.NewInteger(10), bindingType: BindingTypeVariable}
+	parent.local.bindings[1] = Binding{value: values.NewInteger(20), bindingType: BindingTypeVariable}
 
 	child := NewEnvironmentFrameWithParent(NewLocalEnvironment(1), parent)
-	child.local.bindings[0] = NewBinding(values.NewInteger(30), BindingTypeVariable)
+	child.local.bindings[0] = Binding{value: values.NewInteger(30), bindingType: BindingTypeVariable}
 
 	// depth=0, slot=0 in child
 	bd := child.GetLocalBindingBySlotDepth(0, 0)
@@ -561,10 +561,10 @@ func TestEnvironmentFrame_GetLocalBindingBySlotDepth(t *testing.T) {
 func TestEnvironmentFrame_SetLocalValueBySlotDepth(t *testing.T) {
 	parent := NewTopLevelEnvironmentFrame()
 	parent = NewEnvironmentFrameWithParent(NewLocalEnvironment(1), parent)
-	parent.local.bindings[0] = NewBinding(values.NewInteger(10), BindingTypeVariable)
+	parent.local.bindings[0] = Binding{value: values.NewInteger(10), bindingType: BindingTypeVariable}
 
 	child := NewEnvironmentFrameWithParent(NewLocalEnvironment(1), parent)
-	child.local.bindings[0] = NewBinding(values.NewInteger(30), BindingTypeVariable)
+	child.local.bindings[0] = Binding{value: values.NewInteger(30), bindingType: BindingTypeVariable}
 
 	// Set in child (depth=0)
 	err := child.SetLocalValueBySlotDepth(0, 0, values.NewInteger(99))

--- a/environment/local_environment_frame.go
+++ b/environment/local_environment_frame.go
@@ -27,7 +27,7 @@ import (
 // managed by EnvironmentFrame via its parent field.
 type LocalEnvironmentFrame struct {
 	keys       map[values.Symbol]int
-	bindings   []*Binding
+	bindings   []Binding
 	keysShared bool // true when keys map is shared with another frame (CoW)
 }
 
@@ -37,21 +37,21 @@ type LocalEnvironmentFrame struct {
 func NewLocalEnvironment(pcnt int) *LocalEnvironmentFrame {
 	q := &LocalEnvironmentFrame{
 		keys:     make(map[values.Symbol]int),
-		bindings: make([]*Binding, pcnt),
+		bindings: make([]Binding, pcnt),
 	}
 	for i := range pcnt {
-		q.bindings[i] = NewBinding(values.Void, BindingTypeUnknown)
+		q.bindings[i] = Binding{value: values.Void, bindingType: BindingTypeUnknown}
 	}
 	return q
 }
 
 // Bindings returns the slice of bindings in this local environment.
-func (p *LocalEnvironmentFrame) Bindings() []*Binding {
+func (p *LocalEnvironmentFrame) Bindings() []Binding {
 	return p.bindings
 }
 
 // SetBindings replaces the bindings slice in this local environment.
-func (p *LocalEnvironmentFrame) SetBindings(v []*Binding) {
+func (p *LocalEnvironmentFrame) SetBindings(v []Binding) {
 	p.bindings = v
 }
 
@@ -78,7 +78,7 @@ func (p *LocalEnvironmentFrame) EnsureLocalBinding(key *values.Symbol, bt Bindin
 	}
 	i = len(p.bindings)
 	p.keys[*key] = i
-	p.bindings = append(p.bindings, NewBinding(values.Void, bt))
+	p.bindings = append(p.bindings, Binding{value: values.Void, bindingType: bt})
 	return &LocalIndex{i, 0}, true
 }
 
@@ -94,14 +94,12 @@ func (p *LocalEnvironmentFrame) GetLocalIndex(key *values.Symbol) *LocalIndex {
 
 // GetLocalBinding returns the binding at the given LocalIndex.
 func (p *LocalEnvironmentFrame) GetLocalBinding(li *LocalIndex) *Binding {
-	lb := p.bindings[li[0]]
-	return lb
+	return &p.bindings[li[0]]
 }
 
 // SetLocalValue sets the value of the binding at the given LocalIndex.
 func (p *LocalEnvironmentFrame) SetLocalValue(li *LocalIndex, v values.Value) error {
-	lb := p.bindings[li[0]]
-	lb.value = v
+	p.bindings[li[0]].value = v
 	return nil
 }
 
@@ -129,7 +127,7 @@ func (p *LocalEnvironmentFrame) EqualTo(o values.Value) bool {
 		return false
 	}
 	for i := range p.bindings {
-		if !p.bindings[i].EqualTo(v.bindings[i]) {
+		if !p.bindings[i].EqualTo(&v.bindings[i]) {
 			return false
 		}
 	}
@@ -148,21 +146,20 @@ func (p *LocalEnvironmentFrame) Copy() values.Value {
 		return (*LocalEnvironmentFrame)(nil)
 	}
 	n := len(p.bindings)
-	block := make([]Binding, n)
-	ptrs := make([]*Binding, n)
-	for i, b := range p.bindings {
-		block[i] = Binding{
+	bindings := make([]Binding, n)
+	for i := range p.bindings {
+		b := &p.bindings[i]
+		bindings[i] = Binding{
 			value:       b.value,
 			bindingType: b.bindingType,
 			scopes:      b.scopes,
 			source:      b.source,
 		}
-		ptrs[i] = &block[i]
 	}
 	return &LocalEnvironmentFrame{
 		keys:       p.keys,
 		keysShared: true,
-		bindings:   ptrs,
+		bindings:   bindings,
 	}
 }
 
@@ -182,19 +179,17 @@ func (p *LocalEnvironmentFrame) CopyForApply() *LocalEnvironmentFrame {
 	}
 	p.keysShared = true
 
-	// Batch allocation: allocate all Bindings contiguously (1 allocation)
-	// instead of N separate heap objects. Benchmarks show 27-37% speedup
-	// and 67-82% fewer allocations for typical frame sizes (3-10 bindings).
-	allBindings := make([]Binding, len(p.bindings))
-	q.bindings = make([]*Binding, len(p.bindings))
-	for i, b := range p.bindings {
-		allBindings[i] = Binding{
+	// Single contiguous allocation: []Binding stores values directly,
+	// eliminating the former []*Binding pointer slice entirely.
+	q.bindings = make([]Binding, len(p.bindings))
+	for i := range p.bindings {
+		b := &p.bindings[i]
+		q.bindings[i] = Binding{
 			value:       b.value,
 			bindingType: b.bindingType,
 			scopes:      b.scopes,
 			source:      b.source,
 		}
-		q.bindings[i] = &allBindings[i]
 	}
 	return q
 }

--- a/environment/local_environment_frame_test.go
+++ b/environment/local_environment_frame_test.go
@@ -89,9 +89,9 @@ func TestLocalEnvironmentFrame_SetBindings(t *testing.T) {
 	le.EnsureLocalBinding(sym, BindingTypeVariable)
 
 	// Create new bindings
-	newBindings := []*Binding{
-		NewBinding(values.NewInteger(1), BindingTypeVariable),
-		NewBinding(values.NewInteger(2), BindingTypeVariable),
+	newBindings := []Binding{
+		{value: values.NewInteger(1), bindingType: BindingTypeVariable},
+		{value: values.NewInteger(2), bindingType: BindingTypeVariable},
 	}
 
 	le.SetBindings(newBindings)

--- a/machine/compile_validated.go
+++ b/machine/compile_validated.go
@@ -363,10 +363,7 @@ func setScopesOnLastBinding(scopes []*syntax.Scope, lenv *environment.LocalEnvir
 	if len(bindings) == 0 {
 		return
 	}
-	binding := bindings[len(bindings)-1]
-	if binding != nil {
-		binding.SetScopes(scopes)
-	}
+	bindings[len(bindings)-1].SetScopes(scopes)
 }
 
 // compileClosure compiles a complete closure (lambda or define-fn body).

--- a/plans/CONTINUATION_WORKLOAD_OPTIMIZATIONS.md
+++ b/plans/CONTINUATION_WORKLOAD_OPTIMIZATIONS.md
@@ -1,9 +1,10 @@
 # Continuation-Heavy Workload Optimizations
 
-**Status:** Proposed
+**Status:** In Progress (2 of 6 complete)
 **Date:** 2026-02-18
 **Benchmark:** Zebra puzzle (Schelog logic programming)
 **Baseline:** 24.22s, 36.2 GB allocated, 907.8M allocations (Apple M4 Max, GOGC=100)
+**Current:** 23.76s, 33.1 GB allocated, 684.0M allocations (after optimization #2)
 
 ## Profile Summary
 
@@ -41,33 +42,31 @@
 
 ## Optimizations
 
-### 1. Eliminate `NewLocalIndex` Heap Allocation
+### 1. Eliminate `NewLocalIndex` Heap Allocation ✓
 
 **Impact:** ~1.7 GB (4.9%), ~105M fewer allocations
 **Effort:** Low | **Risk:** Low
+**Status:** Complete — PR #286, merged 2026-02-19
 
 `NewLocalIndex` returns `*LocalIndex` (pointer to `[2]int`), forcing a heap allocation on every `OpLoadLocal` and `OpStoreLocal` in the VM loop (`machine_context.go:666-683`).
 
 The VM already has `slot` and `depth` as raw integers from `DecodeLocalIndex`. Fix: add `GetLocalBindingBySlotDepth(slot, depth int)` and `SetLocalValueBySlotDepth(slot, depth int, v values.Value)` to `EnvironmentFrame`, bypassing the `*LocalIndex` allocation entirely.
 
+**Measured result:** -1.8 GB bytes, -110.7M allocations (34.4 GB / 797.1M vs baseline 36.2 GB / 907.8M)
+
 **Files:** `environment/environment_frame.go`, `machine/machine_context.go` (OpLoadLocal/OpStoreLocal cases)
 
-### 2. Binding Storage: `[]*Binding` → `[]Binding`
+### 2. Binding Storage: `[]*Binding` → `[]Binding` ✓
 
 **Impact:** ~2-3 GB (est.), ~112.9M fewer allocations
 **Effort:** Medium | **Risk:** Medium
+**Status:** Complete — implemented 2026-02-18
 
-`CopyForApply` allocates two slices per call:
-```go
-allBindings := make([]Binding, len(p.bindings))   // batch values
-q.bindings = make([]*Binding, len(p.bindings))     // pointer slice
-```
+Changed `LocalEnvironmentFrame.bindings` from `[]*Binding` to `[]Binding`. Eliminates one allocation per `CopyForApply` (pointer slice) and N allocations per `NewLocalEnvironment` (individual Binding heap objects). All accessors return `&p.bindings[i]` (pointer to slice element); mutation sites use direct index access. Audit confirmed no code holds `*Binding` across frame copies.
 
-If `LocalEnvironmentFrame.bindings` were `[]Binding` instead of `[]*Binding`, only one allocation per `CopyForApply`. Every accessor that dereferences `*Binding` needs updating — mechanical but touches many call sites.
+**Measured result:** -1.3 GB bytes, -113.1M allocations (33.1 GB / 684.0M vs post-#1 34.4 GB / 797.1M). Wall time 23.76s (vs 24.52s).
 
-**Audit required:** Every place holding a `*Binding` pointer must not persist across mutations.
-
-**Files:** `environment/local_environment_frame.go`, `environment/environment_frame.go`, all binding accessors
+**Files:** `environment/local_environment_frame.go`, `environment/environment_frame.go`, `machine/compile_validated.go`, test files
 
 ### 3. EnvironmentFrame Struct Pooling or Fusion
 
@@ -123,8 +122,8 @@ Many closures are called in tail position or are non-recursive. The compiler cou
 
 | # | Optimization | Alloc Savings | Effort | Risk |
 |---|-------------|---------------|--------|------|
-| 1 | LocalIndex → value type | ~1.7 GB (4.9%) | Low | Low |
-| 2 | `[]*Binding` → `[]Binding` | ~2-3 GB (est.) | Medium | Medium |
+| 1 | LocalIndex → value type | **-1.8 GB measured** | Low | ✓ Complete |
+| 2 | `[]*Binding` → `[]Binding` | ~2-3 GB (est.) | Medium | ✓ Complete |
 | 3 | EnvironmentFrame pool/fusion | ~5.6 GB (16%) | Medium | Medium |
 | 4 | Stack capacity tuning | ~1-3 GB (est.) | Low | Low |
 | 5 | CoW continuation sharing | ~2.9 GB (8.5%) | High | High |


### PR DESCRIPTION
## Summary

- Change `LocalEnvironmentFrame.bindings` from `[]*Binding` to `[]Binding`, storing bindings as values instead of pointers
- Eliminates one allocation per `CopyForApply` (the `[]*Binding` pointer slice) and N per `NewLocalEnvironment` (individual `Binding` heap objects)
- Accessors return `&p.bindings[i]` (pointer to slice element); mutation sites use direct index access

## Benchmark (Zebra puzzle)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Bytes allocated | 34.4 GB | 33.1 GB | **-1.3 GB** |
| Allocations | 797.1M | 684.0M | **-113.1M** |
| Wall time | 24.52s | 23.76s | -3.1% |

Continuation workload optimization #2 of 6.

## Test plan

- [x] `go test ./...` — all 27 packages pass
- [x] `make lint` — zero issues
- [x] Zebra benchmark measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)