### PR TITLE
refactor: move SchemeEquals to valuestest/, externalize values/ tests

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -333,18 +333,18 @@ func TestInteger_Add(t *testing.T) {
     }
     for _, tc := range tcs {
         result := tc.in0.Add(tc.in1)
-        qt.Assert(t, result, SchemeEquals, tc.out)
+        qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
     }
 }
 ```
 
 ### Testing Framework
 
-Use `quicktest` (`qt`) with `SchemeEquals` custom checker:
+Use `quicktest` (`qt`) with `valuestest.SchemeEquals` custom checker (import `"github.com/aalpar/wile/values/valuestest"`):
 
 ```go
 qt.Assert(t, actual, qt.Equals, expected)
-qt.Assert(t, actual, SchemeEquals, expected)  // For Value comparison
+qt.Assert(t, actual, valuestest.SchemeEquals, expected)  // For Value comparison
 qt.Assert(t, err, qt.IsNil)
 qt.Assert(t, result, qt.IsNotNil)
 ```

--- a/docs/dev/COMPLETED_FEATURES.md
+++ b/docs/dev/COMPLETED_FEATURES.md
@@ -133,7 +133,7 @@ func TestXxx(t *testing.T) {
         t.Run(tc.name, func(t *testing.T) {
             result, err := runSchemeCode(t, tc.code)
             qt.Assert(t, err, qt.IsNil)
-            qt.Assert(t, result, values.SchemeEquals, tc.out)
+            qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
         })
     }
 }

--- a/environment/binding_test.go
+++ b/environment/binding_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -32,7 +33,7 @@ func TestBinding_NewBindingWithScopes(t *testing.T) {
 	b := NewBindingWithScopes(val, BindingTypeVariable, scopes)
 
 	qt.Assert(t, b, qt.Not(qt.IsNil))
-	qt.Assert(t, b.Value(), values.SchemeEquals, val)
+	qt.Assert(t, b.Value(), valuestest.SchemeEquals, val)
 	qt.Assert(t, b.BindingType(), qt.Equals, BindingTypeVariable)
 	qt.Assert(t, b.Scopes(), qt.HasLen, 2)
 	qt.Assert(t, b.Scopes()[0], qt.Equals, scope1)
@@ -46,11 +47,11 @@ func TestBinding_BindingType(t *testing.T) {
 
 func TestBinding_SetValue(t *testing.T) {
 	b := NewBinding(values.Void, BindingTypeVariable)
-	qt.Assert(t, b.Value(), values.SchemeEquals, values.Void)
+	qt.Assert(t, b.Value(), valuestest.SchemeEquals, values.Void)
 
 	newVal := values.NewInteger(123)
 	b.SetValue(newVal)
-	qt.Assert(t, b.Value(), values.SchemeEquals, newVal)
+	qt.Assert(t, b.Value(), valuestest.SchemeEquals, newVal)
 }
 
 func TestBinding_SetBindingType(t *testing.T) {
@@ -146,7 +147,7 @@ func TestBinding_Copy(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 
 	// Check that values are equal
-	qt.Assert(t, b2.Value(), values.SchemeEquals, b1.Value())
+	qt.Assert(t, b2.Value(), valuestest.SchemeEquals, b1.Value())
 	qt.Assert(t, b2.BindingType(), qt.Equals, b1.BindingType())
 	qt.Assert(t, b2.Scopes(), qt.HasLen, 2)
 
@@ -178,7 +179,7 @@ func TestBinding_NewBindingWithSource(t *testing.T) {
 	b := NewBindingWithSource(val, BindingTypeVariable, scopes, source)
 
 	qt.Assert(t, b, qt.Not(qt.IsNil))
-	qt.Assert(t, b.Value(), values.SchemeEquals, val)
+	qt.Assert(t, b.Value(), valuestest.SchemeEquals, val)
 	qt.Assert(t, b.BindingType(), qt.Equals, BindingTypeVariable)
 	qt.Assert(t, b.Scopes(), qt.HasLen, 1)
 	qt.Assert(t, b.Source(), qt.Equals, source)

--- a/environment/environment_frame_test.go
+++ b/environment/environment_frame_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -83,9 +84,9 @@ func TestEnvironmentFrame_Locals(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	lb := env.GetLocalBinding(li0)
-	qt.Assert(t, lb.value, values.SchemeEquals, value0)
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, value0)
 	lb = env.GetLocalBinding(li1)
-	qt.Assert(t, lb.value, values.SchemeEquals, value1)
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, value1)
 }
 
 func TestEnvironmentFrame_Globals(t *testing.T) {
@@ -108,7 +109,7 @@ func TestEnvironmentFrame_Globals(t *testing.T) {
 	// Test adding a binding
 	gi0, ok := env.MaybeCreateOwnGlobalBinding(tv0, BindingTypeVariable)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, gi0, values.SchemeEquals, NewGlobalIndex(tv0))
+	qt.Assert(t, gi0, valuestest.SchemeEquals, NewGlobalIndex(tv0))
 
 	// Set the initial value of the new binding
 	err := env.SetOwnGlobalValue(gi0, value0)
@@ -118,22 +119,22 @@ func TestEnvironmentFrame_Globals(t *testing.T) {
 	tv0 = env.InternSymbol(values.NewSymbol("testVar0"))
 	gi0, ok = env.MaybeCreateOwnGlobalBinding(tv0, BindingTypeVariable)
 	qt.Assert(t, ok, qt.IsFalse)
-	qt.Assert(t, gi0.Index, values.SchemeEquals, tv0)
+	qt.Assert(t, gi0.Index, valuestest.SchemeEquals, tv0)
 
 	// Adding a new binding should create a new index
 	tv1 := values.NewSymbol("testVar1")
 	gi1, ok := env.MaybeCreateOwnGlobalBinding(tv1, BindingTypeVariable)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, gi1.Index, values.SchemeEquals, tv1)
+	qt.Assert(t, gi1.Index, valuestest.SchemeEquals, tv1)
 
 	// Set the initial value of the new binding
 	err = env.SetOwnGlobalValue(gi1, value1)
 	qt.Assert(t, err, qt.IsNil)
 
 	bd := env.GetGlobalBinding(gi0)
-	qt.Assert(t, bd.value, values.SchemeEquals, value0)
+	qt.Assert(t, bd.value, valuestest.SchemeEquals, value0)
 	bd = env.GetGlobalBinding(gi1)
-	qt.Assert(t, bd.value, values.SchemeEquals, value1)
+	qt.Assert(t, bd.value, valuestest.SchemeEquals, value1)
 }
 
 func TestEnvironmentFrame_Bindings(t *testing.T) {
@@ -153,28 +154,28 @@ func TestEnvironmentFrame_Bindings(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	gb := env.GetGlobalBinding(gi)
 	qt.Assert(t, gb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, gb.value, values.SchemeEquals, values.Void)
+	qt.Assert(t, gb.value, valuestest.SchemeEquals, values.Void)
 
 	// check local environment
 	li0 := env.GetLocalIndex(tv0)
 	qt.Assert(t, li0, qt.IsNotNil)
 	lb := env.GetLocalBinding(li0)
 	qt.Assert(t, lb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, lb.value, values.SchemeEquals, values.Void)
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, values.Void)
 
 	err := env.SetLocalValue(li0, values.NewInteger(42))
 	qt.Assert(t, err, qt.IsNil)
 
 	lb = env.GetLocalBinding(li0)
 	qt.Assert(t, lb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, lb.value, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, values.NewInteger(42))
 
 	err = env.SetOwnGlobalValue(gi, values.NewInteger(42))
 	qt.Assert(t, err, qt.IsNil)
 
 	gb = env.GetGlobalBinding(gi)
 	qt.Assert(t, gb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, gb.value, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, gb.value, valuestest.SchemeEquals, values.NewInteger(42))
 
 	env = NewEnvironmentFrameWithParent(NewLocalEnvironment(0), env)
 	li1, ok := env.EnsureLocalBinding(tv0, BindingTypeVariable)
@@ -189,11 +190,11 @@ func TestEnvironmentFrame_Bindings(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	lb = env.GetLocalBinding(li1)
 	qt.Assert(t, lb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, lb.value, values.SchemeEquals, values.NewInteger(43))
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, values.NewInteger(43))
 
 	lb = env.parent.GetLocalBinding(li0)
 	qt.Assert(t, lb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, lb.value, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestEnvironmentFrame_Hierarchy(t *testing.T) {
@@ -208,7 +209,7 @@ func TestEnvironmentFrame_Hierarchy(t *testing.T) {
 
 	gb := env.GetGlobalBinding(gi)
 	qt.Assert(t, gb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, gb.value, values.SchemeEquals, values.Void)
+	qt.Assert(t, gb.value, valuestest.SchemeEquals, values.Void)
 
 	lenv := NewLocalEnvironment(0)
 	env = NewEnvironmentFrameWithParent(lenv, env)
@@ -219,7 +220,7 @@ func TestEnvironmentFrame_Hierarchy(t *testing.T) {
 
 	lb := env.GetLocalBinding(li)
 	qt.Assert(t, lb.bindingType, qt.Equals, BindingTypeVariable)
-	qt.Assert(t, lb.value, values.SchemeEquals, values.Void)
+	qt.Assert(t, lb.value, valuestest.SchemeEquals, values.Void)
 }
 
 func TestEnvironmentFrame_ExpandHierarchy(t *testing.T) {
@@ -366,7 +367,7 @@ func TestEnvironmentFrame_GetBindingWithScopes(t *testing.T) {
 	// GetBindingWithScopes should return it (no scopes = always matches)
 	b1 := env.GetBindingWithScopes(sym1, nil)
 	qt.Assert(t, b1, qt.Not(qt.IsNil))
-	qt.Assert(t, b1.Value(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, b1.Value(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Test with non-existent symbol
 	sym2 := values.NewSymbol("nonexistent")
@@ -409,7 +410,7 @@ func TestEnvironmentFrame_GetLocalBindingByIndex(t *testing.T) {
 	// GetLocalBindingByIndex takes an int (the index), not a LocalIndex
 	binding := env.GetLocalBindingByIndex(li[0])
 	qt.Assert(t, binding, qt.Not(qt.IsNil))
-	qt.Assert(t, binding.Value(), values.SchemeEquals, val)
+	qt.Assert(t, binding.Value(), valuestest.SchemeEquals, val)
 }
 
 func TestEnvironmentFrame_SetGlobalBindingByIndex(t *testing.T) {
@@ -426,7 +427,7 @@ func TestEnvironmentFrame_SetGlobalBindingByIndex(t *testing.T) {
 	env.SetGlobalBindingByIndex(idx, newBinding)
 
 	binding := env.GetGlobalBinding(gi)
-	qt.Assert(t, binding.Value(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, binding.Value(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 func TestEnvironmentFrame_LibraryRegistry(t *testing.T) {

--- a/environment/global_environment_frame_test.go
+++ b/environment/global_environment_frame_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -69,10 +70,10 @@ func TestGlobalEnvironment(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	gb2 := env.GetOwnGlobalBinding(gi0).Value()
-	qt.Assert(t, gb2, values.SchemeEquals, value0)
+	qt.Assert(t, gb2, valuestest.SchemeEquals, value0)
 
 	gb3 := env.GetOwnGlobalBinding(gi1).Value()
-	qt.Assert(t, gb3, values.SchemeEquals, value1)
+	qt.Assert(t, gb3, valuestest.SchemeEquals, value1)
 }
 
 func TestGlobalEnvironmentFrame_Keys(t *testing.T) {

--- a/environment/local_environment_frame_test.go
+++ b/environment/local_environment_frame_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -68,9 +69,9 @@ func TestLocalEnvironment(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	v := env.GetLocalBinding(li0)
-	qt.Assert(t, v.value, values.SchemeEquals, value0)
+	qt.Assert(t, v.value, valuestest.SchemeEquals, value0)
 	v = env.GetLocalBinding(li1)
-	qt.Assert(t, v.value, values.SchemeEquals, value1)
+	qt.Assert(t, v.value, valuestest.SchemeEquals, value1)
 }
 
 func TestLocalEnvironmentFrame_Bindings(t *testing.T) {
@@ -183,11 +184,11 @@ func TestCopyForApply_IndependentBindings(t *testing.T) {
 
 	// SetValue on copy does not affect original
 	copied.SetLocalValue(li0, values.NewInteger(99))
-	qt.Assert(t, le.GetLocalBinding(li0).Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, copied.GetLocalBinding(li0).Value(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, le.GetLocalBinding(li0).Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, copied.GetLocalBinding(li0).Value(), valuestest.SchemeEquals, values.NewInteger(99))
 
 	// Original still intact
-	qt.Assert(t, le.GetLocalBinding(li1).Value(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, le.GetLocalBinding(li1).Value(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 func TestCopyForApply_NilSafe(t *testing.T) {
@@ -229,8 +230,8 @@ func TestCopyInto_CopiesBindings(t *testing.T) {
 
 	// Bindings are independent copies
 	qt.Assert(t, len(dst.bindings), qt.Equals, 2)
-	qt.Assert(t, dst.bindings[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, dst.bindings[1].Value(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, dst.bindings[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, dst.bindings[1].Value(), valuestest.SchemeEquals, values.NewInteger(20))
 
 	// Keys are shared
 	qt.Assert(t, reflect.ValueOf(dst.keys).Pointer(), qt.Equals, reflect.ValueOf(le.Keys()).Pointer())
@@ -238,7 +239,7 @@ func TestCopyInto_CopiesBindings(t *testing.T) {
 
 	// Mutating dst does not affect source
 	dst.bindings[0].SetValue(values.NewInteger(99))
-	qt.Assert(t, le.GetLocalBinding(li0).Value(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, le.GetLocalBinding(li0).Value(), valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 func TestCopyForApplyInto_MarksBothShared(t *testing.T) {
@@ -254,7 +255,7 @@ func TestCopyForApplyInto_MarksBothShared(t *testing.T) {
 	qt.Assert(t, dst.keysShared, qt.IsTrue)
 
 	// Bindings are independent
-	qt.Assert(t, dst.bindings[0].Value(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, dst.bindings[0].Value(), valuestest.SchemeEquals, values.NewInteger(42))
 	dst.bindings[0].SetValue(values.NewInteger(99))
-	qt.Assert(t, le.GetLocalBinding(li0).Value(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, le.GetLocalBinding(li0).Value(), valuestest.SchemeEquals, values.NewInteger(42))
 }

--- a/environment/local_index_test.go
+++ b/environment/local_index_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -47,7 +48,7 @@ func TestLocalIndex_GetBinding(t *testing.T) {
 	// Use LocalIndex.GetBinding method
 	binding := li.GetBinding(env)
 	qt.Assert(t, binding, qt.Not(qt.IsNil))
-	qt.Assert(t, binding.Value(), values.SchemeEquals, val)
+	qt.Assert(t, binding.Value(), valuestest.SchemeEquals, val)
 }
 
 func TestLocalIndex_String(t *testing.T) {

--- a/extensions/exceptions/prim_exceptions_test.go
+++ b/extensions/exceptions/prim_exceptions_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aalpar/wile"
 	extexceptions "github.com/aalpar/wile/extensions/exceptions"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -63,7 +64,7 @@ func TestWithExceptionHandler(t *testing.T) {
 			    (lambda () (raise-continuable 'my-error)))
 			  caught)
 		`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewSymbol("my-error"))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewSymbol("my-error"))
 	})
 
 	t.Run("thunk completes without exception", func(t *testing.T) {
@@ -72,7 +73,7 @@ func TestWithExceptionHandler(t *testing.T) {
 			  (lambda (e) 'not-called)
 			  (lambda () 42))
 		`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(42))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(42))
 	})
 
 	t.Run("nested handlers with continuable", func(t *testing.T) {
@@ -135,7 +136,7 @@ func TestRaiseContinuable(t *testing.T) {
 			  (lambda (e) 100)
 			  (lambda () (+ 1 (raise-continuable 'ignored))))
 		`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(101))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(101))
 	})
 
 	t.Run("raise continuable with symbol", func(t *testing.T) {
@@ -144,7 +145,7 @@ func TestRaiseContinuable(t *testing.T) {
 			  (lambda (e) 42)
 			  (lambda () (raise-continuable 'warning)))
 		`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(42))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(42))
 	})
 
 	t.Run("wrong argument count", func(t *testing.T) {

--- a/extensions/system/prim_system_test.go
+++ b/extensions/system/prim_system_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aalpar/wile"
 	extsystem "github.com/aalpar/wile/extensions/system"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -115,7 +116,7 @@ func TestGetEnvironmentVariable(t *testing.T) {
 	t.Run("existing variable", func(t *testing.T) {
 		t.Setenv("WILE_TEST_VAR", "hello")
 		result := eval(t, engine, `(get-environment-variable "WILE_TEST_VAR")`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewString("hello"))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewString("hello"))
 	})
 
 	t.Run("nonexistent variable returns false", func(t *testing.T) {
@@ -126,13 +127,13 @@ func TestGetEnvironmentVariable(t *testing.T) {
 	t.Run("empty string value", func(t *testing.T) {
 		t.Setenv("WILE_TEST_EMPTY", "")
 		result := eval(t, engine, `(get-environment-variable "WILE_TEST_EMPTY")`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewString(""))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewString(""))
 	})
 
 	t.Run("value with equals sign", func(t *testing.T) {
 		t.Setenv("WILE_TEST_EQUALS", "a=b=c")
 		result := eval(t, engine, `(get-environment-variable "WILE_TEST_EQUALS")`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewString("a=b=c"))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewString("a=b=c"))
 	})
 
 	t.Run("wrong argument type", func(t *testing.T) {
@@ -163,7 +164,7 @@ func TestGetEnvironmentVariables(t *testing.T) {
 			     (cdr (car vars)))
 			    (else (loop (cdr vars)))))
 		`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewString("found"))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewString("found"))
 	})
 
 	t.Run("entries are pairs", func(t *testing.T) {
@@ -249,7 +250,7 @@ func TestJiffiesPerSecond(t *testing.T) {
 
 	t.Run("returns 1 billion", func(t *testing.T) {
 		result := eval(t, engine, `(jiffies-per-second)`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(1_000_000_000))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(1_000_000_000))
 	})
 
 	t.Run("exact integer", func(t *testing.T) {

--- a/internal/bootstrap/library_environment_test.go
+++ b/internal/bootstrap/library_environment_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/registry"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -127,7 +128,7 @@ func TestNewLibraryEnvironmentFrame_PrimitivesAvailable(t *testing.T) {
 	// Evaluate a simple expression in the library environment
 	result, err := evalScheme(t, libEnv, `(+ 1 2)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(3))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestNewLibraryEnvironmentFrame_BootstrapMacrosAvailable verifies that
@@ -158,7 +159,7 @@ func TestNewLibraryEnvironmentFrame_BootstrapMacrosAvailable(t *testing.T) {
 		c.Run(tt.name, func(c *qt.C) {
 			result, err := evalScheme(t, libEnv, tt.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tt.expected)
+			c.Assert(result, valuestest.SchemeEquals, tt.expected)
 		})
 	}
 }
@@ -199,11 +200,11 @@ func TestNewLibraryEnvironmentFrame_IndependentMutation(t *testing.T) {
 	// Each sees its own
 	result, err := evalScheme(t, callerEnv, `caller-var`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(100))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(100))
 
 	result, err = evalScheme(t, libEnv, `lib-var`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(200))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(200))
 }
 
 // ===========================================================================
@@ -231,7 +232,7 @@ func TestNewTopLevelEnvironmentFrameTiny_IndependentEnvironments(t *testing.T) {
 
 	result, err := evalScheme(t, env1, `unique-var`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 
 	// env2 should not have unique-var
 	_, err = evalScheme(t, env2, `unique-var`)
@@ -270,7 +271,7 @@ func TestNewTopLevelEnvironmentFrameTiny_BootstrapMacrosLoaded(t *testing.T) {
 		c.Run(tt.name, func(c *qt.C) {
 			result, err := evalScheme(t, env, tt.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tt.expected)
+			c.Assert(result, valuestest.SchemeEquals, tt.expected)
 		})
 	}
 }
@@ -351,7 +352,7 @@ func TestLoadBootstrapMacros_ValidMacro(t *testing.T) {
 	// Use the macro
 	result, err := evalScheme(t, env, `(my-add 3 4)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(7))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 // TestLoadBootstrapMacros_MultipleSources verifies that multiple macro source
@@ -375,7 +376,7 @@ func TestLoadBootstrapMacros_MultipleSources(t *testing.T) {
 
 	result, err := evalScheme(t, env, `(quadruple 5)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(20))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 // ===========================================================================

--- a/internal/bootstrap/multi_environment_test.go
+++ b/internal/bootstrap/multi_environment_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -48,12 +49,12 @@ func TestMultiEnv_PrimitiveMutationIsolation(t *testing.T) {
 	// env1 sees the redefined +
 	result, err := evalScheme(t, env1, `(+ 1 2)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(0))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(0))
 
 	// env2 still has the original +
 	result, err = evalScheme(t, env2, `(+ 1 2)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(3))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestMultiEnv_SymbolNonIdentityAcrossTopLevels verifies that the same symbol
@@ -118,8 +119,8 @@ func TestMultiEnv_ConcurrentTopLevelUse(t *testing.T) {
 
 	c.Assert(err1, qt.IsNil)
 	c.Assert(err2, qt.IsNil)
-	c.Assert(result1, values.SchemeEquals, values.NewInteger(10000))
-	c.Assert(result2, values.SchemeEquals, values.NewInteger(40000))
+	c.Assert(result1, valuestest.SchemeEquals, values.NewInteger(10000))
+	c.Assert(result2, valuestest.SchemeEquals, values.NewInteger(40000))
 }
 
 // TestMultiEnv_UserMacroIsolation verifies that defining a macro in one
@@ -141,7 +142,7 @@ func TestMultiEnv_UserMacroIsolation(t *testing.T) {
 
 	result, err := evalScheme(t, env1, `(always-42)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 
 	// env2 does not have the macro
 	_, err = evalScheme(t, env2, `(always-42)`)
@@ -178,12 +179,12 @@ func TestMultiEnv_SiblingLibraryIsolation(t *testing.T) {
 	// lib1 sees its own var
 	result, err := evalScheme(t, lib1, `lib1-var`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(111))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(111))
 
 	// lib2 sees its own var
 	result, err = evalScheme(t, lib2, `lib2-var`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(222))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(222))
 
 	// lib1 does NOT see lib2's var
 	_, err = evalScheme(t, lib1, `lib2-var`)
@@ -242,20 +243,20 @@ func TestMultiEnv_SiblingLibrarySharedPrimitives(t *testing.T) {
 	// Both libraries can use core primitives
 	result, err := evalScheme(t, lib1, `(+ 10 20)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(30))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(30))
 
 	result, err = evalScheme(t, lib2, `(+ 10 20)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(30))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(30))
 
 	// Both libraries can use bootstrap macros
 	result, err = evalScheme(t, lib1, `(let ((x 5)) (* x x))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(25))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(25))
 
 	result, err = evalScheme(t, lib2, `(let ((x 5)) (* x x))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(25))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(25))
 }
 
 // TestMultiEnv_SiblingLibraryMacroIsolation verifies that a macro defined in
@@ -281,7 +282,7 @@ func TestMultiEnv_SiblingLibraryMacroIsolation(t *testing.T) {
 	// lib1 can use it
 	result, err := evalScheme(t, lib1, `(double 21)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 
 	// lib2 cannot
 	_, err = evalScheme(t, lib2, `(double 21)`)
@@ -368,15 +369,15 @@ func TestMultiEnv_NestedLibraryBindingIsolation(t *testing.T) {
 	// Each sees its own binding
 	result, err := evalScheme(t, topLevel, `level`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("top"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("top"))
 
 	result, err = evalScheme(t, outerLib, `level`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("outer"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("outer"))
 
 	result, err = evalScheme(t, innerLib, `level`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("inner"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("inner"))
 }
 
 // TestMultiEnv_NestedLibraryPrimitivesAvailable verifies that primitives and
@@ -397,11 +398,11 @@ func TestMultiEnv_NestedLibraryPrimitivesAvailable(t *testing.T) {
 	// Inner library has access to primitives and bootstrap macros
 	result, err := evalScheme(t, innerLib, `(+ 1 2 3)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(6))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(6))
 
 	result, err = evalScheme(t, innerLib, `(let ((x 10)) (cond ((> x 5) 'big) (else 'small)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("big"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("big"))
 }
 
 // ===========================================================================
@@ -437,11 +438,11 @@ func TestMultiEnv_ValuesCrossEnvironmentBoundary(t *testing.T) {
 	// Library can operate on it
 	result, err := evalScheme(t, lib, `(length imported-data)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(3))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(3))
 
 	result, err = evalScheme(t, lib, `(car imported-data)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestMultiEnv_ClosureCapturesDefiningEnvironment verifies that a closure
@@ -476,7 +477,7 @@ func TestMultiEnv_ClosureCapturesDefiningEnvironment(t *testing.T) {
 	// Call it from the library — it should resolve parent-x in the parent env
 	result, err := evalScheme(t, lib, `(get-parent-x)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(100))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(100))
 
 	// Mutate parent-x in the parent and call again from library
 	_, err = evalScheme(t, parent, `(set! parent-x 200)`)
@@ -484,7 +485,7 @@ func TestMultiEnv_ClosureCapturesDefiningEnvironment(t *testing.T) {
 
 	result, err = evalScheme(t, lib, `(get-parent-x)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(200))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(200))
 }
 
 // TestMultiEnv_ParameterObjectAcrossEnvironments verifies that a parameter
@@ -516,17 +517,17 @@ func TestMultiEnv_ParameterObjectAcrossEnvironments(t *testing.T) {
 	// Library sees the default value
 	result, err := evalSchemeEscape(t, lib, `(my-param)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(10))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(10))
 
 	// Library can parameterize it
 	result, err = evalSchemeEscape(t, lib, `(parameterize ((my-param 99)) (my-param))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(99))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(99))
 
 	// After parameterize scope, parent still sees the default
 	result, err = evalSchemeEscape(t, parent, `(my-param)`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(10))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 // ===========================================================================
@@ -571,7 +572,7 @@ func TestMultiEnv_ConcurrentLibraryUse(t *testing.T) {
 	for i := range numLibs {
 		c.Assert(errs[i], qt.IsNil, qt.Commentf("goroutine %d", i))
 		expected := int64((i + 1) * (i + 1))
-		c.Assert(results[i], values.SchemeEquals, values.NewInteger(expected),
+		c.Assert(results[i], valuestest.SchemeEquals, values.NewInteger(expected),
 			qt.Commentf("goroutine %d", i))
 	}
 }
@@ -739,7 +740,7 @@ func TestMultiEnv_LibraryPrimitiveAvailability(t *testing.T) {
 		c.Run(tt.name, func(c *qt.C) {
 			result, err := evalScheme(t, lib, tt.code)
 			c.Assert(err, qt.IsNil, qt.Commentf("code: %s", tt.code))
-			c.Assert(result, values.SchemeEquals, tt.expected, qt.Commentf("code: %s", tt.code))
+			c.Assert(result, valuestest.SchemeEquals, tt.expected, qt.Commentf("code: %s", tt.code))
 		})
 	}
 }

--- a/internal/bootstrap/multithreading_test.go
+++ b/internal/bootstrap/multithreading_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -88,7 +89,7 @@ func TestChannelWithBufferSize(t *testing.T) {
 		  (channel-capacity ch))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(5))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(5))
 }
 
 func TestChannelTrySendReceive(t *testing.T) {
@@ -125,7 +126,7 @@ func TestChannelLength(t *testing.T) {
 		  (channel-length ch))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(2))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestChannelClose(t *testing.T) {
@@ -194,7 +195,7 @@ func TestMutexSpecific(t *testing.T) {
 		  (mutex-specific m))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // ===========================================================================
@@ -407,7 +408,7 @@ func TestAtomicLoadStore(t *testing.T) {
 		  (atomic-load a))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 
 	result, err = evalScheme(t, env, `
 		(let ((a (make-atomic 0)))
@@ -415,7 +416,7 @@ func TestAtomicLoadStore(t *testing.T) {
 		  (atomic-load a))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(100))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 func TestAtomicSwap(t *testing.T) {
@@ -428,7 +429,7 @@ func TestAtomicSwap(t *testing.T) {
 		  (atomic-swap! a 100))
 	`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestAtomicCompareAndSwap(t *testing.T) {

--- a/internal/bootstrap/roundtrip_test.go
+++ b/internal/bootstrap/roundtrip_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -91,7 +92,7 @@ func runRoundTripsWith(t *testing.T, eval evalFunc, cases []roundTripCase) {
 		c.Run(tt.name, func(c *qt.C) {
 			result, err := eval(t, env, tt.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tt.expected)
+			c.Assert(result, valuestest.SchemeEquals, tt.expected)
 		})
 	}
 }

--- a/internal/extensions/all/prim_all_test.go
+++ b/internal/extensions/all/prim_all_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -196,7 +197,7 @@ func TestRecordConstructor(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -301,7 +302,7 @@ func TestRecordAccessor(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -379,7 +380,7 @@ func TestRecordModifier(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -519,7 +520,7 @@ func TestDefineRecordType(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -573,7 +574,7 @@ func TestMakePromise(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -606,7 +607,7 @@ func TestForce(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -634,7 +635,7 @@ func TestDelayForce(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -656,7 +657,7 @@ func TestMakeLazyPromise(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -698,7 +699,7 @@ func TestR7RSPromiseSemantics(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/internal/extensions/all/prim_characters_test.go
+++ b/internal/extensions/all/prim_characters_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aalpar/wile"
 	extall "github.com/aalpar/wile/internal/extensions/all"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -313,7 +314,7 @@ func TestCharUpcase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -338,7 +339,7 @@ func TestCharDowncase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -359,7 +360,7 @@ func TestCharFoldcase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -406,7 +407,7 @@ func TestDigitValue(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 

--- a/internal/extensions/all/prim_strings_test.go
+++ b/internal/extensions/all/prim_strings_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -173,7 +174,7 @@ func TestStringUpcase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -200,7 +201,7 @@ func TestStringDowncase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -222,7 +223,7 @@ func TestStringFoldcase(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -279,7 +280,7 @@ func TestStringCopyTo(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -340,7 +341,7 @@ func TestStringFill(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -397,7 +398,7 @@ func TestStringMap(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 
@@ -462,7 +463,7 @@ func TestStringForEach(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := eval(t, engine, tc.code)
-			c.Assert(result.Internal(), values.SchemeEquals, tc.want)
+			c.Assert(result.Internal(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 

--- a/internal/extensions/eval/prim_eval_test.go
+++ b/internal/extensions/eval/prim_eval_test.go
@@ -25,6 +25,7 @@ import (
 	extexceptions "github.com/aalpar/wile/extensions/exceptions"
 	exteval "github.com/aalpar/wile/internal/extensions/eval"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -69,7 +70,7 @@ func TestEval(t *testing.T) {
 
 	t.Run("evaluate simple expression", func(t *testing.T) {
 		result := eval(t, engine, `(eval '(+ 1 2) (interaction-environment))`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(3))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(3))
 	})
 
 	t.Run("evaluate in null environment", func(t *testing.T) {
@@ -79,7 +80,7 @@ func TestEval(t *testing.T) {
 	t.Run("evaluate variable reference", func(t *testing.T) {
 		eval(t, engine, `(define x 42)`)
 		result := eval(t, engine, `(eval 'x (interaction-environment))`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(42))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(42))
 	})
 
 	t.Run("wrong number of arguments", func(t *testing.T) {
@@ -104,14 +105,14 @@ func TestLoad(t *testing.T) {
 		path := writeTestFile(t, dir, "def.scm", "(define loaded-value 123)")
 		eval(t, engine, fmt.Sprintf(`(load %q)`, path))
 		result := eval(t, engine, `loaded-value`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(123))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(123))
 	})
 
 	t.Run("load multiple expressions", func(t *testing.T) {
 		path := writeTestFile(t, dir, "multi.scm", "(define x 10)\n(define y 20)\n(+ x y)")
 		result := eval(t, engine, fmt.Sprintf(`(load %q)`, path))
 		// load returns the value of the last expression
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(30))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(30))
 	})
 
 	t.Run("load nonexistent file", func(t *testing.T) {
@@ -146,7 +147,7 @@ func TestInteractionEnvironment(t *testing.T) {
 
 	t.Run("environment has standard bindings", func(t *testing.T) {
 		result := eval(t, engine, `(eval '(+ 1 2) (interaction-environment))`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(3))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(3))
 	})
 
 	t.Run("wrong argument count", func(t *testing.T) {
@@ -295,14 +296,14 @@ func TestCompile(t *testing.T) {
 		// compile creates a 0-arg thunk that evaluates the expression
 		eval(t, engine, `(define compiled-expr (compile '(+ 3 4)))`)
 		result := eval(t, engine, `(compiled-expr)`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(7))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(7))
 	})
 
 	t.Run("compile with variable reference", func(t *testing.T) {
 		eval(t, engine, `(define x 10)`)
 		eval(t, engine, `(define compiled-ref (compile 'x))`)
 		result := eval(t, engine, `(compiled-ref)`)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(10))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(10))
 	})
 
 	t.Run("compile syntax object input", func(t *testing.T) {
@@ -456,7 +457,7 @@ func TestEnvironmentWithLibraryRegistry(t *testing.T) {
 		result, err := engine.Eval(context.Background(),
 			`(eval '(caar '((1 2) 3)) (environment '(scheme cxr)))`)
 		c.Assert(err, qt.IsNil)
-		c.Assert(result.Internal(), values.SchemeEquals, values.NewInteger(1))
+		c.Assert(result.Internal(), valuestest.SchemeEquals, values.NewInteger(1))
 	})
 }
 

--- a/internal/parser/bracket_test.go
+++ b/internal/parser/bracket_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -96,7 +97,7 @@ func TestParser_Brackets(t *testing.T) {
 			p := NewParser(env, true, strings.NewReader(tc.in))
 			stx, err := p.ReadSyntax(context.Background())
 			c.Assert(err, qt.IsNil)
-			c.Assert(stx.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(stx.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -187,7 +188,7 @@ func TestParser_BracketDatumLabels(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			// For datum label assignments, unwrap the assignment to get the actual list
 			unwrapped := stx.UnwrapAll()
-			c.Assert(unwrapped, values.SchemeEquals, tc.expect)
+			c.Assert(unwrapped, valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }

--- a/internal/parser/hash_digit_test.go
+++ b/internal/parser/hash_digit_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -189,7 +190,7 @@ func TestHashDigit_Parser(t *testing.T) {
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
 			v := syn.UnwrapAll()
-			c.Assert(v, values.SchemeEquals, tc.expect)
+			c.Assert(v, valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }

--- a/internal/parser/parser_coverage_test.go
+++ b/internal/parser/parser_coverage_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/internal/tokenizer"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -94,7 +95,7 @@ func TestCoverage_BinaryIntegers(t *testing.T) {
 			p := NewParser(env, false, strings.NewReader(tt.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.Unwrap(), values.SchemeEquals, tt.expect)
+			c.Assert(syn.Unwrap(), valuestest.SchemeEquals, tt.expect)
 		})
 	}
 }
@@ -117,7 +118,7 @@ func TestCoverage_OctalIntegers(t *testing.T) {
 			p := NewParser(env, false, strings.NewReader(tt.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.Unwrap(), values.SchemeEquals, tt.expect)
+			c.Assert(syn.Unwrap(), valuestest.SchemeEquals, tt.expect)
 		})
 	}
 }
@@ -141,7 +142,7 @@ func TestCoverage_HexIntegers(t *testing.T) {
 			p := NewParser(env, false, strings.NewReader(tt.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.Unwrap(), values.SchemeEquals, tt.expect)
+			c.Assert(syn.Unwrap(), valuestest.SchemeEquals, tt.expect)
 		})
 	}
 }
@@ -171,7 +172,7 @@ func TestCoverage_BinaryRationals(t *testing.T) {
 			v := syn.Unwrap()
 			r := new(big.Rat).SetFrac64(tt.expectNum, tt.expectDen)
 			expected := values.Simplify(values.NewRationalFromRat(r))
-			c.Assert(v, values.SchemeEquals, expected)
+			c.Assert(v, valuestest.SchemeEquals, expected)
 		})
 	}
 }
@@ -185,7 +186,7 @@ func TestCoverage_OctalRationals(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	r := new(big.Rat).SetFrac64(7, 3)
 	expected := values.Simplify(values.NewRationalFromRat(r))
-	c.Assert(syn.Unwrap(), values.SchemeEquals, expected)
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, expected)
 }
 
 func TestCoverage_HexRationals(t *testing.T) {
@@ -196,7 +197,7 @@ func TestCoverage_HexRationals(t *testing.T) {
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
 	// #x10 = 16, #x8 = 8 => 16/8 = 2
-	c.Assert(syn.Unwrap(), values.SchemeEquals, values.NewInteger(2))
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // ---------------------------------------------------------------------------
@@ -591,15 +592,15 @@ func TestCoverage_MultipleReads(t *testing.T) {
 	p := NewParser(env, true, strings.NewReader("1 2 3"))
 	syn1, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn1.Unwrap(), values.SchemeEquals, values.NewInteger(1))
+	c.Assert(syn1.Unwrap(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	syn2, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn2.Unwrap(), values.SchemeEquals, values.NewInteger(2))
+	c.Assert(syn2.Unwrap(), valuestest.SchemeEquals, values.NewInteger(2))
 
 	syn3, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn3.Unwrap(), values.SchemeEquals, values.NewInteger(3))
+	c.Assert(syn3.Unwrap(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 func TestCoverage_FoldCaseDirective(t *testing.T) {
@@ -929,7 +930,7 @@ func TestCoverage_BlockComment(t *testing.T) {
 	p := NewParser(env, true, strings.NewReader("#| block comment |# 42"))
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.Unwrap(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // ---------------------------------------------------------------------------
@@ -1256,7 +1257,7 @@ func TestCoverage_SkipTopLevelComment(t *testing.T) {
 	p := NewParser(env, true, strings.NewReader("; comment\n42"))
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.Unwrap(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // ---------------------------------------------------------------------------
@@ -1333,7 +1334,7 @@ func TestCoverage_Base10Prefix(t *testing.T) {
 	p := NewParser(env, false, strings.NewReader("#d42"))
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.Unwrap(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // ---------------------------------------------------------------------------
@@ -1402,7 +1403,7 @@ func TestCoverage_SignedRational(t *testing.T) {
 			p := NewParser(env, false, strings.NewReader(tt.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.Unwrap(), values.SchemeEquals, tt.expect)
+			c.Assert(syn.Unwrap(), valuestest.SchemeEquals, tt.expect)
 		})
 	}
 }
@@ -1537,7 +1538,7 @@ func TestCoverage_ParserWithFile(t *testing.T) {
 	p := NewParserWithFile(env, true, strings.NewReader("42"), "test.scm")
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.Unwrap(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.Unwrap(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/internal/schemeutil"
 	"github.com/aalpar/wile/internal/syntax"
+	"github.com/aalpar/wile/internal/syntax/syntaxtest"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -577,11 +579,11 @@ func TestParser_Read(t *testing.T) {
 				return
 			}
 			if tc.sexpect != nil {
-				c.Assert(syn, syntax.SyntaxEquals, tc.sexpect)
+				c.Assert(syn, syntaxtest.SyntaxEquals, tc.sexpect)
 			}
 			if tc.expect != nil {
 				v := syn.UnwrapAll()
-				c.Assert(v, values.SchemeEquals, tc.expect)
+				c.Assert(v, valuestest.SchemeEquals, tc.expect)
 			}
 		})
 	}
@@ -593,7 +595,7 @@ func TestParse(t *testing.T) {
 	env := environment.NewTopLevelEnvironment().Runtime()
 	syn, err := NewParser(env, true, strings.NewReader("42")).ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.UnwrapAll(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestParser_Close tests the Close function.
@@ -606,7 +608,7 @@ func TestParser_Close(t *testing.T) {
 	// Read first expression
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.UnwrapAll(), values.SchemeEquals, values.NewInteger(10))
+	c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(10))
 
 	// Close the parser
 	err = p.Close()
@@ -677,7 +679,7 @@ func TestParser_Quasiquote(t *testing.T) {
 			p.skipComment = false
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -718,7 +720,7 @@ func TestParser_Quasisyntax(t *testing.T) {
 			p.skipComment = false
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -783,7 +785,7 @@ func TestParser_Strings(t *testing.T) {
 			p.skipComment = false
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -813,7 +815,7 @@ func TestParser_MoreCharacters(t *testing.T) {
 			p.skipComment = false
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -953,7 +955,7 @@ func TestParser_CommentsFollowedByCode(t *testing.T) {
 					got = syn.UnwrapAll()
 				}
 				// For datum comments, just check the type since the inner form varies
-				c.Assert(got, values.SchemeEquals, expect, qt.Commentf("mismatch at index %d", i))
+				c.Assert(got, valuestest.SchemeEquals, expect, qt.Commentf("mismatch at index %d", i))
 			}
 
 			// Verify we've consumed everything
@@ -1017,7 +1019,7 @@ func TestParser_CommentsInsideLists(t *testing.T) {
 
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 
 			// Verify we've consumed everything
 			_, err = p.ReadSyntax(context.TODO())
@@ -1970,7 +1972,7 @@ func TestParser_ExtendedExponentMarkers(t *testing.T) {
 			p := NewParser(env, true, strings.NewReader(tc.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -2423,17 +2425,17 @@ func TestParser_MultipleReads(t *testing.T) {
 	// First read
 	syn1, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn1.UnwrapAll(), values.SchemeEquals, values.NewInteger(10))
+	c.Assert(syn1.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(10))
 
 	// Second read - tokenizer should be preserved
 	syn2, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn2.UnwrapAll(), values.SchemeEquals, values.NewInteger(20))
+	c.Assert(syn2.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(20))
 
 	// Third read
 	syn3, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn3.UnwrapAll(), values.SchemeEquals, values.NewInteger(30))
+	c.Assert(syn3.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(30))
 
 	// Fourth read should hit EOF
 	_, err = p.ReadSyntax(context.TODO())
@@ -2481,7 +2483,7 @@ func TestParser_SingleElementVector(t *testing.T) {
 	vec, ok := syn.UnwrapAll().(*values.Vector)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(len(*vec), qt.Equals, 1)
-	c.Assert((*vec)[0], values.SchemeEquals, values.NewInteger(42))
+	c.Assert((*vec)[0], valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestParser_NestedLists tests lists within lists (tests listSyntax with multiple elements)
@@ -2519,10 +2521,10 @@ func TestParser_VectorWithMixedTypes(t *testing.T) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(len(*vec), qt.Equals, 4)
 
-	c.Assert((*vec)[0], values.SchemeEquals, values.NewInteger(42))
-	c.Assert((*vec)[1], values.SchemeEquals, values.NewString("hello"))
-	c.Assert((*vec)[2], values.SchemeEquals, values.TrueValue)
-	c.Assert((*vec)[3], values.SchemeEquals, values.NewSymbol("foo"))
+	c.Assert((*vec)[0], valuestest.SchemeEquals, values.NewInteger(42))
+	c.Assert((*vec)[1], valuestest.SchemeEquals, values.NewString("hello"))
+	c.Assert((*vec)[2], valuestest.SchemeEquals, values.TrueValue)
+	c.Assert((*vec)[3], valuestest.SchemeEquals, values.NewSymbol("foo"))
 }
 
 // TestParser_ListSyntaxMultipleElements tests listSyntax with more than 2 elements
@@ -2537,7 +2539,7 @@ func TestParser_ListSyntaxMultipleElements(t *testing.T) {
 
 	// Should be (quote (a b c d))
 	pair := syn.UnwrapAll().(*values.Pair)
-	c.Assert(pair.Car(), values.SchemeEquals, values.NewSymbol("quote"))
+	c.Assert(pair.Car(), valuestest.SchemeEquals, values.NewSymbol("quote"))
 
 	// The cdr should be the list (a b c d)
 	quotedList := pair.Cdr().(*values.Pair).Car().(*values.Pair)
@@ -2656,7 +2658,7 @@ func TestParser_ReadSyntaxEOFHandling(t *testing.T) {
 	// First read succeeds
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.UnwrapAll(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Second read hits EOF (but this is OK, tokenizer advances)
 	_, err = p.ReadSyntax(context.TODO())
@@ -2715,7 +2717,7 @@ func TestParser_EmptyList(t *testing.T) {
 	p := NewParser(env, true, strings.NewReader("()"))
 	syn, err := p.ReadSyntax(context.TODO())
 	c.Assert(err, qt.IsNil)
-	c.Assert(syn.UnwrapAll(), values.SchemeEquals, values.EmptyList)
+	c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, values.EmptyList)
 }
 
 // TestParser_ImproperList tests improper list (dotted pair) parsing
@@ -2729,7 +2731,7 @@ func TestParser_ImproperList(t *testing.T) {
 
 	// Should be a pair with a and a pair with b and c
 	pair := syn.UnwrapAll().(*values.Pair)
-	c.Assert(pair.Car(), values.SchemeEquals, values.NewSymbol("a"))
+	c.Assert(pair.Car(), valuestest.SchemeEquals, values.NewSymbol("a"))
 }
 
 // TestParser_QuasiquoteSingleElement tests listSyntax with 1 element
@@ -2743,7 +2745,7 @@ func TestParser_QuasiquoteSingleElement(t *testing.T) {
 
 	// Should be (quasiquote x)
 	list := syn.UnwrapAll().(*values.Pair)
-	c.Assert(list.Car(), values.SchemeEquals, values.NewSymbol("quasiquote"))
+	c.Assert(list.Car(), valuestest.SchemeEquals, values.NewSymbol("quasiquote"))
 	c.Assert(list.Length(), qt.Equals, 2) // (quasiquote x) is length 2
 }
 
@@ -2758,7 +2760,7 @@ func TestParser_UnquoteSplicing(t *testing.T) {
 
 	// Should be (unquote-splicing foo)
 	list := syn.UnwrapAll().(*values.Pair)
-	c.Assert(list.Car(), values.SchemeEquals, values.NewSymbol("unquote-splicing"))
+	c.Assert(list.Car(), valuestest.SchemeEquals, values.NewSymbol("unquote-splicing"))
 	c.Assert(list.Length(), qt.Equals, 2)
 }
 
@@ -2780,7 +2782,7 @@ func TestParser_SignedNumbers(t *testing.T) {
 			p := NewParser(env, true, strings.NewReader(tc.input))
 			syn, err := p.ReadSyntax(context.TODO())
 			c.Assert(err, qt.IsNil)
-			c.Assert(syn.UnwrapAll(), values.SchemeEquals, tc.expect)
+			c.Assert(syn.UnwrapAll(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }

--- a/internal/schemeutil/syntax_test.go
+++ b/internal/schemeutil/syntax_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
@@ -55,7 +56,7 @@ func (p *SyntaxValueToDatumSuite) TestSymbol(c *qt.C) {
 	sym := syntax.NewSyntaxSymbol("foo", p.sctx)
 	result := SyntaxValueToDatum(sym)
 	expected := values.NewSymbol("foo")
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxValueToDatumSuite) TestProperList(c *qt.C) {
@@ -70,7 +71,7 @@ func (p *SyntaxValueToDatumSuite) TestProperList(c *qt.C) {
 
 	result := SyntaxValueToDatum(list)
 	expected := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxValueToDatumSuite) TestImproperList(c *qt.C) {
@@ -81,7 +82,7 @@ func (p *SyntaxValueToDatumSuite) TestImproperList(c *qt.C) {
 
 	result := SyntaxValueToDatum(pair)
 	expected := values.NewCons(values.NewInteger(1), values.NewInteger(2))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxValueToDatumSuite) TestImproperListLonger(c *qt.C) {
@@ -95,7 +96,7 @@ func (p *SyntaxValueToDatumSuite) TestImproperListLonger(c *qt.C) {
 	result := SyntaxValueToDatum(list)
 	expected := values.NewCons(values.NewInteger(1),
 		values.NewCons(values.NewInteger(2), values.NewInteger(3)))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxValueToDatumSuite) TestVector(c *qt.C) {
@@ -108,13 +109,13 @@ func (p *SyntaxValueToDatumSuite) TestVector(c *qt.C) {
 
 	result := SyntaxValueToDatum(vec)
 	expected := values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxValueToDatumSuite) TestSyntaxObject(c *qt.C) {
 	obj := syntax.NewSyntaxObject(values.NewInteger(42), p.sctx)
 	result := SyntaxValueToDatum(obj)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func (p *SyntaxValueToDatumSuite) TestSyntaxObjectWithBox(c *qt.C) {
@@ -125,7 +126,7 @@ func (p *SyntaxValueToDatumSuite) TestSyntaxObjectWithBox(c *qt.C) {
 	result := SyntaxValueToDatum(obj)
 	resultBox, ok := result.(*values.Box)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(resultBox.Unbox(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(resultBox.Unbox(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func (p *SyntaxValueToDatumSuite) TestPlainValue(c *qt.C) {
@@ -155,7 +156,7 @@ func (p *SyntaxValueToDatumSuite) TestNestedList(c *qt.C) {
 	expected := values.List(
 		values.List(values.NewInteger(1), values.NewInteger(2)),
 		values.List(values.NewInteger(3), values.NewInteger(4)))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func TestSyntaxValueToDatum(t *testing.T) {
@@ -195,7 +196,7 @@ func (p *DatumToSyntaxValueSuite) TestProperList(c *qt.C) {
 
 	// Convert back to datum and compare
 	datum := SyntaxValueToDatum(result)
-	c.Assert(datum, values.SchemeEquals, list)
+	c.Assert(datum, valuestest.SchemeEquals, list)
 }
 
 func (p *DatumToSyntaxValueSuite) TestImproperList(c *qt.C) {
@@ -204,7 +205,7 @@ func (p *DatumToSyntaxValueSuite) TestImproperList(c *qt.C) {
 
 	// Convert back to datum and compare
 	datum := SyntaxValueToDatum(result)
-	c.Assert(datum, values.SchemeEquals, pair)
+	c.Assert(datum, valuestest.SchemeEquals, pair)
 }
 
 func (p *DatumToSyntaxValueSuite) TestImproperListLonger(c *qt.C) {
@@ -215,7 +216,7 @@ func (p *DatumToSyntaxValueSuite) TestImproperListLonger(c *qt.C) {
 
 	// Convert back to datum and compare
 	datum := SyntaxValueToDatum(result)
-	c.Assert(datum, values.SchemeEquals, pair)
+	c.Assert(datum, valuestest.SchemeEquals, pair)
 }
 
 func (p *DatumToSyntaxValueSuite) TestVector(c *qt.C) {
@@ -228,7 +229,7 @@ func (p *DatumToSyntaxValueSuite) TestVector(c *qt.C) {
 
 	// Convert back to datum and compare
 	datum := SyntaxValueToDatum(result)
-	c.Assert(datum, values.SchemeEquals, vec)
+	c.Assert(datum, valuestest.SchemeEquals, vec)
 }
 
 func (p *DatumToSyntaxValueSuite) TestBox(c *qt.C) {
@@ -256,7 +257,7 @@ func (p *DatumToSyntaxValueSuite) TestInteger(c *qt.C) {
 
 	synObj, ok := result.(*syntax.SyntaxObject)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(synObj.Datum(), values.SchemeEquals, num)
+	c.Assert(synObj.Datum(), valuestest.SchemeEquals, num)
 }
 
 func (p *DatumToSyntaxValueSuite) TestNestedList(c *qt.C) {
@@ -268,7 +269,7 @@ func (p *DatumToSyntaxValueSuite) TestNestedList(c *qt.C) {
 
 	// Convert back to datum and compare
 	datum := SyntaxValueToDatum(result)
-	c.Assert(datum, values.SchemeEquals, list)
+	c.Assert(datum, valuestest.SchemeEquals, list)
 }
 
 func TestDatumToSyntaxValue(t *testing.T) {
@@ -292,7 +293,7 @@ func (p *RoundTripSuite) TestProperList(c *qt.C) {
 
 	syntaxVal := DatumToSyntaxValue(context.Background(), p.sctx, original)
 	result := SyntaxValueToDatum(syntaxVal)
-	c.Assert(result, values.SchemeEquals, original)
+	c.Assert(result, valuestest.SchemeEquals, original)
 }
 
 func (p *RoundTripSuite) TestComplexStructure(c *qt.C) {
@@ -304,7 +305,7 @@ func (p *RoundTripSuite) TestComplexStructure(c *qt.C) {
 
 	syntaxVal := DatumToSyntaxValue(context.Background(), p.sctx, original)
 	result := SyntaxValueToDatum(syntaxVal)
-	c.Assert(result, values.SchemeEquals, original)
+	c.Assert(result, valuestest.SchemeEquals, original)
 }
 
 func TestRoundTrip(t *testing.T) {

--- a/internal/syntax/coverage_extra_test.go
+++ b/internal/syntax/coverage_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -44,11 +45,11 @@ func TestSyntaxVoid_SourceContext(t *testing.T) {
 }
 
 func TestSyntaxVoid_Unwrap(t *testing.T) {
-	qt.Assert(t, SyntaxVoid.Unwrap(), values.SchemeEquals, values.Void)
+	qt.Assert(t, SyntaxVoid.Unwrap(), valuestest.SchemeEquals, values.Void)
 }
 
 func TestSyntaxVoid_UnwrapAll(t *testing.T) {
-	qt.Assert(t, SyntaxVoid.UnwrapAll(), values.SchemeEquals, values.Void)
+	qt.Assert(t, SyntaxVoid.UnwrapAll(), valuestest.SchemeEquals, values.Void)
 }
 
 // SourceIndexes.Tab

--- a/internal/syntax/coverage_test.go
+++ b/internal/syntax/coverage_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -266,14 +267,14 @@ func TestSyntaxComment_Unwrap(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	comment := NewSyntaxComment("; hello", sctx)
 	result := comment.Unwrap()
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("; hello"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("; hello"))
 }
 
 func TestSyntaxComment_UnwrapAll(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	comment := NewSyntaxComment("; hello", sctx)
 	result := comment.UnwrapAll()
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("; hello"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("; hello"))
 }
 
 func TestSyntaxComment_IsVoid(t *testing.T) {
@@ -315,14 +316,14 @@ func TestSyntaxDirective_Unwrap(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	directive := NewSyntaxDirective("#!fold-case", sctx)
 	result := directive.Unwrap()
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("#!fold-case"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("#!fold-case"))
 }
 
 func TestSyntaxDirective_UnwrapAll(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	directive := NewSyntaxDirective("#!fold-case", sctx)
 	result := directive.UnwrapAll()
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("#!fold-case"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("#!fold-case"))
 }
 
 func TestSyntaxDirective_IsVoid(t *testing.T) {
@@ -375,7 +376,7 @@ func TestSyntaxDatumComment_UnwrapAll(t *testing.T) {
 	value := NewSyntaxObject(values.NewInteger(42), sctx)
 	datum := NewSyntaxDatumComment("#;", value, sctx)
 	result := datum.UnwrapAll()
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestSyntaxDatumComment_IsVoid(t *testing.T) {
@@ -427,14 +428,14 @@ func TestSyntaxDatumLabel_Unwrap(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	label := NewSyntaxDatumLabel(1, sctx)
 	result := label.Unwrap()
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestSyntaxDatumLabel_UnwrapAll(t *testing.T) {
 	sctx := NewSourceContext("", "", NewSourceIndexes(0, 0, 0), NewSourceIndexes(0, 0, 0))
 	label := NewSyntaxDatumLabel(1, sctx)
 	result := label.UnwrapAll()
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestSyntaxDatumLabel_IsVoid(t *testing.T) {
@@ -486,7 +487,7 @@ func TestSyntaxDatumLabelAssignment_UnwrapAll(t *testing.T) {
 	value := NewSyntaxObject(values.NewInteger(42), sctx)
 	assignment := NewSyntaxDatumLabelAssignment(1, value, sctx)
 	result := assignment.UnwrapAll()
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestSyntaxDatumLabelAssignment_IsVoid(t *testing.T) {
@@ -712,26 +713,6 @@ func TestNewScope(t *testing.T) {
 func TestSyntaxEmptyListCoverage(t *testing.T) {
 	qt.Assert(t, SyntaxEmptyList, qt.IsNotNil)
 	qt.Assert(t, SyntaxEmptyList.IsEmptyList(), qt.IsTrue)
-}
-
-// Test SyntaxEquals checker
-func TestSyntaxEquals(t *testing.T) {
-	checker := SyntaxEquals
-	qt.Assert(t, checker.ArgNames(), qt.DeepEquals, []string{"got", "want"})
-
-	sctx1 := NewSourceContext("test", "file.scm", NewSourceIndexes(0, 0, 1), NewSourceIndexes(5, 5, 1))
-	sctx2 := NewSourceContext("test", "file.scm", NewSourceIndexes(0, 0, 1), NewSourceIndexes(5, 5, 1))
-	sctx3 := NewSourceContext("other", "file.scm", NewSourceIndexes(0, 0, 1), NewSourceIndexes(5, 5, 1))
-
-	sym1 := NewSyntaxSymbol("foo", sctx1)
-	sym2 := NewSyntaxSymbol("foo", sctx2)
-	sym3 := NewSyntaxSymbol("foo", sctx3)
-
-	err := checker.Check(sym1, []any{sym2}, nil)
-	qt.Assert(t, err, qt.IsNil)
-
-	err = checker.Check(sym1, []any{sym3}, nil)
-	qt.Assert(t, err, qt.IsNotNil)
 }
 
 // TestSyntaxList_ElementSourceContext verifies that SyntaxList preserves

--- a/internal/syntax/syntax_value_test.go
+++ b/internal/syntax/syntax_value_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
@@ -62,7 +63,7 @@ func (p *SyntaxValueSuite) TestEqualTo_SameValue(c *qt.C) {
 	stx1 := NewSyntaxSymbol("foob", NewSourceContext("", "bar", sidx10, sidx11))
 
 	c.Assert(stx0, qt.Not(qt.Equals), stx1)
-	c.Assert(stx0, qt.Not(values.SchemeEquals), stx1)
+	c.Assert(stx0, qt.Not(valuestest.SchemeEquals), stx1)
 }
 
 // Test EqualTo and SchemeEquals methods for different values
@@ -72,7 +73,7 @@ func (p *SyntaxValueSuite) TestEqualTo_DifferentValue(c *qt.C) {
 	stx1 := p.makeSyntaxSymbol("bars")
 
 	c.Assert(stx0, qt.Not(qt.Equals), stx1)
-	c.Assert(stx0, qt.Not(values.SchemeEquals), stx1)
+	c.Assert(stx0, qt.Not(valuestest.SchemeEquals), stx1)
 }
 
 // Test EqualTo and SchemeEquals methods for different source contexts
@@ -86,7 +87,7 @@ func (p *SyntaxValueSuite) TestEqualTo_DifferentSourceContext(c *qt.C) {
 	stx1 := NewSyntaxSymbol("foob", sctx1)
 
 	c.Assert(stx0, qt.Not(qt.Equals), stx1)
-	c.Assert(stx0, qt.Not(values.SchemeEquals), stx1)
+	c.Assert(stx0, qt.Not(valuestest.SchemeEquals), stx1)
 }
 
 func (p *SyntaxValueSuite) TestUnwrap_Symbol(c *qt.C) {
@@ -100,7 +101,7 @@ func (p *SyntaxValueSuite) TestUnwrap_Integer(c *qt.C) {
 	// SyntaxObject can wrap integers
 	stx := p.makeSyntaxObject(values.NewInteger(42))
 	v := stx.Unwrap()
-	c.Assert(v, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(v, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func (p *SyntaxValueSuite) TestUnwrapAll_Symbol(c *qt.C) {
@@ -114,7 +115,7 @@ func (p *SyntaxValueSuite) TestUnwrapAll_Integer(c *qt.C) {
 	// SyntaxObject can wrap integers
 	stx := p.makeSyntaxObject(values.NewInteger(42))
 	v := stx.UnwrapAll()
-	c.Assert(v, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(v, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func (p *SyntaxValueSuite) TestUnwrapAll_Pair(c *qt.C) {
@@ -125,7 +126,7 @@ func (p *SyntaxValueSuite) TestUnwrapAll_Pair(c *qt.C) {
 
 	pr1 := values.List(values.NewSymbol("foob"), values.NewSymbol("barb"))
 	v := pr0.UnwrapAll()
-	c.Assert(v, values.SchemeEquals, pr1)
+	c.Assert(v, valuestest.SchemeEquals, pr1)
 }
 
 func TestSyntaxValue(t *testing.T) {

--- a/internal/syntax/syntax_vector_test.go
+++ b/internal/syntax/syntax_vector_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/frankban/quicktest/qtsuite"
@@ -49,9 +50,9 @@ func (p *SyntaxVectorSuite) TestNewSyntaxVector_WithValues(c *qt.C) {
 
 	vec := NewSyntaxVector(p.sctx, v1, v2, v3)
 	c.Assert(len(vec.Values), qt.Equals, 3)
-	c.Assert(vec.Values[0], values.SchemeEquals, v1)
-	c.Assert(vec.Values[1], values.SchemeEquals, v2)
-	c.Assert(vec.Values[2], values.SchemeEquals, v3)
+	c.Assert(vec.Values[0], valuestest.SchemeEquals, v1)
+	c.Assert(vec.Values[1], valuestest.SchemeEquals, v2)
+	c.Assert(vec.Values[2], valuestest.SchemeEquals, v3)
 }
 
 func (p *SyntaxVectorSuite) TestSourceContext(c *qt.C) {
@@ -88,14 +89,14 @@ func (p *SyntaxVectorSuite) TestUnwrap_WithValues(c *qt.C) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(len(*resultVec), qt.Equals, 2)
 	// Unwrap keeps syntax values inside
-	c.Assert((*resultVec)[0], values.SchemeEquals, v1)
-	c.Assert((*resultVec)[1], values.SchemeEquals, v2)
+	c.Assert((*resultVec)[0], valuestest.SchemeEquals, v1)
+	c.Assert((*resultVec)[1], valuestest.SchemeEquals, v2)
 }
 
 func (p *SyntaxVectorSuite) TestUnwrap_Nil(c *qt.C) {
 	var vec *SyntaxVector
 	result := vec.Unwrap()
-	c.Assert(result, values.SchemeEquals, values.Void)
+	c.Assert(result, valuestest.SchemeEquals, values.Void)
 }
 
 func (p *SyntaxVectorSuite) TestUnwrapAll_Empty(c *qt.C) {
@@ -117,8 +118,8 @@ func (p *SyntaxVectorSuite) TestUnwrapAll_WithValues(c *qt.C) {
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(len(*resultVec), qt.Equals, 2)
 	// UnwrapAll recursively unwraps to raw values
-	c.Assert((*resultVec)[0], values.SchemeEquals, values.NewInteger(1))
-	c.Assert((*resultVec)[1], values.SchemeEquals, values.NewInteger(2))
+	c.Assert((*resultVec)[0], valuestest.SchemeEquals, values.NewInteger(1))
+	c.Assert((*resultVec)[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func (p *SyntaxVectorSuite) TestUnwrapAll_Nested(c *qt.C) {
@@ -135,13 +136,13 @@ func (p *SyntaxVectorSuite) TestUnwrapAll_Nested(c *qt.C) {
 	expected := values.NewVector(
 		values.NewVector(values.NewInteger(1), values.NewInteger(2)),
 		values.NewVector(values.NewInteger(3), values.NewInteger(4)))
-	c.Assert(result, values.SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 }
 
 func (p *SyntaxVectorSuite) TestUnwrapAll_Nil(c *qt.C) {
 	var vec *SyntaxVector
 	result := vec.UnwrapAll()
-	c.Assert(result, values.SchemeEquals, values.Void)
+	c.Assert(result, valuestest.SchemeEquals, values.Void)
 }
 
 func (p *SyntaxVectorSuite) TestSchemeString_Empty(c *qt.C) {
@@ -230,9 +231,9 @@ func (p *SyntaxVectorSuite) TestSyntaxForEach_IteratesElements(c *qt.C) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(IsSyntaxEmptyList(tail), qt.IsTrue)
 	c.Assert(len(seen), qt.Equals, 3)
-	c.Assert(seen[0], values.SchemeEquals, v1)
-	c.Assert(seen[1], values.SchemeEquals, v2)
-	c.Assert(seen[2], values.SchemeEquals, v3)
+	c.Assert(seen[0], valuestest.SchemeEquals, v1)
+	c.Assert(seen[1], valuestest.SchemeEquals, v2)
+	c.Assert(seen[2], valuestest.SchemeEquals, v3)
 	c.Assert(idxs, qt.DeepEquals, []int{0, 1, 2})
 	c.Assert(lastFlags, qt.DeepEquals, []bool{true, true, false})
 }
@@ -285,8 +286,8 @@ func (p *SyntaxVectorSuite) TestSyntaxForEach_ErrorStopsIteration(c *qt.C) {
 	c.Assert(err, qt.Equals, sentinel)
 	c.Assert(tail, qt.IsNil)
 	c.Assert(len(seen), qt.Equals, 2)
-	c.Assert(seen[0], values.SchemeEquals, v1)
-	c.Assert(seen[1], values.SchemeEquals, v2)
+	c.Assert(seen[0], valuestest.SchemeEquals, v1)
+	c.Assert(seen[1], valuestest.SchemeEquals, v2)
 }
 
 // TestAddScope_EmptyVector verifies empty vectors return unchanged

--- a/internal/syntax/syntaxtest/syntax_equals.go
+++ b/internal/syntax/syntaxtest/syntax_equals.go
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package syntax
+// Package syntaxtest provides test helpers for the syntax package.
+package syntaxtest
 
 import (
 	"errors"
 	"fmt"
 	"reflect"
+
+	"github.com/aalpar/wile/internal/syntax"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -37,7 +40,7 @@ func (p *syntaxEqualsChecker) Check(got any, args []any, note func(key string, v
 		// A panic is raised when the provided args are not comparable.
 		r := recover()
 		if r != nil {
-			err = fmt.Errorf("%v", r) //nolint:gocritic // quicktest checker, not Scheme runtime
+			err = fmt.Errorf("%v", r) //nolint:gocritic // test helper, not Scheme runtime
 		}
 	}()
 
@@ -46,7 +49,7 @@ func (p *syntaxEqualsChecker) Check(got any, args []any, note func(key string, v
 	// Customize error message for non-nil errors.
 	_, ok := got.(error)
 	if ok && got == nil {
-		return errors.New("got non-nil error") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("got non-nil error") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
 	// Show error types when comparing errors with different types.
@@ -61,20 +64,20 @@ func (p *syntaxEqualsChecker) Check(got any, args []any, note func(key string, v
 				note("want type", qt.Unquoted(wantType.String()))
 			}
 		}
-		return errors.New("values are not equal") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("values are not equal") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
-	gotSyntaxValue, ok0 := got.(SyntaxValue)
-	wantSyntaxValue, ok1 := want.(SyntaxValue)
+	gotSyntaxValue, ok0 := got.(syntax.SyntaxValue)
+	wantSyntaxValue, ok1 := want.(syntax.SyntaxValue)
 	if !ok0 || !ok1 {
-		return errors.New("got and want must be of type Datum") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("got and want must be of type Datum") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
 	if !gotSyntaxValue.SourceContext().EqualTo(wantSyntaxValue.SourceContext()) {
-		return errors.New("source contexts are not equal") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("source contexts are not equal") //nolint:gocritic // test helper, not Scheme runtime
 	}
 	if !gotSyntaxValue.UnwrapAll().EqualTo(wantSyntaxValue.UnwrapAll()) {
-		return errors.New("values are not equal") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("values are not equal") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
 	return nil

--- a/internal/syntax/syntaxtest/syntax_equals_test.go
+++ b/internal/syntax/syntaxtest/syntax_equals_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntaxtest
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aalpar/wile/internal/syntax"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestSyntaxEquals(t *testing.T) {
+	checker := SyntaxEquals
+	qt.Assert(t, checker.ArgNames(), qt.DeepEquals, []string{"got", "want"})
+
+	sctx1 := syntax.NewSourceContext("test", "file.scm", syntax.NewSourceIndexes(0, 0, 1), syntax.NewSourceIndexes(5, 5, 1))
+	sctx2 := syntax.NewSourceContext("test", "file.scm", syntax.NewSourceIndexes(0, 0, 1), syntax.NewSourceIndexes(5, 5, 1))
+	sctx3 := syntax.NewSourceContext("other", "file.scm", syntax.NewSourceIndexes(0, 0, 1), syntax.NewSourceIndexes(5, 5, 1))
+
+	sym1 := syntax.NewSyntaxSymbol("foo", sctx1)
+	sym2 := syntax.NewSyntaxSymbol("foo", sctx2)
+	sym3 := syntax.NewSyntaxSymbol("foo", sctx3)
+
+	err := checker.Check(sym1, []any{sym2}, nil)
+	qt.Assert(t, err, qt.IsNil)
+
+	err = checker.Check(sym1, []any{sym3}, nil)
+	qt.Assert(t, err, qt.IsNotNil)
+}
+
+func TestSyntaxEqualsEdgeCases(t *testing.T) {
+	c := qt.New(t)
+	checker := SyntaxEquals
+
+	sctx := syntax.NewSourceContext("test", "file.scm", syntax.NewSourceIndexes(0, 0, 1), syntax.NewSourceIndexes(5, 5, 1))
+
+	t.Run("panic recovery on nil args", func(t *testing.T) {
+		err := checker.Check(syntax.NewSyntaxSymbol("x", sctx), nil, nil)
+		c.Assert(err, qt.IsNotNil)
+	})
+
+	t.Run("got is error want is error different types", func(t *testing.T) {
+		gotErr := fmt.Errorf("wrapped: %w", errors.New("inner"))
+		wantErr := errors.New("plain")
+		var noteKeys []string
+		note := func(key string, value any) {
+			noteKeys = append(noteKeys, key)
+		}
+		err := checker.Check(gotErr, []any{wantErr}, note)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+		c.Assert(noteKeys, qt.DeepEquals, []string{"got type", "want type"})
+	})
+
+	t.Run("got is error want is error same type", func(t *testing.T) {
+		gotErr := errors.New("a")
+		wantErr := errors.New("b")
+		var noteKeys []string
+		note := func(key string, value any) {
+			noteKeys = append(noteKeys, key)
+		}
+		err := checker.Check(gotErr, []any{wantErr}, note)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+		c.Assert(len(noteKeys), qt.Equals, 0)
+	})
+
+	t.Run("got is error want is non-error", func(t *testing.T) {
+		err := checker.Check(errors.New("oops"), []any{syntax.NewSyntaxSymbol("x", sctx)}, nil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+	})
+
+	t.Run("non-SyntaxValue arguments", func(t *testing.T) {
+		err := checker.Check("not syntax", []any{"also not"}, nil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "got and want must be of type Datum")
+	})
+
+	t.Run("same context different values", func(t *testing.T) {
+		sym1 := syntax.NewSyntaxSymbol("foo", sctx)
+		sym2 := syntax.NewSyntaxSymbol("bar", sctx)
+		err := checker.Check(sym1, []any{sym2}, nil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+	})
+}

--- a/machine/compile_syntax_rules_test.go
+++ b/machine/compile_syntax_rules_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -104,7 +105,7 @@ func TestCompileSyntaxRules_RoundTrip(t *testing.T) {
 			mc = machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -134,7 +135,7 @@ func TestCompileSyntaxRules_LiteralsNonMatch(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 }
 
 // TestCompileSyntaxRules_Errors tests error conditions during syntax-rules

--- a/machine/compile_time_continuation_test.go
+++ b/machine/compile_time_continuation_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aalpar/wile/internal/schemeutil"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -40,7 +41,7 @@ func TestCompileContext_CompileLambda(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 5)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationPush(),
 		NewOperationLoadLiteralByLiteralIndexImmediate(1),
@@ -54,7 +55,7 @@ func TestCompileContext_CompileLambda(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	// check that the template has been compiled correctly
 	qt.Assert(t, tpl0.EffectiveOperations(), qt.HasLen, 2)
-	qt.Assert(t, tpl0.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, tpl0.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLocalByLocalIndexImmediate(environment.NewLocalIndex(0, 0)),
 		NewOperationRestoreContinuation(),
 	))
@@ -85,7 +86,7 @@ func TestCompileContext_CompileLambdaCall(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 11)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationSaveContinuationOffsetImmediate(11),
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationPush(),
@@ -106,7 +107,7 @@ func TestCompileContext_CompileLambdaCall(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	// check that the template has been compiled correctly
 	qt.Assert(t, tpl0.EffectiveOperations(), qt.HasLen, 2)
-	qt.Assert(t, tpl0.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, tpl0.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLocalByLocalIndexImmediate(environment.NewLocalIndex(0, 0)),
 		NewOperationRestoreContinuation(),
 	))
@@ -123,7 +124,7 @@ func TestCompileContext_CompileLambdaCall(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewCons(values.NewString("hello"), values.EmptyList))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewCons(values.NewString("hello"), values.EmptyList))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -140,7 +141,7 @@ func TestCompileContext_CompileDefine(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 4)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationPush(),
 		NewOperationStoreGlobalByGlobalIndexLiteralIndexImmediate(LiteralIndex(1)),
@@ -171,7 +172,7 @@ func TestCompileContext_CompileQuote(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 1)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 	))
 	qt.Assert(t, cont.template.isVariadic, qt.Equals, false)
@@ -183,7 +184,7 @@ func TestCompileContext_CompileQuote(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewSymbol("x"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("x"))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -200,7 +201,7 @@ func TestCompileContext_CompileQuasiquote(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 1)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 	))
 	qt.Assert(t, cont.template.isVariadic, qt.Equals, false)
@@ -212,7 +213,7 @@ func TestCompileContext_CompileQuasiquote(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewSymbol("x"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("x"))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -303,7 +304,7 @@ func TestCompileContext_CompileNestedQuasiquote(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := evalSchemeString(tc.input)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -402,7 +403,7 @@ func TestCompileContext_CompileIf(t *testing.T) {
 
 	// BranchOnFalseValue reads value register directly, no Push needed
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 5)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadGlobalByGlobalIndexLiteralIndexImmediate(0),
 		NewOperationBranchOnFalseValueOffsetImmediate(3),
 		NewOperationLoadLiteralByLiteralIndexImmediate(1),
@@ -415,7 +416,7 @@ func TestCompileContext_CompileIf(t *testing.T) {
 	mc := NewMachineContext(context.Background(), NewMachineContinuation(nil, cont.template, env))
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("false"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("false"))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 
 	// Run with x = #t → should take the true branch
@@ -423,7 +424,7 @@ func TestCompileContext_CompileIf(t *testing.T) {
 	mc = NewMachineContext(context.Background(), NewMachineContinuation(nil, cont.template, env))
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("true"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("true"))
 }
 
 func TestCompileContext_CompileIfConstantFolding(t *testing.T) {
@@ -441,14 +442,14 @@ func TestCompileContext_CompileIfConstantFolding(t *testing.T) {
 
 	// Constant folding: only the alternative branch is compiled
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 1)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 	))
 
 	mc := NewMachineContext(context.Background(), NewMachineContinuation(nil, cont.template, env))
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("false"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("false"))
 
 	// (if #t "true" "false") — constant-folds to just "true"
 	prog2 := values.List(values.NewSymbol("if"),
@@ -463,7 +464,7 @@ func TestCompileContext_CompileIfConstantFolding(t *testing.T) {
 	mc2 := NewMachineContext(context.Background(), NewMachineContinuation(nil, cont2.template, env))
 	err = mc2.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc2.GetValue(), values.SchemeEquals, values.NewString("true"))
+	qt.Assert(t, mc2.GetValue(), valuestest.SchemeEquals, values.NewString("true"))
 }
 
 func TestCompileContext_CompileSetBang(t *testing.T) {
@@ -479,7 +480,7 @@ func TestCompileContext_CompileSetBang(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 4)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationPush(),
 		NewOperationStoreGlobalByGlobalIndexLiteralIndexImmediate(LiteralIndex(1)),
@@ -488,8 +489,8 @@ func TestCompileContext_CompileSetBang(t *testing.T) {
 	qt.Assert(t, cont.template.isVariadic, qt.Equals, false)
 	qt.Assert(t, cont.template.parameterCount, qt.Equals, 0)
 	qt.Assert(t, cont.template.literals, qt.HasLen, 2)
-	qt.Assert(t, cont.template.literals[0], values.SchemeEquals, values.NewString("true"))
-	qt.Assert(t, cont.template.literals[1], values.SchemeEquals, gi)
+	qt.Assert(t, cont.template.literals[0], valuestest.SchemeEquals, values.NewString("true"))
+	qt.Assert(t, cont.template.literals[1], valuestest.SchemeEquals, gi)
 
 	mc := NewMachineContext(context.Background(), NewMachineContinuation(nil, cont.template, env))
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 0)
@@ -503,7 +504,7 @@ func TestCompileContext_CompileSetBang(t *testing.T) {
 	qt.Assert(t, gi, qt.IsNotNil)
 	v := mc.env.GlobalEnvironment().GetOwnGlobalBinding(gi)
 	qt.Assert(t, v.BindingType(), qt.Equals, environment.BindingTypeVariable)
-	qt.Assert(t, v.Value(), values.SchemeEquals, values.NewString("true"))
+	qt.Assert(t, v.Value(), valuestest.SchemeEquals, values.NewString("true"))
 }
 
 func TestCompileContext_CompileBegin_0(t *testing.T) {
@@ -521,7 +522,7 @@ func TestCompileContext_CompileBegin_0(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.literals, qt.HasLen, 4)
-	qt.Assert(t, cont.template.literals, values.SchemeEquals,
+	qt.Assert(t, cont.template.literals, valuestest.SchemeEquals,
 		NewMultipleValues(
 			cont.template.literals[0],
 			cont.template.literals[1],
@@ -530,7 +531,7 @@ func TestCompileContext_CompileBegin_0(t *testing.T) {
 		),
 	)
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 15)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationPush(),
 		NewOperationLoadLiteralByLiteralIndexImmediate(1),
@@ -556,7 +557,7 @@ func TestCompileContext_CompileBegin_0(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewBoolean(true))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewBoolean(true))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -570,7 +571,7 @@ func TestCompileContext_CompileBegin_1(t *testing.T) {
 
 	// check that the closure has been compiled correctly
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 2)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationLoadLiteralByLiteralIndexImmediate(1),
 	))
@@ -583,7 +584,7 @@ func TestCompileContext_CompileBegin_1(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("false"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("false"))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -598,7 +599,7 @@ func TestCompileContext_CompileMeta(t *testing.T) {
 	// check that the closure has been compiled correctly
 	// meta should compile like begin - sequence of expressions
 	qt.Assert(t, cont.template.EffectiveOperations(), qt.HasLen, 2)
-	qt.Assert(t, cont.template.EffectiveOperations(), values.SchemeEquals, NewOperations(
+	qt.Assert(t, cont.template.EffectiveOperations(), valuestest.SchemeEquals, NewOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(0),
 		NewOperationLoadLiteralByLiteralIndexImmediate(1),
 	))
@@ -611,7 +612,7 @@ func TestCompileContext_CompileMeta(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("second"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("second"))
 	qt.Assert(t, *mc.evals, qt.HasLen, 0)
 }
 
@@ -838,7 +839,7 @@ func TestCompileContext_CompileCaseLambdaCall(t *testing.T) {
 
 	// Should call first clause with 1 arg: returns 42
 	qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // Tests moved from coverage_additional_test.go
@@ -1121,7 +1122,7 @@ func TestCompileIfBranches(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	// if without else (just consequent)
 	sv2 := parseSchemeExpr(t, env, `(if #f 1)`)
@@ -1236,7 +1237,7 @@ func TestCompileProcedureCallTail(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileProcedureCallNonTail tests non-tail call compilation
@@ -1252,7 +1253,7 @@ func TestCompileProcedureCallNonTail(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCompileBeginSequence tests begin with multiple expressions
@@ -1267,7 +1268,7 @@ func TestCompileBeginSequence(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCompileIfNoAlternate tests if without else
@@ -1283,7 +1284,7 @@ func TestCompileIfNoAlternate(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// If without else, false case - should return void
 	sv = parseSchemeExpr(t, env, `(if #f 42)`)
@@ -1340,7 +1341,7 @@ func TestCompileCondExpandNotFeature(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileCondExpandAndFeature tests cond-expand with and feature
@@ -1356,7 +1357,7 @@ func TestCompileCondExpandAndFeature(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileCondExpandOrFeature tests cond-expand with or feature
@@ -1372,7 +1373,7 @@ func TestCompileCondExpandOrFeature(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileCondExpandLibraryFeature tests cond-expand with library feature
@@ -1388,7 +1389,7 @@ func TestCompileCondExpandLibraryFeature(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCompileSymbolBranches tests various branches of CompileSymbol
@@ -1412,7 +1413,7 @@ func TestCompileSymbolBranches(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileSymbolLocalBinding tests compiling local bindings
@@ -1428,7 +1429,7 @@ func TestCompileSymbolLocalBinding(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // historical but the test remains valid for verifying primitive form compilation.
@@ -1482,7 +1483,7 @@ func TestCompileMultipleForms(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileSelfEvaluating tests compiling self-evaluating values
@@ -1511,7 +1512,7 @@ func TestCompileSelfEvaluating(t *testing.T) {
 			mc := NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expect)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expect)
 		})
 	}
 }
@@ -1529,7 +1530,7 @@ func TestCompileNestedLambda(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestCompileComplexIf tests complex if expressions
@@ -1545,7 +1546,7 @@ func TestCompileComplexIf(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestCompileUnquoteOutsideQuasiquote tests that unquote outside quasiquote returns error
@@ -1677,7 +1678,7 @@ func TestCompileSymbolGlobal(t *testing.T) {
 	mc2 := NewMachineContext(context.Background(), cont2)
 	err = mc2.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc2.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc2.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileSetBangGlobal tests set! on global variable
@@ -1709,7 +1710,7 @@ func TestCompileSetBangGlobal(t *testing.T) {
 	mc3 := NewMachineContext(context.Background(), cont3)
 	err = mc3.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc3.GetValue(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, mc3.GetValue(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 // TestCompileBegin tests begin form
@@ -1724,7 +1725,7 @@ func TestCompileBegin(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCompileLambdaMultiExprBody tests lambda with multiple expressions in body
@@ -1739,7 +1740,7 @@ func TestCompileLambdaMultiExprBody(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCompileCaseLambdaMultiClause tests case-lambda with multiple clauses
@@ -1803,7 +1804,7 @@ func TestCompileIfThenOnly(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileIfFalsePath tests if with false condition
@@ -1818,7 +1819,7 @@ func TestCompileIfFalsePath(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestCompileDefineVarSimple tests define simple variable
@@ -1847,7 +1848,7 @@ func TestCompileLambdaWithMultipleParams(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestCompileLambdaRest tests lambda with rest parameter only
@@ -2159,7 +2160,7 @@ func TestCompileSymbolLocal(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileSymbolNoBinding tests CompileSymbol with unbound symbol
@@ -2187,7 +2188,7 @@ func TestCompilePrimitiveOrProcedureCallWithPair(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileValidatedLambdaVariadic tests variadic lambda compilation

--- a/machine/compile_validated_test.go
+++ b/machine/compile_validated_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/internal/validate"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -93,7 +94,7 @@ func TestCompileValidatedDynamicWind_ReturnValue(t *testing.T) {
 	})
 
 	mc := compileAndRun(t, env, "(dynamic-wind noop ret42 noop)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCompileValidatedDynamicWind_CallOrder verifies that before, thunk, and after
@@ -124,7 +125,7 @@ func TestCompileValidatedDynamicWind_CallOrder(t *testing.T) {
 	mc := compileAndRun(t, env, "(dynamic-wind before-fn thunk-fn after-fn)")
 
 	qt.Assert(t, log, qt.DeepEquals, []string{"before", "thunk", "after"})
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("result"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("result"))
 }
 
 // TestCompileValidatedDynamicWind_WithLambdas verifies dynamic-wind works with
@@ -153,7 +154,7 @@ func TestCompileValidatedDynamicWind_WithLambdas(t *testing.T) {
 			(lambda () (log-after)))`)
 
 	qt.Assert(t, log, qt.DeepEquals, []string{"before", "after"})
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCompileValidatedDynamicWind_Nested verifies correct ordering when
@@ -198,7 +199,7 @@ func TestCompileValidatedDynamicWind_Nested(t *testing.T) {
 		"inner-after",
 		"outer-after",
 	})
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(7))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 // TestCompileValidated_UnknownExprType verifies the default branch in
@@ -310,11 +311,11 @@ func TestCompileValidatedCaseLambda_ZeroArgClause(t *testing.T) {
 
 	// Call with zero args
 	mc := compileAndRun(t, env, "(f)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(0))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(0))
 
 	// Call with one arg
 	mc = compileAndRun(t, env, "(f 10)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 }
 
 // TestCompileValidatedCaseLambda_VariadicClause verifies case-lambda with
@@ -328,13 +329,13 @@ func TestCompileValidatedCaseLambda_VariadicClause(t *testing.T) {
 
 	// Call with one arg (matches first clause)
 	mc := compileAndRun(t, env, "(g 42)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Call with two args (matches second clause, returns y)
 	mc = compileAndRun(t, env, "(g 1 2)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 
 	// Call with three args (matches second clause, returns y)
 	mc = compileAndRun(t, env, "(g 1 2 3)")
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }

--- a/machine/continuation_winding_coverage_test.go
+++ b/machine/continuation_winding_coverage_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -74,11 +75,11 @@ func TestUnwindTo_DirectCall(t *testing.T) {
 	// Verify both after thunks were called
 	mc, err := runSchemeExpr(t, env, "after1-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "after2-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestUnwindTo_PartialUnwind exercises UnwindTo with a commonDepth > 0,
@@ -110,11 +111,11 @@ func TestUnwindTo_PartialUnwind(t *testing.T) {
 	// Only inner should have been called
 	mc, err := runSchemeExpr(t, env, "inner-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "outer-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.FalseValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.FalseValue)
 }
 
 // TestUnwindTo_NilAfterThunks verifies that frames with nil After closures
@@ -145,7 +146,7 @@ func TestUnwindTo_NilAfterThunks(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "tracked")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestUnwindTo_DynamicWindWithPromptAbort exercises UnwindTo via Scheme:
@@ -168,7 +169,7 @@ func TestUnwindTo_DynamicWindWithPromptAbort(t *testing.T) {
 			(lambda (v) v))`,
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// The after thunk should have run during unwinding
 	mc, err = runSchemeExpr(t, env, "(memq 'after wind-log)")
@@ -200,7 +201,7 @@ func TestUnwindTo_NestedDynamicWindWithPromptAbort(t *testing.T) {
 			(lambda (v) v))`,
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 
 	// Both after thunks should have run (inner first, then outer)
 	mc, err = runSchemeExpr(t, env, "wind-log2")
@@ -212,7 +213,7 @@ func TestUnwindTo_NestedDynamicWindWithPromptAbort(t *testing.T) {
 		values.NewSymbol("inner-before"),
 		values.NewSymbol("outer-before"),
 	)
-	c.Assert(mc.GetValue(), values.SchemeEquals, expected)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // --- RestoreWithWinding ---
@@ -244,7 +245,7 @@ func TestRestoreWithWinding_DirectCall(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "before-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestRestoreWithWinding_UnwindAndRewind exercises RestoreWithWinding with
@@ -280,11 +281,11 @@ func TestRestoreWithWinding_UnwindAndRewind(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "src-after-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "tgt-before-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // --- FindPrompt ---
@@ -429,7 +430,7 @@ func TestRewindTo_DirectCall(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	// b2 was cons'd last (innermost, called second), so it's car
 	expected := values.List(values.NewSymbol("b2"), values.NewSymbol("b1"))
-	c.Assert(mc.GetValue(), values.SchemeEquals, expected)
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestRewindTo_NilBeforeThunks verifies that frames with nil Before
@@ -474,7 +475,7 @@ func TestCallCC_DynamicWindReentry(t *testing.T) {
 			(lambda () (set! reentry-log (cons 'after reentry-log))))`,
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewSymbol("result"))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("result"))
 
 	// Log should be (after thunk before) from first pass
 	_, err = runSchemeExpr(t, env, "reentry-log")
@@ -483,7 +484,7 @@ func TestCallCC_DynamicWindReentry(t *testing.T) {
 	// Now re-enter the continuation
 	mc, err = runSchemeExpr(t, env, "(k 'ignored)")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewSymbol("result"))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("result"))
 
 	// After re-entry, log should have additional before/thunk/after entries
 	mc, err = runSchemeExpr(t, env, "(memq 'before reentry-log)")
@@ -526,7 +527,7 @@ func TestComposableContinuation_DynamicWind(t *testing.T) {
 	var mc *machine.MachineContext
 	mc, err = runSchemeExpr(t, env, "(cc-k 10)")
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 
 	// Verify winding happened
 	mc, err = runSchemeExpr(t, env, "(memq 'before cc-log)")
@@ -735,7 +736,7 @@ func TestRunWithEscapeHandling_PromptAbortNoHandler(t *testing.T) {
 			(lambda (v) v))`,
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestRunWithEscapeHandling_PromptAbortWithMultipleValues exercises abort
@@ -753,7 +754,7 @@ func TestRunWithEscapeHandling_PromptAbortWithMultipleValues(t *testing.T) {
 			(lambda (a b) (+ a b)))`,
 	)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 // TestRunWithEscapeHandling_NormalCompletionWithWindingStack exercises the
@@ -781,7 +782,7 @@ func TestRunWithEscapeHandling_NormalCompletionWithWindingStack(t *testing.T) {
 
 	result, err := runSchemeExpr(t, env, "unwind-called")
 	c.Assert(err, qt.IsNil)
-	c.Assert(result.GetValue(), values.SchemeEquals, values.TrueValue)
+	c.Assert(result.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestRunWithEscapeHandling_OtherError exercises the fallthrough path

--- a/machine/coverage_fullruntime_test.go
+++ b/machine/coverage_fullruntime_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -148,7 +149,7 @@ func TestCaseLambdaWithArithmetic(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 
 	// Call with 3 args
 	sv = parseSchemeExprExt(t, env, "(cl 1 2 3)")
@@ -157,7 +158,7 @@ func TestCaseLambdaWithArithmetic(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(6))
 }
 
 // TestDefineSyntaxWithMacroUsage tests define-syntax and macro expansion
@@ -182,7 +183,7 @@ func TestDefineSyntaxWithMacroUsage(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 // TestMapWithLambda tests map with lambda (exercises closure + multiple calls)
@@ -208,7 +209,7 @@ func TestApplyWithPrimitives(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(15))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(15))
 }
 
 // TestLetBindings tests let, let*, letrec forms
@@ -233,7 +234,7 @@ func TestLetBindings(t *testing.T) {
 			mc := machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(tc.expected))
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(tc.expected))
 		})
 	}
 }
@@ -261,7 +262,7 @@ func TestCondArrow(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestCondArrowFalseTest tests cond with => when test is false
@@ -275,7 +276,7 @@ func TestCondArrowFalseTest(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewSymbol("not-found"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("not-found"))
 }
 
 // TestCondArrowWithLambda tests cond with => using a lambda
@@ -289,7 +290,7 @@ func TestCondArrowWithLambda(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestCaseArrow tests case with => clause (R7RS §4.2.1)
@@ -305,7 +306,7 @@ func TestCaseArrow(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	// (case 6 ...) should match (1 4 6 8 9) and return (composite 6)
 	expected := values.List(values.NewSymbol("composite"), values.NewInteger(6))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestQuasiquoteComplexList tests compileQuasiquoteComplexList path
@@ -368,7 +369,7 @@ func TestCompileSymbolWithScopesFullEnv(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestQuasiquoteDirectUnquote tests direct unquote at top level of quasiquote
@@ -382,7 +383,7 @@ func TestQuasiquoteDirectUnquote(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestRecursiveFunction tests recursive function with full runtime
@@ -407,7 +408,7 @@ func TestRecursiveFunction(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(120))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(120))
 }
 
 // TestLetrecBindings tests letrec for mutual recursion
@@ -425,7 +426,7 @@ func TestLetrecBindings(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestForEachWithSideEffects tests for-each primitive
@@ -441,7 +442,7 @@ func TestForEachWithSideEffects(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(15))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(15))
 }
 
 // TestCallWithValues tests call-with-values
@@ -454,7 +455,7 @@ func TestCallWithValues(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(6))
 }
 
 // TestVectorOperations tests vector primitives
@@ -467,7 +468,7 @@ func TestVectorOperations(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestStringOperations tests string primitives
@@ -480,7 +481,7 @@ func TestStringOperations(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("hello world"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("hello world"))
 }
 
 // TestHigherOrderClosure tests closures captured in higher-order functions
@@ -510,7 +511,7 @@ func TestHigherOrderClosure(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(15))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(15))
 }
 
 // TestNestedConditions tests nested if/cond expressions
@@ -552,7 +553,7 @@ func TestAndOrForms(t *testing.T) {
 			mc := machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -606,7 +607,7 @@ func TestComplexLambdaWithDefine(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 // TestNestedLambdaClosure tests nested closures
@@ -620,7 +621,7 @@ func TestNestedLambdaClosure(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestQuasiquoteWithDeepNesting tests deeply nested quasiquote structures
@@ -656,7 +657,7 @@ func TestVariadicLambda(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(15))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(15))
 }
 
 // TestListOperations tests various list operations
@@ -686,7 +687,7 @@ func TestListOperations(t *testing.T) {
 			mc := machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -721,7 +722,7 @@ func TestNumericOperations(t *testing.T) {
 			mc := machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -942,7 +943,7 @@ func TestCompileSymbolVariants(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(100))
 
 	// Test local symbol resolution
 	sv = parseSchemeExprExt(t, env, "(let ((local-var 50)) local-var)")
@@ -951,7 +952,7 @@ func TestCompileSymbolVariants(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(50))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(50))
 }
 
 // TestCondExpandFeature tests cond-expand with features
@@ -997,7 +998,7 @@ func TestMutualRecursion(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestSymbolIdentityAcrossCompilationBoundaries tests R7RS 6.5 symbol identity.
@@ -1089,7 +1090,7 @@ func TestQuasiquoteImproperList(t *testing.T) {
 			mc := machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1115,7 +1116,7 @@ func TestCompileSyntaxCase_SimpleMatch(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 }
 
 // TestCompileSyntaxCase_PatternVars tests syntax-case with pattern variables in body.
@@ -1140,7 +1141,7 @@ func TestCompileSyntaxCase_PatternVars(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 	expected := values.List(values.NewInteger(2), values.NewInteger(1))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCompileSyntaxCase_MultiClause tests syntax-case with multiple clauses.
@@ -1166,7 +1167,7 @@ func TestCompileSyntaxCase_MultiClause(t *testing.T) {
 	mc = machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(7))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 // TestCompileSyntaxCase_NoMatch tests syntax-case when no clause matches.
@@ -1240,7 +1241,7 @@ func TestCompileQuasisyntax_RoundTrip(t *testing.T) {
 			mc = machine.NewMachineContext(context.Background(), cont)
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1255,7 +1256,7 @@ func TestCompileEvalWhen_ExpandPhase(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCompileEvalWhen_MultiPhase tests eval-when with both expand and run phases.
@@ -1268,7 +1269,7 @@ func TestCompileEvalWhen_MultiPhase(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 // TestCompileEvalWhen_MultiBody tests eval-when with a body expression that uses begin.
@@ -1281,7 +1282,7 @@ func TestCompileEvalWhen_MultiBody(t *testing.T) {
 	mc := machine.NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(7))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 // TestCompileBeginForSyntax_Success tests begin-for-syntax with expressions.
@@ -1455,7 +1456,7 @@ func TestCoverageSyntaxRulesWithEllipsis(t *testing.T) {
 			}
 			mc, err := runSchemeExpr(t, testEnv, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 
@@ -1473,11 +1474,11 @@ func TestCoverageSyntaxRulesWithEllipsis(t *testing.T) {
 
 		mc, err := runSchemeExpr(t, testEnv, "(my-cond (#t 42))")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 		mc, err = runSchemeExpr(t, testEnv, "(my-cond (#f 1) (else 99))")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 	})
 }
 
@@ -1539,7 +1540,7 @@ func TestCoverageLetSyntax(t *testing.T) {
 			testEnv := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, testEnv, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1614,7 +1615,7 @@ func TestCoverageDelimitedContinuations(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1635,7 +1636,7 @@ func TestCoverageDynamicWindWithCallCC(t *testing.T) {
 						(lambda () (set! wind-log (cons 'after wind-log))))))`,
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 		// Verify the after thunk ran
 		mc, err = runSchemeExpr(t, env, "(memq 'after wind-log)")
@@ -1654,13 +1655,13 @@ func TestCoverageDynamicWindWithCallCC(t *testing.T) {
 				(lambda () (set! result (cons 'out result))))`,
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 		mc, err = runSchemeExpr(t, testEnv, "result")
 		qt.Assert(t, err, qt.IsNil)
 		// result should be (out body in) - reverse order of cons
 		expected := values.List(values.NewSymbol("out"), values.NewSymbol("body"), values.NewSymbol("in"))
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 	})
 }
 
@@ -1722,7 +1723,7 @@ func TestCoverageParameterObjects(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExprs(t, env, tc.codes...)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1763,7 +1764,7 @@ func TestCoverageWithSyntax(t *testing.T) {
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
 			if tc.expected != nil {
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 			}
 		})
 	}
@@ -1778,7 +1779,7 @@ func TestCoverageWithSyntax(t *testing.T) {
 
 		mc, err := runSchemeExpr(t, env, "(add-ten 5)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(15))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(15))
 	})
 }
 
@@ -1826,7 +1827,7 @@ func TestCoverageQuasisyntax(t *testing.T) {
 			}
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1869,7 +1870,7 @@ func TestCoverageExceptionHandling(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1905,7 +1906,7 @@ func TestCoverageDoForm(t *testing.T) {
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
 			if tc.expected != nil {
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 			}
 		})
 	}
@@ -1947,7 +1948,7 @@ func TestCoverageCondExpandLibrary(t *testing.T) {
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
 			if tc.expected != nil {
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 			}
 		})
 	}
@@ -1965,7 +1966,7 @@ func TestCoverageTailCallOptimization(t *testing.T) {
 			"(loop 1000 0)",
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(500500))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(500500))
 	})
 
 	t.Run("mutual tail recursion", func(t *testing.T) {
@@ -1975,7 +1976,7 @@ func TestCoverageTailCallOptimization(t *testing.T) {
 				  (my-odd? (lambda (n) (if (= n 0) #f (my-even? (- n 1))))))
 				(my-even? 100))`)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 	})
 }
 
@@ -2009,7 +2010,7 @@ func TestCoverageMultipleValues(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2050,7 +2051,7 @@ func TestCoverageNamedLet(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2083,7 +2084,7 @@ func TestCoverageLetValues(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2119,7 +2120,7 @@ func TestCoverageCallCCBasic(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2130,15 +2131,15 @@ func TestCoveragePromptTagPredicate(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(continuation-prompt-tag? (default-continuation-prompt-tag))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "(continuation-prompt-tag? (make-continuation-prompt-tag 'test))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "(continuation-prompt-tag? 42)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.FalseValue)
 }
 
 // TestCoverageBoxOperations tests box operations (mutable cells).
@@ -2150,18 +2151,18 @@ func TestCoverageBoxOperations(t *testing.T) {
 		"(unbox b)",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 
 	mc, err = runSchemeExprs(t, env,
 		"(set-box! b 20)",
 		"(unbox b)",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(20))
 
 	mc, err = runSchemeExpr(t, env, "(box? b)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestCoverageHashtableOperations tests hashtable operations.
@@ -2175,11 +2176,11 @@ func TestCoverageHashtableOperations(t *testing.T) {
 		"(hashtable-ref ht 'a #f)",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	mc, err = runSchemeExpr(t, env, "(hashtable-size ht)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestCoverageSyntaxCaseWithFender tests syntax-case with fender (guard) expressions.
@@ -2197,7 +2198,7 @@ func TestCoverageSyntaxCaseWithFender(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(checked-add 3 4)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(7))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 // TestCoverageInclude tests include and include-ci forms.
@@ -2238,7 +2239,7 @@ func TestCoverageComplexMacroPatterns(t *testing.T) {
 			"(list x y)",
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 			values.List(values.NewInteger(2), values.NewInteger(1)))
 	})
 
@@ -2255,7 +2256,7 @@ func TestCoverageComplexMacroPatterns(t *testing.T) {
 			"counter",
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(5))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(5))
 	})
 }
 
@@ -2324,15 +2325,15 @@ func TestCoverageRecordType(t *testing.T) {
 		"(point? p)",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 
 	mc, err = runSchemeExpr(t, env, "(point-x p)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 
 	mc, err = runSchemeExpr(t, env, "(point-y p)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(4))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(4))
 }
 
 // TestCoveragePromises tests delay, force, and delay-force (bootstrap macros).
@@ -2367,7 +2368,7 @@ func TestCoveragePromises(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExprs(t, env, tc.codes...)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2385,7 +2386,7 @@ func TestCoverageDynamicWindFull(t *testing.T) {
 				(lambda () (set! log (cons 'after log))))`,
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 	})
 
 	t.Run("dynamic-wind with callcc escape", func(t *testing.T) {
@@ -2435,7 +2436,7 @@ func TestCoverageCallCCReentry(t *testing.T) {
 					(k 42)
 					99))`)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 	})
 }
 
@@ -2489,7 +2490,7 @@ func TestCoverageCondExpand(t *testing.T) {
 			env := newFullRuntimeEnv(t)
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -2533,7 +2534,7 @@ func TestCoverageQuasiquoteEdgeCases(t *testing.T) {
 			mc, err := runSchemeExpr(t, env, tc.code)
 			qt.Assert(t, err, qt.IsNil)
 			if tc.expected != nil {
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.expected)
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.expected)
 			}
 		})
 	}
@@ -2571,11 +2572,11 @@ func TestCoverageSyntaxCaseFender(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(check-positive 5)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, env.TopLevelEnv().InternSymbol(values.NewSymbol("positive")))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, env.TopLevelEnv().InternSymbol(values.NewSymbol("positive")))
 
 	mc, err = runSchemeExpr(t, env, "(check-positive -3)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, env.TopLevelEnv().InternSymbol(values.NewSymbol("non-positive")))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, env.TopLevelEnv().InternSymbol(values.NewSymbol("non-positive")))
 }
 
 // TestCoverageParameterObjectsExtended tests parameterize with nested scoping.
@@ -2590,7 +2591,7 @@ func TestCoverageParameterObjectsExtended(t *testing.T) {
 				(my-param)))`,
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCoverageSyntaxCaseEllipsis tests syntax-case with ellipsis patterns.
@@ -2606,7 +2607,7 @@ func TestCoverageSyntaxCaseEllipsis(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(my-list 1 2 3)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 		values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)))
 }
 
@@ -2624,7 +2625,7 @@ func TestCoverageQuasisyntaxRuntime(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(wrap-in-list 42)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 		values.List(values.NewInteger(42)))
 }
 
@@ -2636,7 +2637,7 @@ func TestCoverageLetrecStar(t *testing.T) {
 	mc, err := runSchemeExpr(t, env,
 		`(letrec* ((x 1) (y (+ x 1))) (+ x y))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCoverageWhenUnless tests when and unless forms.
@@ -2645,11 +2646,11 @@ func TestCoverageWhenUnless(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "(when #t 42)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	mc, err = runSchemeExpr(t, env, "(unless #f 99)")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCoverageRaiseAndGuard tests raise with guard handler.
@@ -2682,7 +2683,7 @@ func TestCoverageSyntaxRulesFreeIdentifiers(t *testing.T) {
 	)
 	qt.Assert(t, err, qt.IsNil)
 	// Due to hygiene, (reveal) should reference the outer secret=42
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCoverageQuasiquoteImproper tests quasiquote with improper list.
@@ -2711,7 +2712,7 @@ func TestCoverageQuasiquoteImproperWithUnquote(t *testing.T) {
 			"`(a ,x . c)",
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 			values.NewCons(
 				values.NewSymbol("a"),
 				values.NewCons(values.NewInteger(10), values.NewSymbol("c")),
@@ -2726,7 +2727,7 @@ func TestCoverageQuasiquoteImproperWithUnquote(t *testing.T) {
 			"`(,x ,y . z)",
 		)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+		qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 			values.NewCons(
 				values.NewInteger(1),
 				values.NewCons(values.NewInteger(2), values.NewSymbol("z")),
@@ -2744,7 +2745,7 @@ func TestCoverageQuasiquoteSplicingInList(t *testing.T) {
 		"`(1 ,@xs 4)",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals,
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals,
 		values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3), values.NewInteger(4)))
 }
 
@@ -2784,7 +2785,7 @@ func TestCoverageDefineValues(t *testing.T) {
 			(define b 2)
 			(+ a b)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCoverageInternalDefineSyntax tests internal define-syntax.
@@ -2799,7 +2800,7 @@ func TestCoverageInternalDefineSyntax(t *testing.T) {
 					((double x) (+ x x))))
 			(double 21))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCoverageTailPosition tests various tail position scenarios.
@@ -2811,19 +2812,19 @@ func TestCoverageTailPosition(t *testing.T) {
 	mc, err := runSchemeExpr(t, env,
 		`((lambda (x) (if (> x 0) x (- x))) 5)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(5))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(5))
 
 	// begin in tail position
 	mc, err = runSchemeExpr(t, env,
 		`((lambda () (begin 1 2 3)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 
 	// let in tail position
 	mc, err = runSchemeExpr(t, env,
 		`((lambda () (let ((x 10)) (+ x 1))))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 
 	// case-lambda
 	mc, err = runSchemeExpr(t, env,
@@ -2831,7 +2832,7 @@ func TestCoverageTailPosition(t *testing.T) {
 			((x) (+ x 1))
 			((x y) (+ x y))) 10)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(11))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(11))
 }
 
 // TestCoverageDynamicWindReentry tests dynamic-wind with continuation re-entry.
@@ -2863,12 +2864,12 @@ func TestCoverageApplyProcedure(t *testing.T) {
 	// Apply with explicit args and rest list
 	mc, err := runSchemeExpr(t, env, "(apply + 1 2 '(3 4))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 
 	// Apply with just a list
 	mc, err = runSchemeExpr(t, env, "(apply + '(1 2 3))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(6))
 
 	// Apply with case-lambda
 	mc, err = runSchemeExpr(t, env,
@@ -2876,7 +2877,7 @@ func TestCoverageApplyProcedure(t *testing.T) {
 			((x) x)
 			((x y) (+ x y))) '(10 20))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 // TestCoverageSetBangTop tests set! at top level.
@@ -2890,7 +2891,7 @@ func TestCoverageSetBangTop(t *testing.T) {
 		"x",
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCoverageNamedLetLoop tests named let with a simple accumulator loop.
@@ -2902,7 +2903,7 @@ func TestCoverageNamedLetLoop(t *testing.T) {
 		`(let loop ((i 0) (acc 0))
 			(if (= i 10) acc (loop (+ i 1) (+ acc i))))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(45))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(45))
 }
 
 // TestCoverageCallCCEscapeThroughDynamicWind tests call/cc capturing inside
@@ -2925,14 +2926,14 @@ func TestCoverageCallCCEscapeThroughDynamicWind(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	// First run: k captured a continuation, result is 1
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	// Invoke the captured continuation from outside
 	mc, err = runSchemeExpr(t, env, `(k 42)`)
 	// k invokes the continuation, which escapes and gets caught by RunWithEscapeHandling
 	// It should trigger before thunk (rewind) and after thunk (unwind)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCoveragePromptAbortHandling tests abort-current-continuation which
@@ -2950,7 +2951,7 @@ func TestCoveragePromptAbortHandling(t *testing.T) {
 			(default-continuation-prompt-tag)
 			(lambda (v) (* v 2)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 // TestCoveragePromptAbortIdentity tests abort with identity handler.
@@ -2968,7 +2969,7 @@ func TestCoveragePromptAbortIdentity(t *testing.T) {
 			(default-continuation-prompt-tag)
 			(lambda (v) v))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 // TestCoverageParameterObjectConverter tests parameter objects with converter.
@@ -2983,14 +2984,14 @@ func TestCoverageParameterObjectConverter(t *testing.T) {
 	)
 	qt.Assert(t, err, qt.IsNil)
 	// 10 passed through converter → 20
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(20))
 
 	// parameterize also goes through converter
 	mc, err = runSchemeExpr(t, env,
 		`(parameterize ((p 5)) (p))`)
 	qt.Assert(t, err, qt.IsNil)
 	// 5 through converter → 10
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 // TestCoverageParameterObjectSet tests parameter set! path.
@@ -3004,7 +3005,7 @@ func TestCoverageParameterObjectSet(t *testing.T) {
 		`(p)`,
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 // TestCoverageSyntaxRulesRecursive tests recursive macros with free identifiers.
@@ -3023,11 +3024,11 @@ func TestCoverageSyntaxRulesRecursive(t *testing.T) {
 		`(my-and 1 2 3)`,
 	)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 
 	mc, err = runSchemeExpr(t, env, `(my-and 1 #f 3)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.FalseValue)
 }
 
 // TestCoverageVectorQuasiquoteSplicing tests quasiquote with unquote-splicing
@@ -3048,7 +3049,7 @@ func TestCoverageVectorQuasiquoteSplicing(t *testing.T) {
 		values.NewInteger(4),
 		values.NewInteger(5),
 	)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageNestedQuasiquoteDepth tests nested quasiquote at depth > 1.
@@ -3065,7 +3066,7 @@ func TestCoverageNestedQuasiquoteDepth(t *testing.T) {
 	// Should be ((a 3) 42)
 	inner := values.NewCons(values.NewSymbol("a"), values.NewCons(values.NewInteger(3), values.EmptyList))
 	expected := values.NewCons(inner, values.NewCons(values.NewInteger(42), values.EmptyList))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageCondExpandFeatures tests cond-expand with various feature identifiers.
@@ -3079,7 +3080,7 @@ func TestCoverageCondExpandFeatures(t *testing.T) {
 			(r7rs 'r7rs-supported)
 			(else 'not-r7rs))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewSymbol("r7rs-supported"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("r7rs-supported"))
 
 	// cond-expand with implementation feature
 	mc, err = runSchemeExpr(t, env,
@@ -3087,7 +3088,7 @@ func TestCoverageCondExpandFeatures(t *testing.T) {
 			(wile 'wile-detected)
 			(else 'unknown))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewSymbol("wile-detected"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewSymbol("wile-detected"))
 }
 
 // TestCoverageEvalWhen tests eval-when form.
@@ -3100,7 +3101,7 @@ func TestCoverageEvalWhen(t *testing.T) {
 		`(eval-when (eval load)
 			(+ 1 2))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestCoverageGuardWithCond tests guard with multiple clauses.
@@ -3114,7 +3115,7 @@ func TestCoverageGuardWithCond(t *testing.T) {
 				 (string-append "caught: " (error-object-message exn))))
 			(error "test" "details"))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewString("caught: test"))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewString("caught: test"))
 }
 
 // TestCoverageCaseLambdaDispatch tests case-lambda with multiple clauses.
@@ -3137,7 +3138,7 @@ func TestCoverageCaseLambdaDispatch(t *testing.T) {
 			values.NewCons(values.NewInteger(3),
 				values.NewCons(values.NewInteger(10),
 					values.EmptyList))))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageDoLoop tests do loop form.
@@ -3150,7 +3151,7 @@ func TestCoverageDoLoop(t *testing.T) {
 			  (sum 0 (+ sum i)))
 			 ((= i 5) sum))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 // TestCoverageLetValuesMultiBinding tests let-values with multiple bindings.
@@ -3163,7 +3164,7 @@ func TestCoverageLetValuesMultiBinding(t *testing.T) {
 					  ((c) (values 3)))
 			(+ a b c))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(6))
 }
 
 // TestCoverageSyntaxCaseWithTemplate tests syntax-case with (syntax ...) template.
@@ -3188,7 +3189,7 @@ func TestCoverageSyntaxCaseWithTemplate(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	expected := values.NewCons(values.NewInteger(2),
 		values.NewCons(values.NewInteger(1), values.EmptyList))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageDynamicWindNested tests deeply nested dynamic-wind.
@@ -3214,7 +3215,7 @@ func TestCoverageDynamicWindNested(t *testing.T) {
 		values.NewCons(values.NewSymbol("b-in"),
 			values.NewCons(values.NewSymbol("b-out"),
 				values.NewCons(values.NewSymbol("a-out"), values.EmptyList))))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageExceptionReRaise tests exception re-raising with guard.
@@ -3233,7 +3234,7 @@ func TestCoverageExceptionReRaise(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	// Inner guard catches 1 (< 5), re-raises 11
 	// Outer guard catches 11 (number?), returns 111
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(111))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(111))
 }
 
 // TestCoverageDefineRecordType tests define-record-type.
@@ -3254,7 +3255,7 @@ func TestCoverageDefineRecordType(t *testing.T) {
 	expected := values.NewCons(values.TrueValue,
 		values.NewCons(values.NewInteger(3),
 			values.NewCons(values.NewInteger(4), values.EmptyList)))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestCoverageSyntaxRulesCustomEllipsis tests syntax-rules with custom ellipsis.
@@ -3272,7 +3273,7 @@ func TestCoverageSyntaxRulesCustomEllipsis(t *testing.T) {
 	expected := values.NewCons(values.NewInteger(1),
 		values.NewCons(values.NewInteger(2),
 			values.NewCons(values.NewInteger(3), values.EmptyList)))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 // TestEmptyListExpression verifies that a bare () in expression position
@@ -3283,5 +3284,5 @@ func TestEmptyListExpression(t *testing.T) {
 
 	mc, err := runSchemeExpr(t, env, "()")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.EmptyList)
 }

--- a/machine/expander_time_continuation_test.go
+++ b/machine/expander_time_continuation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -123,7 +124,7 @@ func TestExpandExpression_List(t *testing.T) {
 	cctx := context.Background()
 	result, err := cont.ExpandExpression(cctx, lst0)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result.UnwrapAll(), values.SchemeEquals, lst1.UnwrapAll())
+	qt.Assert(t, result.UnwrapAll(), valuestest.SchemeEquals, lst1.UnwrapAll())
 }
 
 func TestExpandCaseLambdaForm_Basic(t *testing.T) {
@@ -153,7 +154,7 @@ func TestExpandCaseLambdaForm_Basic(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	resultSym, ok := resultPair.Car().(*syntax.SyntaxSymbol)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, resultSym.Unwrap(), values.SchemeEquals, values.NewSymbol("case-lambda"))
+	qt.Assert(t, resultSym.Unwrap(), valuestest.SchemeEquals, values.NewSymbol("case-lambda"))
 
 	// Count clauses
 	clauseCount := 0
@@ -182,7 +183,7 @@ func TestExpandCaseLambdaForm_Empty(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	resultSym, ok := resultPair.Car().(*syntax.SyntaxSymbol)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, resultSym.Unwrap(), values.SchemeEquals, values.NewSymbol("case-lambda"))
+	qt.Assert(t, resultSym.Unwrap(), valuestest.SchemeEquals, values.NewSymbol("case-lambda"))
 }
 
 // Tests moved from coverage_additional_test.go
@@ -236,7 +237,7 @@ func TestAddScopeToSyntax(t *testing.T) {
 
 	// Test with non-syntax value
 	result = addScopeToSyntax(values.NewInteger(42), scope)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestAddScopeToSyntaxSkipFreeIds tests the addScopeToSyntaxSkipFreeIds function
@@ -285,7 +286,7 @@ func TestAddScopeToSyntaxSkipFreeIds(t *testing.T) {
 
 	// Test with non-syntax value
 	result = addScopeToSyntaxSkipFreeIds(values.NewInteger(42), scope, freeIds)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestAddScopeToPairSkipFreeIds tests the addScopeToPairSkipFreeIds function
@@ -352,7 +353,7 @@ func TestExpandSetForm(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestExpandCaseLambdaForm tests case-lambda expansion
@@ -380,7 +381,7 @@ func TestExpandCaseLambdaForm(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(0))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(0))
 
 	// Call with 1 arg
 	sv = parseSchemeExpr(t, env, "(cl 42)")
@@ -389,5 +390,5 @@ func TestExpandCaseLambdaForm(t *testing.T) {
 	mc = NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }

--- a/machine/features_test.go
+++ b/machine/features_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -210,7 +211,7 @@ func TestCondExpandWithElse(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestCondExpandR7RS tests cond-expand with r7rs feature
@@ -226,7 +227,7 @@ func TestCondExpandR7RS(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 // TestCondExpandAnd tests cond-expand with and requirement
@@ -241,7 +242,7 @@ func TestCondExpandAnd(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(200))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(200))
 }
 
 // TestCondExpandOr tests cond-expand with or requirement
@@ -256,7 +257,7 @@ func TestCondExpandOr(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(300))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(300))
 }
 
 // TestCondExpandNot tests cond-expand with not requirement
@@ -271,7 +272,7 @@ func TestCondExpandNot(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(400))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(400))
 }
 
 // TestFeatureRequirementIsSatisfied tests various feature requirements

--- a/machine/hygiene_test.go
+++ b/machine/hygiene_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -160,7 +161,7 @@ func TestLetMacroExpansion(t *testing.T) {
 	t.Logf("Expanded: %s", expanded.SchemeString())
 
 	expectedForm := parseString(t, env, `(list 1 2 3)`)
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll())
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll())
 }
 
 // TestLetMacroSimple tests a simplified let macro without body ellipsis
@@ -200,7 +201,7 @@ func TestLetMacroSimple(t *testing.T) {
 	t.Logf("Expanded: %s", expanded.SchemeString())
 
 	expectedForm := parseString(t, env, `((lambda (x) x) 1)`)
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll())
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll())
 }
 
 // TestMultipleElementsWithTrailingEllipsis tests patterns like (bindSymbolWithScopes a b ...)
@@ -237,7 +238,7 @@ func TestMultipleElementsWithTrailingEllipsis(t *testing.T) {
 	t.Logf("Expanded: %s", expanded.SchemeString())
 
 	expectedForm := parseString(t, env, `(begin x)`)
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll())
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll())
 
 	// Test with multiple expressions: (begin-with-first x y z) -> (begin x y z)
 	testForm2 := parseString(t, env, `(begin-with-first x y z)`)
@@ -249,7 +250,7 @@ func TestMultipleElementsWithTrailingEllipsis(t *testing.T) {
 	t.Logf("Expanded2: %s", expanded2.SchemeString())
 
 	expectedForm2 := parseString(t, env, `(begin x y z)`)
-	qt.Assert(t, expanded2.UnwrapAll(), values.SchemeEquals, expectedForm2.UnwrapAll())
+	qt.Assert(t, expanded2.UnwrapAll(), valuestest.SchemeEquals, expectedForm2.UnwrapAll())
 }
 
 // TestLetMacroFull tests the full R7RS let macro with multiple body expressions
@@ -293,7 +294,7 @@ func TestLetMacroFull(t *testing.T) {
 	// With the (begin body ...) wrapper, the expansion is:
 	// ((lambda (x) (begin x)) 1)
 	expectedForm := parseString(t, env, `((lambda (x) (begin x)) 1)`)
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll())
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll())
 }
 
 func TestScopeCreation(t *testing.T) {
@@ -362,7 +363,7 @@ func TestScopeCreation(t *testing.T) {
 	// Check semantic equality by comparing unwrapped values (ignoring syntax metadata)
 	// The expected form is (quote expanded)
 	expandedForm := parseString(t, env, "'expanded")
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expandedForm.UnwrapAll())
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expandedForm.UnwrapAll())
 
 	// Verify the expansion is structurally correct
 	// Note: Free identifiers (like 'quote' and 'expanded') do NOT get intro scope
@@ -554,7 +555,7 @@ func TestAuxiliarySyntaxShadowing(t *testing.T) {
 
 			// Parse expected form and compare
 			expectedForm := parseString(t, env, tt.expected)
-			qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll(),
+			qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll(),
 				qt.Commentf("expanded: %s, expected: %s", expanded.SchemeString(), expectedForm.SchemeString()))
 		})
 	}
@@ -627,7 +628,7 @@ func TestBoundIdentifierHygieneInNestedSyntaxRules(t *testing.T) {
 	// The expected result is (begin (quote bound-identifier=?))
 	// The outer begin comes from let-syntax body wrapping
 	expectedForm := parseString(t, env, `(begin (quote bound-identifier=?))`)
-	qt.Assert(t, expanded.UnwrapAll(), values.SchemeEquals, expectedForm.UnwrapAll(),
+	qt.Assert(t, expanded.UnwrapAll(), valuestest.SchemeEquals, expectedForm.UnwrapAll(),
 		qt.Commentf("expected (begin (quote bound-identifier=?)), got: %s", expanded.SchemeString()))
 }
 

--- a/machine/let_shadow_macro_test.go
+++ b/machine/let_shadow_macro_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -138,7 +139,7 @@ func TestLetShadowsMacro(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCodeForShadowTest(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.want)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -186,7 +187,7 @@ func TestHygienePreservedWithShadowing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCodeForShadowTest(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.want)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/machine/library_scheme_test.go
+++ b/machine/library_scheme_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -213,19 +214,19 @@ func TestSchemeLibraryImportsWithUsage(t *testing.T) {
 	sv = parseSchemeExpr(t, env, "(car '(1 2 3))")
 	result, err := compileAndRun(t, env, sv)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(1))
 
 	// Test (scheme char) - char-upcase
 	sv = parseSchemeExpr(t, env, "(char-upcase #\\a)")
 	result, err = compileAndRun(t, env, sv)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewCharacter('A'))
+	c.Assert(result, valuestest.SchemeEquals, values.NewCharacter('A'))
 
 	// Test (scheme inexact) - exp
 	sv = parseSchemeExpr(t, env, "(exp 0)")
 	result, err = compileAndRun(t, env, sv)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewFloat(1.0))
+	c.Assert(result, valuestest.SchemeEquals, values.NewFloat(1.0))
 }
 
 // TestLibraryInternalMacroHygiene tests that macros defined in a library can
@@ -297,7 +298,7 @@ func TestLibraryInternalMacroHygiene(t *testing.T) {
 	sv = parseSchemeExpr(t, env, useCode)
 	result, err := compileAndRun(t, env, sv)
 	c.Assert(err, qt.IsNil, qt.Commentf("macro using non-exported helper should work"))
-	c.Assert(result, values.SchemeEquals, values.NewInteger(6))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(6))
 }
 
 // TestIndividualSchemeLibraries tests each scheme library can be imported individually

--- a/machine/library_test.go
+++ b/machine/library_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	"github.com/aalpar/wile/internal/bootstrap"
 
@@ -514,14 +515,14 @@ func TestCopyLibraryBindingsToEnv(t *testing.T) {
 	fooTarget := targetEnv.InternSymbol(values.NewSymbol("bindSymbolWithScopes"))
 	fooBinding := targetEnv.GetBinding(fooTarget)
 	c.Assert(fooBinding, qt.IsNotNil)
-	c.Assert(fooBinding.Value(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(fooBinding.Value(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Verify syntax binding was copied
 	barTarget := targetEnv.InternSymbol(values.NewSymbol("bar"))
 	barBinding := targetEnv.Expand().GetBinding(barTarget)
 	c.Assert(barBinding, qt.IsNotNil)
 	c.Assert(barBinding.BindingType(), qt.Equals, environment.BindingTypeSyntax)
-	c.Assert(barBinding.Value(), values.SchemeEquals, mockMacro)
+	c.Assert(barBinding.Value(), valuestest.SchemeEquals, mockMacro)
 }
 
 func TestCopyLibraryBindingsToEnv_WithRename(t *testing.T) {
@@ -554,7 +555,7 @@ func TestCopyLibraryBindingsToEnv_WithRename(t *testing.T) {
 	myFooSym := targetEnv.InternSymbol(values.NewSymbol("my-bindSymbolWithScopes"))
 	binding := targetEnv.GetBinding(myFooSym)
 	c.Assert(binding, qt.IsNotNil)
-	c.Assert(binding.Value(), values.SchemeEquals, values.NewInteger(99))
+	c.Assert(binding.Value(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 func TestCopyLibraryBindingsToEnv_MissingBinding(t *testing.T) {
@@ -706,14 +707,14 @@ func TestCopyLibraryBindingsToEnv_CompilePhase(t *testing.T) {
 	elseTarget := targetEnv.InternSymbol(values.NewSymbol("else"))
 	runtimeBinding := targetEnv.GetBinding(elseTarget)
 	c.Assert(runtimeBinding, qt.IsNotNil, qt.Commentf("else should be in runtime phase"))
-	c.Assert(runtimeBinding.Value(), values.SchemeEquals, mockValue)
+	c.Assert(runtimeBinding.Value(), valuestest.SchemeEquals, mockValue)
 
 	// Verify binding is also present in compile phase (phase 2)
 	targetCompileEnv := targetEnv.AtPhase(2)
 	elseCompileSym := targetCompileEnv.InternSymbol(values.NewSymbol("else"))
 	compileBinding := targetCompileEnv.GetBinding(elseCompileSym)
 	c.Assert(compileBinding, qt.IsNotNil, qt.Commentf("else should be propagated to compile phase"))
-	c.Assert(compileBinding.Value(), values.SchemeEquals, mockValue)
+	c.Assert(compileBinding.Value(), valuestest.SchemeEquals, mockValue)
 }
 
 // TestLibraryForwardReferences tests that library bodies support forward references

--- a/machine/machine_context_test.go
+++ b/machine/machine_context_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -55,7 +56,7 @@ func TestNewMachineContext(t *testing.T) {
 	qt.Assert(t, mc.cont, qt.Equals, parentCont) // cont field should be cont.parent
 	qt.Assert(t, mc.pc, qt.Equals, 5)
 	qt.Assert(t, mc.GetValues().Len(), qt.Equals, 1)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 	qt.Assert(t, mc.evals.Len(), qt.Equals, 2)
 }
 
@@ -111,7 +112,7 @@ func TestMachineContext_PushContinuation_0(t *testing.T) {
 	qt.Assert(t, mc.cont.CallDepth(), qt.Equals, 0)
 	qt.Assert(t, mc.cont, qt.IsNil)
 	qt.Assert(t, mc.PC(), qt.Equals, 0)
-	qt.Assert(t, mc.EnvironmentFrame(), values.SchemeEquals, mc.env)
+	qt.Assert(t, mc.EnvironmentFrame(), valuestest.SchemeEquals, mc.env)
 	qt.Assert(t, mc.Template(), qt.IsNil)
 	qt.Assert(t, mc.GetValues().Len(), qt.Equals, 0)
 	qt.Assert(t, mc.evals.Len(), qt.Equals, 0)
@@ -125,7 +126,7 @@ func TestMachineContext_PushContinuation_1(t *testing.T) {
 	qt.Assert(t, mc.Parent(), qt.IsNotNil)
 	qt.Assert(t, mc.Parent().PC(), qt.Equals, 10)
 	qt.Assert(t, mc.PC(), qt.Equals, 0)
-	qt.Assert(t, mc.EnvironmentFrame(), values.SchemeEquals, mc.env)
+	qt.Assert(t, mc.EnvironmentFrame(), valuestest.SchemeEquals, mc.env)
 	qt.Assert(t, mc.Template(), qt.IsNil)
 	qt.Assert(t, mc.GetValues().Len(), qt.Equals, 0)
 	qt.Assert(t, mc.evals.Len(), qt.Equals, 0)
@@ -141,7 +142,7 @@ func TestMachineContext_PushContinuation_2(t *testing.T) {
 	bottom2 := mc.cont
 	qt.Assert(t, mc.cont, qt.IsNotNil)
 	qt.Assert(t, mc.CallDepth(), qt.Equals, 2)
-	qt.Assert(t, mc.Parent(), values.SchemeEquals, bottom2)
+	qt.Assert(t, mc.Parent(), valuestest.SchemeEquals, bottom2)
 	qt.Assert(t, mc.PC(), qt.Equals, 0)
 	mc.PopContinuation()
 	qt.Assert(t, mc.cont, qt.Equals, bottom1)
@@ -163,17 +164,17 @@ func TestMachineContext_SetValues_GetValues(t *testing.T) {
 	mc.SetValues(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
 	vs := mc.GetValues()
 	qt.Assert(t, vs.Len(), qt.Equals, 3)
-	qt.Assert(t, vs[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, vs[1], values.SchemeEquals, values.NewInteger(2))
-	qt.Assert(t, vs[2], values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, vs[1], valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, vs[2], valuestest.SchemeEquals, values.NewInteger(3))
 
 	// GetValue returns first value
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	// Test empty values
 	mc.SetValues()
 	qt.Assert(t, mc.GetValues().Len(), qt.Equals, 0)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.Void)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.Void)
 }
 
 func TestMachineContext_CurrentContinuation(t *testing.T) {
@@ -265,8 +266,8 @@ func TestMachineContext_Apply_FixedArity(t *testing.T) {
 	// Check bindings were set in the NEW call environment (not the closure's env)
 	// Apply now creates a fresh environment for each call to support recursion
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, bnds[1].Value(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, bnds[1].Value(), valuestest.SchemeEquals, values.NewInteger(20))
 
 	// Check context was updated
 	qt.Assert(t, mc.template, qt.Equals, tpl)
@@ -306,11 +307,11 @@ func TestMachineContext_Apply_Variadic(t *testing.T) {
 
 	// Check bindings in the NEW call environment (not the closure's env)
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, bnds[1].Value(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, bnds[1].Value(), valuestest.SchemeEquals, values.NewInteger(2))
 	// Rest parameter should be a list
 	rest := bnds[2].Value()
-	qt.Assert(t, rest, values.SchemeEquals, values.List(values.NewInteger(3), values.NewInteger(4)))
+	qt.Assert(t, rest, valuestest.SchemeEquals, values.List(values.NewInteger(3), values.NewInteger(4)))
 }
 
 func TestMachineContext_Apply_VariadicTooFewArgs(t *testing.T) {
@@ -426,9 +427,9 @@ func TestMachineContext_Apply_VariadicExactlyRequiredArgs(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, bnds[1].Value(), values.SchemeEquals, values.NewInteger(20))
-	qt.Assert(t, bnds[2].Value(), values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, bnds[1].Value(), valuestest.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, bnds[2].Value(), valuestest.SchemeEquals, values.EmptyList)
 }
 
 func TestMachineContext_Apply_VariadicRestOnly(t *testing.T) {
@@ -446,7 +447,7 @@ func TestMachineContext_Apply_VariadicRestOnly(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.List(
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.List(
 		values.NewInteger(1), values.NewInteger(2), values.NewInteger(3),
 	))
 }
@@ -465,7 +466,7 @@ func TestMachineContext_Apply_VariadicRestOnlyNoArgs(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.EmptyList)
 }
 
 func TestMachineContext_Apply_EnvironmentIsolation(t *testing.T) {
@@ -497,8 +498,8 @@ func TestMachineContext_Apply_EnvironmentIsolation(t *testing.T) {
 	// Modifying one must not affect the other
 	bnds1 := env1.LocalEnvironment().Bindings()
 	bnds2 := env2.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds1[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, bnds2[0].Value(), values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, bnds1[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, bnds2[0].Value(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 func TestMachineContext_Apply_PCResetFromNonZero(t *testing.T) {
@@ -623,8 +624,8 @@ func TestMachineContext_ApplyCaseLambda_VariadicClause(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.template, qt.Equals, tpl2)
 	bnds := mc.env.LocalEnvironment().Bindings()
-	qt.Assert(t, bnds[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, bnds[1].Value(), values.SchemeEquals, values.List(values.NewInteger(20), values.NewInteger(30)))
+	qt.Assert(t, bnds[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, bnds[1].Value(), valuestest.SchemeEquals, values.List(values.NewInteger(20), values.NewInteger(30)))
 }
 
 func TestMachineContext_ApplyCaseLambda_NoMatchErrorSentinel(t *testing.T) {
@@ -732,7 +733,7 @@ func TestExecuteSimpleProcedureCall(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, mc.GetValues(), qt.IsNotNil)
 	qt.Assert(t, mc.GetValues().Len() > 0, qt.IsTrue)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestExecuteVariadicProcedure tests running a variadic procedure
@@ -783,8 +784,8 @@ func TestMachineContextSetValues(t *testing.T) {
 	mc.SetValues(values.NewInteger(1), values.NewInteger(2))
 	vs := mc.GetValues()
 	qt.Assert(t, len(vs), qt.Equals, 2)
-	qt.Assert(t, vs[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, vs[1], values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, vs[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestMachineContextSetValue tests SetValue and GetValue
@@ -801,7 +802,7 @@ func TestMachineContextSetValue(t *testing.T) {
 	// SetValue
 	mc.SetValue(values.NewInteger(42))
 	v := mc.GetValue()
-	qt.Assert(t, v, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestMachineContextApplySimple tests mc.Apply with a simple closure
@@ -817,7 +818,7 @@ func TestMachineContextApplySimple(t *testing.T) {
 	mc := NewMachineContext(context.Background(), cont)
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 // TestMachineContextValueMethods tests MachineContext value get/set
@@ -830,7 +831,7 @@ func TestMachineContextValueMethods(t *testing.T) {
 
 	// Test SetValue and GetValue
 	mc.SetValue(values.NewInteger(42))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Test SetValues and GetValues
 	mc.SetValues(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
@@ -870,8 +871,8 @@ func TestApplyCallable_MachineClosure(t *testing.T) {
 	c.Assert(mc.pc, qt.Equals, 0)
 
 	bnds := mc.env.LocalEnvironment().Bindings()
-	c.Assert(bnds[0].Value(), values.SchemeEquals, values.NewInteger(10))
-	c.Assert(bnds[1].Value(), values.SchemeEquals, values.NewInteger(20))
+	c.Assert(bnds[0].Value(), valuestest.SchemeEquals, values.NewInteger(10))
+	c.Assert(bnds[1].Value(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 func TestApplyCallable_CaseLambdaClosure(t *testing.T) {
@@ -945,8 +946,8 @@ func TestApplyCallable_Parameter(t *testing.T) {
 			err = sub.Run()
 			c.Assert(err, qt.IsNil)
 
-			c.Assert(sub.GetValue(), values.SchemeEquals, tc.wantValue)
-			c.Assert(param.Value(), values.SchemeEquals, tc.wantParam)
+			c.Assert(sub.GetValue(), valuestest.SchemeEquals, tc.wantValue)
+			c.Assert(param.Value(), valuestest.SchemeEquals, tc.wantParam)
 		})
 	}
 }
@@ -982,7 +983,7 @@ func TestApplyCallable_Parameter_WithContinuation(t *testing.T) {
 
 	_, err := mc.ApplyCallable(param)
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestApplyCallable_ComposableContinuation(t *testing.T) {
@@ -1000,7 +1001,7 @@ func TestApplyCallable_ComposableContinuation(t *testing.T) {
 
 	_, err := mc.ApplyCallable(cc, values.NewInteger(7))
 	c.Assert(err, qt.IsNil)
-	c.Assert(mc.GetValue(), values.SchemeEquals, values.NewInteger(7))
+	c.Assert(mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(7))
 }
 
 func TestApplyCallable_ComposableContinuation_WrongArgCount(t *testing.T) {

--- a/machine/machine_continuation_test.go
+++ b/machine/machine_continuation_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -78,8 +79,8 @@ func TestMachineContinuation_PushValues(t *testing.T) {
 
 	cont.PushValues(values.NewInteger(1), values.NewInteger(2))
 	qt.Assert(t, len(cont.multiValues), qt.Equals, 2)
-	qt.Assert(t, cont.multiValues[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, cont.multiValues[1], values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, cont.multiValues[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, cont.multiValues[1], valuestest.SchemeEquals, values.NewInteger(2))
 
 	cont.PushValues(values.NewInteger(3))
 	qt.Assert(t, len(cont.multiValues), qt.Equals, 3)
@@ -97,9 +98,9 @@ func TestMachineContinuation_PushValues_PromoteSingleToMulti(t *testing.T) {
 	cont.PushValues(values.NewInteger(2), values.NewInteger(3))
 
 	qt.Assert(t, len(cont.multiValues), qt.Equals, 3)
-	qt.Assert(t, cont.multiValues[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, cont.multiValues[1], values.SchemeEquals, values.NewInteger(2))
-	qt.Assert(t, cont.multiValues[2], values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, cont.multiValues[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, cont.multiValues[1], valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, cont.multiValues[2], valuestest.SchemeEquals, values.NewInteger(3))
 	qt.Assert(t, cont.singleValue, qt.IsNil)
 }
 
@@ -123,7 +124,7 @@ func TestMachineContinuation_Copy(t *testing.T) {
 	qt.Assert(t, cpy.template, qt.Equals, cont.template)
 	qt.Assert(t, cpy.pc, qt.Equals, cont.pc)
 	// Verify singleValue is copied
-	qt.Assert(t, cpy.singleValue, values.SchemeEquals, cont.singleValue)
+	qt.Assert(t, cpy.singleValue, valuestest.SchemeEquals, cont.singleValue)
 	// Verify evals stack is copied
 	qt.Assert(t, cpy.evals != cont.evals, qt.IsTrue)
 }

--- a/machine/multiple_values_test.go
+++ b/machine/multiple_values_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -30,9 +31,9 @@ func TestMultipleValues_NewMultipleValues(t *testing.T) {
 	)
 
 	qt.Assert(t, mv, qt.HasLen, 3)
-	qt.Assert(t, mv[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, mv[1], values.SchemeEquals, values.NewInteger(2))
-	qt.Assert(t, mv[2], values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, mv[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, mv[1], valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mv[2], valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 func TestMultipleValues_Length(t *testing.T) {
@@ -56,8 +57,8 @@ func TestMultipleValues_Copy(t *testing.T) {
 	cp := mv.Copy()
 
 	qt.Assert(t, cp.Len(), qt.Equals, 2)
-	qt.Assert(t, cp[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, cp[1], values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, cp[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, cp[1], valuestest.SchemeEquals, values.NewInteger(2))
 	// Verify it's a different slice
 	qt.Assert(t, &cp[0] != &mv[0], qt.IsTrue)
 }

--- a/machine/native_template_test.go
+++ b/machine/native_template_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -177,7 +178,7 @@ func TestNativeTemplate_DeduplicateLiteral_EmptyPair(t *testing.T) {
 
 	// Empty list
 	result := tmpl.DeduplicateLiteral(values.EmptyList)
-	qt.Assert(t, result, values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.EmptyList)
 }
 
 func TestNativeTemplate_DeduplicateLiteral_EmptyVector(t *testing.T) {
@@ -330,7 +331,7 @@ func TestNativeTemplateDeduplicateLiteral(t *testing.T) {
 
 	// Test with empty list
 	result = tpl.DeduplicateLiteral(values.EmptyList)
-	qt.Assert(t, result, values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.EmptyList)
 
 	// Test with nil Vector
 	var nilVec *values.Vector

--- a/machine/operation_test.go
+++ b/machine/operation_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -39,7 +40,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, (*mc.evals), qt.HasLen, 1)
-				qt.Assert(t, (*mc.evals)[0], values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, (*mc.evals)[0], valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -48,7 +49,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, *mc.evals, qt.HasLen, 0)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -65,7 +66,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -77,7 +78,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -94,7 +95,7 @@ func TestOperation(t *testing.T) {
 				sym := mc.env.InternSymbol(values.NewSymbol("bindSymbolWithScopes"))
 				li := mc.env.LocalEnvironment().GetLocalIndex(sym)
 				bd := mc.env.LocalEnvironment().GetLocalBinding(li)
-				qt.Assert(t, bd.Value(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, bd.Value(), valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -110,7 +111,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(10))
 				qt.Assert(t, *mc.evals, qt.HasLen, 0)
 			},
 		},
@@ -129,7 +130,7 @@ func TestOperation(t *testing.T) {
 				sym := mc.env.InternSymbol(values.NewSymbol("bindSymbolWithScopes"))
 				gi := mc.env.GlobalEnvironment().GetGlobalIndex(sym)
 				v := mc.env.GlobalEnvironment().GetOwnGlobalBinding(gi).Value()
-				qt.Assert(t, v, values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(10))
 			},
 		},
 		{
@@ -142,7 +143,7 @@ func TestOperation(t *testing.T) {
 			checkFn: func(t *testing.T, mc *MachineContext) {
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 			},
 		},
 		{
@@ -191,7 +192,7 @@ func TestOperation(t *testing.T) {
 				// Closure executed: value = 42; returned via RestoreContinuation.
 				qt.Assert(t, mc.pc, qt.Equals, 1)
 				qt.Assert(t, mc.GetValues(), qt.HasLen, 1)
-				qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(42))
+				qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(42))
 				qt.Assert(t, *mc.evals, qt.HasLen, 0)
 			},
 		},
@@ -428,9 +429,9 @@ func TestOperations_Copy(t *testing.T) {
 	copied := ops.Copy()
 	qt.Assert(t, copied, qt.IsNotNil)
 	qt.Assert(t, copied.Len(), qt.Equals, 3)
-	qt.Assert(t, copied[0], values.SchemeEquals, ops[0])
-	qt.Assert(t, copied[1], values.SchemeEquals, ops[1])
-	qt.Assert(t, copied[2], values.SchemeEquals, ops[2])
+	qt.Assert(t, copied[0], valuestest.SchemeEquals, ops[0])
+	qt.Assert(t, copied[1], valuestest.SchemeEquals, ops[1])
+	qt.Assert(t, copied[2], valuestest.SchemeEquals, ops[2])
 }
 
 func TestOperations_EqualTo(t *testing.T) {

--- a/machine/record_test.go
+++ b/machine/record_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	"github.com/aalpar/wile/internal/bootstrap"
 
@@ -143,7 +144,7 @@ func TestRecordAccessors(t *testing.T) {
 			(y point-y))
 		(point-x (make-point 3 4))
 	`)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(3))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(3))
 
 	result = evalScheme(t, `
 		(define-record-type :point
@@ -153,7 +154,7 @@ func TestRecordAccessors(t *testing.T) {
 			(y point-y))
 		(point-y (make-point 3 4))
 	`)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(4))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(4))
 }
 
 func TestRecordModifiers(t *testing.T) {
@@ -170,7 +171,7 @@ func TestRecordModifiers(t *testing.T) {
 			(set-point-x! p 10)
 			(point-x p))
 	`)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(10))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 func TestRecordPartialConstructor(t *testing.T) {
@@ -187,7 +188,7 @@ func TestRecordPartialConstructor(t *testing.T) {
 			(set-person-age! p 30)
 			(person-age p))
 	`)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(30))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 func TestRecordEquality(t *testing.T) {
@@ -299,5 +300,5 @@ func TestNestedRecords(t *testing.T) {
 		(let ((l (make-line (make-point 0 0) (make-point 10 10))))
 			(point-x (line-end l)))
 	`)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(10))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(10))
 }

--- a/machine/stack_test.go
+++ b/machine/stack_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -34,7 +35,7 @@ func TestStack_Push(t *testing.T) {
 	qt.Assert(t, func() { q.Pop() }, qt.PanicMatches, "stack underflow.*")
 	q.Push(values.NewInteger(10))
 	qt.Assert(t, q.Len(), qt.Equals, 1)
-	qt.Assert(t, q.Pop(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, q.Pop(), valuestest.SchemeEquals, values.NewInteger(10))
 	qt.Assert(t, q.Len(), qt.Equals, 0)
 }
 
@@ -49,7 +50,7 @@ func TestStack_Clear(t *testing.T) {
 func TestStack_Pop(t *testing.T) {
 	q := NewStack()
 	q.Push(values.NewInteger(10))
-	qt.Assert(t, q.Pop(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, q.Pop(), valuestest.SchemeEquals, values.NewInteger(10))
 	qt.Assert(t, q.Len(), qt.Equals, 0)
 }
 
@@ -60,10 +61,10 @@ func TestStack_Copy(t *testing.T) {
 	r.Push(values.NewInteger(20))
 	qt.Assert(t, q.Len(), qt.Equals, 1)
 	qt.Assert(t, r.Len(), qt.Equals, 2)
-	qt.Assert(t, q.Pop(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, q.Pop(), valuestest.SchemeEquals, values.NewInteger(10))
 	qt.Assert(t, q.Len(), qt.Equals, 0)
-	qt.Assert(t, r.Pop(), values.SchemeEquals, values.NewInteger(20))
-	qt.Assert(t, r.Pop(), values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, r.Pop(), valuestest.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, r.Pop(), valuestest.SchemeEquals, values.NewInteger(10))
 	qt.Assert(t, q.Len(), qt.Equals, 0)
 }
 
@@ -82,8 +83,8 @@ func TestStack_PopAll(t *testing.T) {
 	q.Push(values.NewInteger(20))
 	qs := q.PopAll()
 	qt.Assert(t, qs, qt.HasLen, 2)
-	qt.Assert(t, qs[0], values.SchemeEquals, values.NewInteger(10))
-	qt.Assert(t, qs[1], values.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, qs[0], valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, qs[1], valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 func TestStack_Pull(t *testing.T) {
@@ -92,8 +93,8 @@ func TestStack_Pull(t *testing.T) {
 	q.Push(values.NewInteger(20))
 	r := q.Pull()
 	qt.Assert(t, q.Len(), qt.Equals, 1)
-	qt.Assert(t, (*q)[0], values.SchemeEquals, values.NewInteger(20))
-	qt.Assert(t, r, values.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, (*q)[0], valuestest.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, r, valuestest.SchemeEquals, values.NewInteger(10))
 }
 
 func TestStack_AsList(t *testing.T) {
@@ -137,7 +138,7 @@ func TestStackOperations(t *testing.T) {
 	pr, ok := list.(*values.Pair)
 	qt.Assert(t, ok, qt.IsTrue)
 	// Stack order: push 1, push 2, push 3 - AsList builds from top
-	qt.Assert(t, pr.Car(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, pr.Car(), valuestest.SchemeEquals, values.NewInteger(1))
 
 	// Test Clear
 	s.Clear()
@@ -145,7 +146,7 @@ func TestStackOperations(t *testing.T) {
 
 	// AsList on empty stack
 	emptyList := s.AsList()
-	qt.Assert(t, emptyList, values.SchemeEquals, values.EmptyList)
+	qt.Assert(t, emptyList, valuestest.SchemeEquals, values.EmptyList)
 
 	// Single element stack
 	s.Push(values.NewInteger(42))
@@ -166,14 +167,14 @@ func TestStackMoreOperations(t *testing.T) {
 	// Pop all
 	for i := 9; i >= 0; i-- {
 		v := s.Pop()
-		qt.Assert(t, v, values.SchemeEquals, values.NewInteger(int64(i)))
+		qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(int64(i)))
 	}
 	qt.Assert(t, s.Len(), qt.Equals, 0)
 
 	// PeekK to peek at stack
 	s.Push(values.NewInteger(42))
 	v := s.PeekK(0) // PeekK(0) gets top of stack
-	qt.Assert(t, v, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(42))
 	qt.Assert(t, s.Len(), qt.Equals, 1) // Still there
 }
 
@@ -202,7 +203,7 @@ func TestStackPull(t *testing.T) {
 
 	// Pull removes from front (FIFO)
 	v := s.Pull()
-	qt.Assert(t, v, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(1))
 	qt.Assert(t, s.Len(), qt.Equals, 2)
 }
 
@@ -221,13 +222,13 @@ func TestStackPopN(t *testing.T) {
 	qt.Assert(t, s.Len(), qt.Equals, 2) // 2 elements remain
 
 	// PopN returns elements in stack order (bottom to top of the popped range)
-	qt.Assert(t, vs[0], values.SchemeEquals, values.NewInteger(3)) // Bottom of popped range
-	qt.Assert(t, vs[1], values.SchemeEquals, values.NewInteger(4))
-	qt.Assert(t, vs[2], values.SchemeEquals, values.NewInteger(5)) // Top of stack (last popped)
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(3)) // Bottom of popped range
+	qt.Assert(t, vs[1], valuestest.SchemeEquals, values.NewInteger(4))
+	qt.Assert(t, vs[2], valuestest.SchemeEquals, values.NewInteger(5)) // Top of stack (last popped)
 
 	// Remaining elements
-	qt.Assert(t, s.Pop(), values.SchemeEquals, values.NewInteger(2))
-	qt.Assert(t, s.Pop(), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, s.Pop(), valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, s.Pop(), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestStackPopN_EdgeCases tests PopN edge cases
@@ -297,7 +298,7 @@ func TestStackAsListEmpty(t *testing.T) {
 	s2 := NewStack(values.NewInteger(1))
 	s2.Pop()
 	list2 := s2.AsList()
-	qt.Assert(t, list2, values.SchemeEquals, values.EmptyList) // empty (non-nil) slice returns EmptyList
+	qt.Assert(t, list2, valuestest.SchemeEquals, values.EmptyList) // empty (non-nil) slice returns EmptyList
 }
 
 // TestStackSchemeString tests stack SchemeString
@@ -372,11 +373,11 @@ func TestStackPeekKMultiple(t *testing.T) {
 	s.Push(values.NewInteger(3))
 
 	// PeekK(0) is top of stack (last pushed)
-	qt.Assert(t, s.PeekK(0), values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, s.PeekK(0), valuestest.SchemeEquals, values.NewInteger(3))
 	// PeekK(1) is one below top
-	qt.Assert(t, s.PeekK(1), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, s.PeekK(1), valuestest.SchemeEquals, values.NewInteger(2))
 	// PeekK(2) is bottom
-	qt.Assert(t, s.PeekK(2), values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, s.PeekK(2), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestStackNilLength tests Length on nil stack
@@ -403,9 +404,9 @@ func TestStackPeekKBoundary(t *testing.T) {
 	s := NewStack(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
 
 	// Peek at different positions
-	qt.Assert(t, s.PeekK(0), values.SchemeEquals, values.NewInteger(3)) // top
-	qt.Assert(t, s.PeekK(1), values.SchemeEquals, values.NewInteger(2)) // second
-	qt.Assert(t, s.PeekK(2), values.SchemeEquals, values.NewInteger(1)) // third/bottom
+	qt.Assert(t, s.PeekK(0), valuestest.SchemeEquals, values.NewInteger(3)) // top
+	qt.Assert(t, s.PeekK(1), valuestest.SchemeEquals, values.NewInteger(2)) // second
+	qt.Assert(t, s.PeekK(2), valuestest.SchemeEquals, values.NewInteger(1)) // third/bottom
 }
 
 // TestStackPopAllThenPush verifies that Push works after PopAll
@@ -422,11 +423,11 @@ func TestStackPopAllThenPush(t *testing.T) {
 	// Push after PopAll must work and must not corrupt the returned slice.
 	s.Push(values.NewInteger(99))
 	qt.Assert(t, s.Len(), qt.Equals, 1)
-	qt.Assert(t, s.Pop(), values.SchemeEquals, values.NewInteger(99))
+	qt.Assert(t, s.Pop(), valuestest.SchemeEquals, values.NewInteger(99))
 
 	// Original slice unchanged.
-	qt.Assert(t, got[0], values.SchemeEquals, values.NewInteger(1))
-	qt.Assert(t, got[1], values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, got[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, got[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 // TestStackPeekKPanics tests that Stack.PeekK panics on invalid indices

--- a/machine/value_methods_test.go
+++ b/machine/value_methods_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -29,10 +30,10 @@ import (
 func TestParameter_ValueAndSetValue(t *testing.T) {
 	c := qt.New(t)
 	p := NewParameter(values.NewInteger(42), nil)
-	c.Assert(p.Value(), values.SchemeEquals, values.NewInteger(42))
+	c.Assert(p.Value(), valuestest.SchemeEquals, values.NewInteger(42))
 
 	p.SetValue(values.NewString("hello"))
-	c.Assert(p.Value(), values.SchemeEquals, values.NewString("hello"))
+	c.Assert(p.Value(), valuestest.SchemeEquals, values.NewString("hello"))
 }
 
 func TestParameter_Converter(t *testing.T) {
@@ -330,11 +331,11 @@ func TestMachineContext_PushPopExceptionHandler(t *testing.T) {
 	// Pop returns most recent first
 	h2 := mc.PopExceptionHandler()
 	c.Assert(h2, qt.IsNotNil)
-	c.Assert(h2.Handler(), values.SchemeEquals, values.NewString("h2"))
+	c.Assert(h2.Handler(), valuestest.SchemeEquals, values.NewString("h2"))
 
 	h1 := mc.PopExceptionHandler()
 	c.Assert(h1, qt.IsNotNil)
-	c.Assert(h1.Handler(), values.SchemeEquals, values.NewString("h1"))
+	c.Assert(h1.Handler(), valuestest.SchemeEquals, values.NewString("h1"))
 
 	c.Assert(mc.PopExceptionHandler(), qt.IsNil)
 }

--- a/registry/core/core_test.go
+++ b/registry/core/core_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/registry/testhelpers"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestCoreArithmetic tests basic arithmetic primitives.
@@ -40,7 +41,7 @@ func TestCoreArithmetic(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			result, err := testhelpers.RunSchemeCode(t, tc.Code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.Expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.Expected)
 		})
 	}
 }
@@ -92,7 +93,7 @@ func TestCoreListOperations(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			result, err := testhelpers.RunSchemeCode(t, tc.Code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.Expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.Expected)
 		})
 	}
 }

--- a/registry/core/prim_abs_div_extra_test.go
+++ b/registry/core/prim_abs_div_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -62,7 +63,7 @@ func TestAbsExtraCoverage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -128,7 +129,7 @@ func TestMagnitudeExtraCoverage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -178,7 +179,7 @@ func TestDivisionExtraCoverage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_apply_test.go
+++ b/registry/core/prim_apply_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -63,7 +64,7 @@ func TestApplyComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -104,7 +105,7 @@ func TestApplyMultipleValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -192,7 +193,7 @@ func TestApplyWindingStackInheritance(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_arithmetic_test.go
+++ b/registry/core/prim_arithmetic_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -61,7 +62,7 @@ func TestAddition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -138,7 +139,7 @@ func TestSubtraction(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -221,7 +222,7 @@ func TestMultiplication(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -298,7 +299,7 @@ func TestDivision(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -381,7 +382,7 @@ func TestAbs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -438,7 +439,7 @@ func TestFloor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -469,7 +470,7 @@ func TestCeiling(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -500,7 +501,7 @@ func TestRound(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -531,7 +532,7 @@ func TestTruncate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -558,7 +559,7 @@ func TestSqrt(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -640,7 +641,7 @@ func TestExpt(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -733,7 +734,7 @@ func TestSquare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -791,7 +792,7 @@ func TestGcd(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -823,7 +824,7 @@ func TestLcm(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -850,7 +851,7 @@ func TestQuotient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -889,7 +890,7 @@ func TestRemainder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -932,7 +933,7 @@ func TestModulo(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -982,7 +983,7 @@ func TestMax(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1058,7 +1059,7 @@ func TestMin(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1205,7 +1206,7 @@ func TestDivisionByZero_SchemeException(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1267,7 +1268,7 @@ func TestOverflowPromotion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 

--- a/registry/core/prim_auxiliary_syntax_test.go
+++ b/registry/core/prim_auxiliary_syntax_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/aalpar/wile/registry/testhelpers"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestAuxiliarySyntax_CondElse verifies that auxiliary syntax `else` works
@@ -30,7 +31,7 @@ func TestAuxiliarySyntax_CondElse(t *testing.T) {
 
 	result, err := testhelpers.RunSchemeCode(t, "(cond (else 42))")
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(42))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 // TestAuxiliarySyntax_CondArrow verifies that auxiliary syntax `=>` works
@@ -40,7 +41,7 @@ func TestAuxiliarySyntax_CondArrow(t *testing.T) {
 
 	result, err := testhelpers.RunSchemeCode(t, "(cond (#t => (lambda (x) x)))")
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.TrueValue)
+	c.Assert(result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 // TestAuxiliarySyntax_CaseElse verifies that auxiliary syntax `else` works
@@ -50,5 +51,5 @@ func TestAuxiliarySyntax_CaseElse(t *testing.T) {
 
 	result, err := testhelpers.RunSchemeCode(t, "(case 1 (else 'ok))")
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("ok"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("ok"))
 }

--- a/registry/core/prim_barrier_test.go
+++ b/registry/core/prim_barrier_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -103,7 +104,7 @@ func TestWithContinuationBarrier_Success(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -158,5 +159,5 @@ func TestWithContinuationBarrier_ExceptionPassthrough(t *testing.T) {
 	result, err := runSchemeCode(t, `(guard (e (#t 'caught))
 	  (with-continuation-barrier (error "boom")))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("caught"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("caught"))
 }

--- a/registry/core/prim_box_test.go
+++ b/registry/core/prim_box_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -63,7 +64,7 @@ func TestBox(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -109,7 +110,7 @@ func TestBoxQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -145,7 +146,7 @@ func TestUnbox(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -201,7 +202,7 @@ func TestSetBox(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -257,7 +258,7 @@ func TestBoxEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_byte_vector_copy2_test.go
+++ b/registry/core/prim_byte_vector_copy2_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -71,7 +72,7 @@ func TestBytevectorCopyIndependence(t *testing.T) {
 	         (bytevector-u8-ref bv1 0))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestBytevectorCopyPartialIndependence(t *testing.T) {
@@ -81,5 +82,5 @@ func TestBytevectorCopyPartialIndependence(t *testing.T) {
 	         (list (bytevector-u8-ref bv1 1) (bytevector-u8-ref bv2 0)))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.List(values.NewInteger(20), values.NewInteger(99)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.List(values.NewInteger(20), values.NewInteger(99)))
 }

--- a/registry/core/prim_byte_vector_port_test.go
+++ b/registry/core/prim_byte_vector_port_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -51,7 +52,7 @@ func TestOpenInputBytevector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -83,7 +84,7 @@ func TestOpenOutputBytevector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -97,5 +98,5 @@ func TestGetOutputBytevector(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	// "Hi" as bytes: H=72, i=105
 	expected := values.ByteVector{{Value: 72}, {Value: 105}}
-	qt.Assert(t, result, values.SchemeEquals, &expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, &expected)
 }

--- a/registry/core/prim_byte_vector_test.go
+++ b/registry/core/prim_byte_vector_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -58,7 +59,7 @@ func TestBytevectorQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -99,7 +100,7 @@ func TestMakeBytevector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -134,7 +135,7 @@ func TestBytevector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -162,7 +163,7 @@ func TestBytevectorLength(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -199,7 +200,7 @@ func TestBytevectorU8Ref(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -236,7 +237,7 @@ func TestBytevectorU8Set(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -272,7 +273,7 @@ func TestBytevectorCopy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -308,7 +309,7 @@ func TestBytevectorAppend(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -339,7 +340,7 @@ func TestUtf8ToString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -375,7 +376,7 @@ func TestStringToUtf8(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -407,7 +408,7 @@ func TestBytevectorRoundTrip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -460,7 +461,7 @@ func TestMakeBytevector_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -488,7 +489,7 @@ func TestBytevector_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -559,7 +560,7 @@ func TestBytevectorU8Set_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -613,7 +614,7 @@ func TestBytevectorCopy_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -640,7 +641,7 @@ func TestBytevectorAppend_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -673,7 +674,7 @@ func TestUtf8ToString_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -706,7 +707,7 @@ func TestStringToUtf8_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_call_with_input_file_test.go
+++ b/registry/core/prim_call_with_input_file_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -65,7 +66,7 @@ func TestCallWithInputFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_call_with_output_file_test.go
+++ b/registry/core/prim_call_with_output_file_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -70,7 +71,7 @@ func TestCallWithOutputFileReturnsResult(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("done"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("done"))
 }
 
 func TestCallWithOutputFileErrors(t *testing.T) {

--- a/registry/core/prim_call_with_values_test.go
+++ b/registry/core/prim_call_with_values_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -47,7 +48,7 @@ func TestCallWithValuesComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_channel_test.go
+++ b/registry/core/prim_channel_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -63,7 +64,7 @@ func TestChannelQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -72,7 +73,7 @@ func TestMakeChannel(t *testing.T) {
 	// make-channel should return a channel
 	result, err := runSchemeCode(t, "(channel? (make-channel))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMakeChannelWithBuffer(t *testing.T) {
@@ -80,7 +81,7 @@ func TestMakeChannelWithBuffer(t *testing.T) {
 	code := "(channel-capacity (make-channel 5))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(5))
 }
 
 func TestChannelCapacity(t *testing.T) {
@@ -104,7 +105,7 @@ func TestChannelCapacity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -119,7 +120,7 @@ func TestChannelLength(t *testing.T) {
 	code := "(channel-length (make-channel 5))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(0))
 }
 
 func TestChannelLengthError(t *testing.T) {
@@ -136,7 +137,7 @@ func TestChannelSendAndReceive(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestChannelSendError(t *testing.T) {
@@ -157,7 +158,7 @@ func TestChannelTrySend(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestChannelTrySendFull(t *testing.T) {
@@ -169,7 +170,7 @@ func TestChannelTrySendFull(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestChannelTrySendError(t *testing.T) {
@@ -192,7 +193,7 @@ func TestChannelTryReceive(t *testing.T) {
 	// Should return (42 #t #t)
 	pair, ok := result.(*values.Pair)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, pair.Car(), values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, pair.Car(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestChannelTryReceiveEmpty(t *testing.T) {
@@ -206,7 +207,7 @@ func TestChannelTryReceiveEmpty(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestChannelTryReceiveError(t *testing.T) {
@@ -222,7 +223,7 @@ func TestChannelClose(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestChannelCloseError(t *testing.T) {
@@ -255,7 +256,7 @@ func TestChannelClosedQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -276,7 +277,7 @@ func TestChannelWithThread(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 func TestChannelMultipleValues(t *testing.T) {
@@ -292,5 +293,5 @@ func TestChannelMultipleValues(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(6))
 }

--- a/registry/core/prim_char_extra_test.go
+++ b/registry/core/prim_char_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -54,7 +55,7 @@ func TestCharPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -90,7 +91,7 @@ func TestCharAlphabetic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -126,7 +127,7 @@ func TestCharNumeric(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -167,7 +168,7 @@ func TestCharWhitespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -203,7 +204,7 @@ func TestCharUpperCase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -239,7 +240,7 @@ func TestCharLowerCase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -275,7 +276,7 @@ func TestCharUpcase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -311,7 +312,7 @@ func TestCharDowncase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -347,7 +348,7 @@ func TestCharFoldcase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -388,7 +389,7 @@ func TestDigitValue(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -452,7 +453,7 @@ func TestCharFoldcaseUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -552,7 +553,7 @@ func TestDigitValueUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -680,7 +681,7 @@ func TestCharAlphabeticUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -759,7 +760,7 @@ func TestCharNumericUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -846,7 +847,7 @@ func TestCharWhitespaceUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -947,7 +948,7 @@ func TestCharUpperCaseUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1048,7 +1049,7 @@ func TestCharLowerCaseUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1110,7 +1111,7 @@ func TestCharCaseConversionTurkish(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1175,7 +1176,7 @@ func TestCharCaseConversionGermanSS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_char_test.go
+++ b/registry/core/prim_char_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -98,7 +99,7 @@ func TestCharComparisons(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -124,7 +125,7 @@ func TestCharToInteger(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -150,7 +151,7 @@ func TestIntegerToChar(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -194,7 +195,7 @@ func TestCharToIntegerExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -231,7 +232,7 @@ func TestIntegerToCharExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -275,7 +276,7 @@ func TestCharCIEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -307,7 +308,7 @@ func TestCharCILessThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -339,7 +340,7 @@ func TestCharCIGreaterThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -371,7 +372,7 @@ func TestCharCILessThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -403,7 +404,7 @@ func TestCharCIGreaterThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -478,7 +479,7 @@ func TestCharCICompareVariadic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -527,7 +528,7 @@ func TestCharCompareVariadic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -684,7 +685,7 @@ func TestIntegerToChar_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -713,7 +714,7 @@ func TestCharToInteger_EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_close_port_test.go
+++ b/registry/core/prim_close_port_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -32,7 +33,7 @@ func TestClosePortOnStringPorts(t *testing.T) {
 			#t)
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `
 		(let ((p (open-output-string)))
@@ -40,7 +41,7 @@ func TestClosePortOnStringPorts(t *testing.T) {
 			#t)
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestClosePortOnBytevectorPorts(t *testing.T) {
@@ -50,7 +51,7 @@ func TestClosePortOnBytevectorPorts(t *testing.T) {
 			#t)
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `
 		(let ((p (open-output-bytevector)))
@@ -58,5 +59,5 @@ func TestClosePortOnBytevectorPorts(t *testing.T) {
 			#t)
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_complex_test.go
+++ b/registry/core/prim_complex_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -47,7 +48,7 @@ func TestRealPart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -73,7 +74,7 @@ func TestImagPart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -99,7 +100,7 @@ func TestMagnitude(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -125,7 +126,7 @@ func TestMakeRectangular(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -150,7 +151,7 @@ func TestNumerator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -171,7 +172,7 @@ func TestDenominator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_condvar_test.go
+++ b/registry/core/prim_condvar_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -62,7 +63,7 @@ func TestConditionVariableQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -71,21 +72,21 @@ func TestMakeConditionVariable(t *testing.T) {
 	// make-condition-variable should return a condition-variable
 	result, err := runSchemeCode(t, "(condition-variable? (make-condition-variable))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMakeConditionVariableWithName(t *testing.T) {
 	code := `(condition-variable-name (make-condition-variable "test-cv"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("test-cv"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("test-cv"))
 }
 
 func TestConditionVariableName(t *testing.T) {
 	code := `(condition-variable-name (make-condition-variable "my-cv"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("my-cv"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("my-cv"))
 }
 
 func TestConditionVariableNameError(t *testing.T) {
@@ -98,7 +99,7 @@ func TestConditionVariableSpecific(t *testing.T) {
 	code := `(void? (condition-variable-specific (make-condition-variable)))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestConditionVariableSpecificSet(t *testing.T) {
@@ -109,7 +110,7 @@ func TestConditionVariableSpecificSet(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("my-data"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("my-data"))
 }
 
 func TestConditionVariableSpecificError(t *testing.T) {

--- a/registry/core/prim_control_flow_test.go
+++ b/registry/core/prim_control_flow_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -58,7 +59,7 @@ func TestControlFlowCombinations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_control_test.go
+++ b/registry/core/prim_control_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -90,7 +91,7 @@ func TestCallCC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -156,7 +157,7 @@ func TestCallCCWithHigherOrderFunctions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -250,7 +251,7 @@ func TestMapMultipleLists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -367,7 +368,7 @@ func TestApplyMultipleArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -403,7 +404,7 @@ func TestValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -492,7 +493,7 @@ func TestCallWithValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -585,7 +586,7 @@ func TestDynamicWind(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -630,7 +631,7 @@ func TestDynamicWindEscape(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	// After should have run, setting v[0] to 2
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestDynamicWindBasic(t *testing.T) {
@@ -674,7 +675,7 @@ func TestCallWithValuesExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -705,7 +706,7 @@ func TestCallCCMultiInvoke(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -782,7 +783,7 @@ func TestCallCCSubContextReentry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCodeWithTimeout(t, tc.code, 5*time.Second)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -815,7 +816,7 @@ func TestDynamicWindExceptionInThunks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -838,7 +839,7 @@ func TestApplyExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -886,7 +887,7 @@ func TestForEachExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1007,7 +1008,7 @@ func TestCallCCCoroutines(t *testing.T) {
 				(f))`,
 			check: func(t *testing.T, result values.Value) {
 				t.Helper()
-				qt.Assert(t, result, values.SchemeEquals, values.NewInteger(11))
+				qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(11))
 			},
 			timeout: 5 * time.Second,
 		},
@@ -1023,7 +1024,7 @@ func TestCallCCCoroutines(t *testing.T) {
 						count)))`,
 			check: func(t *testing.T, result values.Value) {
 				t.Helper()
-				qt.Assert(t, result, values.SchemeEquals, values.NewInteger(3))
+				qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(3))
 			},
 			timeout: 5 * time.Second,
 		},
@@ -1070,7 +1071,7 @@ func TestApplyWithParameter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.want)
+			c.Assert(result, valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/core/prim_current_port_test.go
+++ b/registry/core/prim_current_port_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -27,23 +28,23 @@ import (
 func TestCurrentInputPortIsInputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestCurrentOutputPortIsOutputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestCurrentInputPortIsPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestCurrentOutputPortIsPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_cxr_test.go
+++ b/registry/core/prim_cxr_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -51,7 +52,7 @@ func TestCxR2Level(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -105,7 +106,7 @@ func TestCxR3Level(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -199,7 +200,7 @@ func TestCxR4Level(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_define_values_test.go
+++ b/registry/core/prim_define_values_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -101,7 +102,7 @@ func TestDefineValuesComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_delete_load_test.go
+++ b/registry/core/prim_delete_load_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -34,7 +35,7 @@ func TestDeleteFile(t *testing.T) {
 	code := fmt.Sprintf(`(begin (delete-file %q) #t)`, path)
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	// Verify file was deleted
 	_, err = os.Stat(path)
@@ -63,7 +64,7 @@ func TestLoad(t *testing.T) {
 	code := fmt.Sprintf(`(load %q)`, f.Name())
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestLoadWithMultipleExpressions(t *testing.T) {
@@ -77,7 +78,7 @@ func TestLoadWithMultipleExpressions(t *testing.T) {
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
 	// Should return the value of the last expression
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(30))
 }
 
 func TestLoadReturnsLastValue(t *testing.T) {
@@ -90,7 +91,7 @@ func TestLoadReturnsLastValue(t *testing.T) {
 	code := fmt.Sprintf(`(load %q)`, f.Name())
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 func TestLoadWithEmptyFile(t *testing.T) {
@@ -143,5 +144,5 @@ func TestLoadAccessesTopLevelEnvironment(t *testing.T) {
 	code := fmt.Sprintf(`(begin (define global-var 32) (load %q))`, f.Name())
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }

--- a/registry/core/prim_division_test.go
+++ b/registry/core/prim_division_test.go
@@ -20,6 +20,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // ============================================================================
@@ -156,7 +157,7 @@ func TestFloorDivComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -248,7 +249,7 @@ func TestFloorQuotientComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -293,7 +294,7 @@ func TestFloorRemainderComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -412,7 +413,7 @@ func TestTruncateDivComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -504,7 +505,7 @@ func TestTruncateQuotientComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -549,7 +550,7 @@ func TestTruncateRemainderComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -614,16 +615,16 @@ func TestFloorVsTruncateDifference(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			floorRes, err := runSchemeCode(t, tc.floorCode)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, floorRes, values.SchemeEquals, tc.floorResult)
+			qt.Assert(t, floorRes, valuestest.SchemeEquals, tc.floorResult)
 
 			truncRes, err := runSchemeCode(t, tc.truncateCode)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, truncRes, values.SchemeEquals, tc.truncResult)
+			qt.Assert(t, truncRes, valuestest.SchemeEquals, tc.truncResult)
 
 			if tc.shouldDiffer {
-				qt.Assert(t, floorRes, qt.Not(values.SchemeEquals), truncRes)
+				qt.Assert(t, floorRes, qt.Not(valuestest.SchemeEquals), truncRes)
 			} else {
-				qt.Assert(t, floorRes, values.SchemeEquals, truncRes)
+				qt.Assert(t, floorRes, valuestest.SchemeEquals, truncRes)
 			}
 		})
 	}

--- a/registry/core/prim_dynamic_wind_test.go
+++ b/registry/core/prim_dynamic_wind_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -57,7 +58,7 @@ func TestDynamicWindComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -103,7 +104,7 @@ func TestDynamicWindWithContinuations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -157,7 +158,7 @@ func TestDynamicWindR7RSExample(t *testing.T) {
 		values.NewSymbol("talk2"),
 		values.NewSymbol("disconnect"),
 	)
-	qt.Assert(t, result, values.SchemeEquals, expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, expected)
 }
 
 // TestDynamicWindNestedContinuations tests nested dynamic-wind with continuations.
@@ -214,7 +215,7 @@ func TestDynamicWindNestedContinuations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -274,7 +275,7 @@ func TestDynamicWindContinuationReentry(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -340,7 +341,7 @@ func TestCallCCComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_env_extra_test.go
+++ b/registry/core/prim_env_extra_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -96,7 +97,7 @@ func TestEvalWithEnvironments(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_eof_object_test.go
+++ b/registry/core/prim_eof_object_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -33,7 +34,7 @@ func TestEofObjectFromRead(t *testing.T) {
 			(eof-object? (read p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectFromReadAfterData(t *testing.T) {
@@ -44,7 +45,7 @@ func TestEofObjectFromReadAfterData(t *testing.T) {
 			(eof-object? (read p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectFromReadCharAfterRead(t *testing.T) {
@@ -55,7 +56,7 @@ func TestEofObjectFromReadCharAfterRead(t *testing.T) {
 			(eof-object? (read-char p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectFromReadMultipleEof(t *testing.T) {
@@ -70,24 +71,24 @@ func TestEofObjectFromReadMultipleEof(t *testing.T) {
 				     (eof-object? c))))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectUniqueness(t *testing.T) {
 	// There is only one eof-object
 	result, err := runSchemeCode(t, `(eq? (eof-object) (eof-object))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectEqv(t *testing.T) {
 	result, err := runSchemeCode(t, `(eqv? (eof-object) (eof-object))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectEqual(t *testing.T) {
 	result, err := runSchemeCode(t, `(equal? (eof-object) (eof-object))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_eq_q_test.go
+++ b/registry/core/prim_eq_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -84,7 +85,7 @@ func TestEqQComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -117,7 +118,7 @@ func TestEqQWithLetBinding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_equal_q_test.go
+++ b/registry/core/prim_equal_q_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -69,7 +70,7 @@ func TestEqualQComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -98,7 +99,7 @@ func TestEqualityHierarchy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -113,7 +114,7 @@ func TestEqualQCircular_SelfReferentialList(t *testing.T) {
 		  (equal? x x))
 	`, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEqualQCircular_TwoIdenticalCircularLists(t *testing.T) {
@@ -125,7 +126,7 @@ func TestEqualQCircular_TwoIdenticalCircularLists(t *testing.T) {
 		  (equal? a b))
 	`, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEqualQCircular_DifferentCircularLists(t *testing.T) {
@@ -137,7 +138,7 @@ func TestEqualQCircular_DifferentCircularLists(t *testing.T) {
 		  (equal? a b))
 	`, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestEqualQCircular_CircularVector(t *testing.T) {
@@ -147,7 +148,7 @@ func TestEqualQCircular_CircularVector(t *testing.T) {
 		  (equal? v v))
 	`, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEqualQCircular_PairContainingCircularVector(t *testing.T) {
@@ -159,5 +160,5 @@ func TestEqualQCircular_PairContainingCircularVector(t *testing.T) {
 		    (equal? a b)))
 	`, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_equality_test.go
+++ b/registry/core/prim_equality_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aalpar/wile/registry/helpers"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -54,7 +55,7 @@ func TestNumericEquality(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -94,7 +95,7 @@ func TestEqQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -130,7 +131,7 @@ func TestEqualQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -146,7 +147,7 @@ func TestEqQWithDifferentPairs(t *testing.T) {
 	result, err := runProgramAST(t, prog)
 	qt.Assert(t, err, qt.IsNil)
 	// Two different pairs should not be eq?
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestEqualQWithLists(t *testing.T) {
@@ -159,7 +160,7 @@ func TestEqualQWithLists(t *testing.T) {
 	result, err := runProgramAST(t, prog)
 	qt.Assert(t, err, qt.IsNil)
 	// equal? compares by value, so equivalent lists should be equal?
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEqv(t *testing.T) {
@@ -409,7 +410,7 @@ func TestEqvQPrimitive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_eqv_q_test.go
+++ b/registry/core/prim_eqv_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -89,7 +90,7 @@ func TestEqvQComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -108,7 +109,7 @@ func TestEqvQSpecialValues(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_eval_env_test.go
+++ b/registry/core/prim_eval_env_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -53,7 +54,7 @@ func TestEval(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -89,7 +90,7 @@ func TestEvalExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -127,7 +128,7 @@ func TestEvalWithLambda(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -228,7 +229,7 @@ func TestCompile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -277,7 +278,7 @@ func TestSyntaxToDatum(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -315,7 +316,7 @@ func TestDatumToSyntax(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -382,7 +383,7 @@ func TestIdentifierQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -415,7 +416,7 @@ func TestExpand(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -449,7 +450,7 @@ func TestExpandOnce(t *testing.T) {
 		result, err := runSchemeCode(t, code)
 		qt.Assert(t, err, qt.IsNil)
 		// For a primitive form like +, no expansion happens
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("expand-once returns syntax object", func(t *testing.T) {
@@ -460,7 +461,7 @@ func TestExpandOnce(t *testing.T) {
 		result, err := runSchemeCode(t, code)
 		qt.Assert(t, err, qt.IsNil)
 		expected := values.List(values.NewSymbol("+"), values.NewInteger(1), values.NewInteger(2))
-		qt.Assert(t, result, values.SchemeEquals, expected)
+		qt.Assert(t, result, valuestest.SchemeEquals, expected)
 	})
 }
 
@@ -523,7 +524,7 @@ func TestEnvironmentSymbolIdentity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -548,7 +549,7 @@ func TestNullEnvironmentSymbolIdentity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_exact_integer_q_test.go
+++ b/registry/core/prim_exact_integer_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -43,7 +44,7 @@ func TestExactIntegerQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_exact_q_test.go
+++ b/registry/core/prim_exact_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -43,7 +44,7 @@ func TestExactQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_exact_test.go
+++ b/registry/core/prim_exact_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -44,7 +45,7 @@ func TestExact(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -133,7 +134,7 @@ func TestExact_ComplexFractionalParts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_exactness_aliases_test.go
+++ b/registry/core/prim_exactness_aliases_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -40,7 +41,7 @@ func TestExactnessAliases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_exception_test.go
+++ b/registry/core/prim_exception_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -66,7 +67,7 @@ func TestWithExceptionHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -97,7 +98,7 @@ func TestWithExceptionHandlerContinuable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -124,7 +125,7 @@ func TestWithExceptionHandlerNested(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -183,7 +184,7 @@ func TestRaiseWithCallCC(t *testing.T) {
 					(lambda () (raise 'my-error)))))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("my-error"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("my-error"))
 }
 
 // =============================================================================
@@ -237,7 +238,7 @@ func TestRaiseContinuable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -278,7 +279,7 @@ func TestError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -294,7 +295,7 @@ func TestErrorWithIrritants(t *testing.T) {
 	`)
 	qt.Assert(t, err, qt.IsNil)
 	expected := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
-	qt.Assert(t, result, values.SchemeEquals, expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, expected)
 }
 
 func TestErrorErrors(t *testing.T) {
@@ -377,7 +378,7 @@ func TestErrorObjectQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -416,7 +417,7 @@ func TestErrorObjectMessage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -484,7 +485,7 @@ func TestErrorObjectIrritants(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -543,7 +544,7 @@ func TestRaiseNonContinuableR7RS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -584,7 +585,7 @@ func TestRaiseContinuableR7RS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -661,7 +662,7 @@ func TestRaiseContinuableResumption(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -694,7 +695,7 @@ func TestExceptionHandlerChain(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -729,7 +730,7 @@ func TestErrorR7RS(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -815,7 +816,7 @@ func TestGuard(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -852,7 +853,7 @@ func TestGuardArrowClause(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -892,7 +893,7 @@ func TestGuardReraise(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -930,7 +931,7 @@ func TestGuardWithError(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -973,7 +974,7 @@ func TestGuardNested(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1085,7 +1086,7 @@ func TestExceptionInHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1211,7 +1212,7 @@ func TestGuardDeeplyNested(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1244,7 +1245,7 @@ func TestFileErrorPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -1277,7 +1278,7 @@ func TestReadErrorPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_exit_test.go
+++ b/registry/core/prim_exit_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -107,7 +108,7 @@ func TestCallWithExit_Success(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_file_env_test.go
+++ b/registry/core/prim_file_env_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -26,13 +27,13 @@ import (
 func TestFileExistsWithExistingFile(t *testing.T) {
 	result, err := runSchemeCode(t, `(file-exists? "test_helpers_test.go")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestFileExistsWithNonexistentFile(t *testing.T) {
 	result, err := runSchemeCode(t, `(file-exists? "nonexistent-file-xyz.txt")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestGetEnvironmentVariableWithPATH(t *testing.T) {
@@ -48,7 +49,7 @@ func TestGetEnvironmentVariableWithPATH(t *testing.T) {
 func TestGetEnvironmentVariableWithNonexistentVar(t *testing.T) {
 	result, err := runSchemeCode(t, `(get-environment-variable "WILE_NONEXISTENT_VAR_12345")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestGetEnvironmentVariableWithTestVar(t *testing.T) {
@@ -57,7 +58,7 @@ func TestGetEnvironmentVariableWithTestVar(t *testing.T) {
 
 	result, err := runSchemeCode(t, `(get-environment-variable "WILE_TEST_VAR")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("test_value"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("test_value"))
 }
 
 func TestGetEnvironmentVariablesReturnsAlist(t *testing.T) {

--- a/registry/core/prim_for_each_test.go
+++ b/registry/core/prim_for_each_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -78,7 +79,7 @@ func TestForEachComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_hashtable_test.go
+++ b/registry/core/prim_hashtable_test.go
@@ -20,6 +20,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestHashtable_MakeAndPredicate(t *testing.T) {
@@ -34,7 +35,7 @@ func TestHashtable_MakeAndPredicate(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -89,7 +90,7 @@ func TestHashtable_SetAndRef(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -132,7 +133,7 @@ func TestHashtable_Delete(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -159,7 +160,7 @@ func TestHashtable_Size(t *testing.T) {
 		c.Run(tc.name, func(c *qt.C) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -173,7 +174,7 @@ func TestHashtable_KeysAndValues(t *testing.T) {
 		  (hashtable-set! ht 'only 1)
 		  (car (hashtable-keys ht)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewSymbol("only"))
+	c.Assert(result, valuestest.SchemeEquals, values.NewSymbol("only"))
 
 	// Values returns a list of values
 	result, err = runSchemeCode(t, `
@@ -181,16 +182,16 @@ func TestHashtable_KeysAndValues(t *testing.T) {
 		  (hashtable-set! ht 'only 99)
 		  (car (hashtable-values ht)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(99))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(99))
 
 	// Empty hashtable returns empty lists
 	result, err = runSchemeCode(t, `(null? (hashtable-keys (make-hashtable)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.TrueValue)
+	c.Assert(result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(null? (hashtable-values (make-hashtable)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.TrueValue)
+	c.Assert(result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestHashtable_Copy(t *testing.T) {
@@ -204,7 +205,7 @@ func TestHashtable_Copy(t *testing.T) {
 		    (hashtable-set! ht 'b 2)
 		    (hashtable-size cp)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(1))
 
 	// Copy preserves content
 	result, err = runSchemeCode(t, `
@@ -213,7 +214,7 @@ func TestHashtable_Copy(t *testing.T) {
 		  (let ((cp (hashtable-copy ht)))
 		    (hashtable-ref cp 'a)))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(1))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestHashtable_Clear(t *testing.T) {
@@ -225,7 +226,7 @@ func TestHashtable_Clear(t *testing.T) {
 		  (hashtable-clear! ht)
 		  (hashtable-size ht))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.NewInteger(0))
+	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(0))
 }
 
 func TestHashtable_EqualQ(t *testing.T) {
@@ -239,7 +240,7 @@ func TestHashtable_EqualQ(t *testing.T) {
 		  (hashtable-set! b 'x 1)
 		  (equal? a b))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.TrueValue)
+	c.Assert(result, valuestest.SchemeEquals, values.TrueValue)
 
 	// equal? on different content
 	result, err = runSchemeCode(t, `
@@ -249,7 +250,7 @@ func TestHashtable_EqualQ(t *testing.T) {
 		  (hashtable-set! b 'x 2)
 		  (equal? a b))`)
 	c.Assert(err, qt.IsNil)
-	c.Assert(result, values.SchemeEquals, values.FalseValue)
+	c.Assert(result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestHashtable_TypeErrors(t *testing.T) {

--- a/registry/core/prim_imag_part_test.go
+++ b/registry/core/prim_imag_part_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -42,7 +43,7 @@ func TestImagPartExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_inexact_q_test.go
+++ b/registry/core/prim_inexact_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -40,7 +41,7 @@ func TestInexactQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_inexact_test.go
+++ b/registry/core/prim_inexact_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -44,7 +45,7 @@ func TestInexact(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -73,7 +74,7 @@ func TestInexactBigNumbers(t *testing.T) {
 		// Create exact BigComplex via arithmetic on BigIntegers
 		result, err := runSchemeCode(t, `(inexact? (inexact (make-rectangular (expt 2 100) (expt 2 50))))`)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 }
 

--- a/registry/core/prim_io_test.go
+++ b/registry/core/prim_io_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -585,7 +586,7 @@ func TestStringPorts(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, &values.String{Value: "hello world"})
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, &values.String{Value: "hello world"})
 }
 
 func TestStringInputPort(t *testing.T) {
@@ -617,7 +618,7 @@ func TestStringInputPort(t *testing.T) {
 
 	// Read should return the list (+ 1 2)
 	expected := values.List(values.NewSymbol("+"), values.NewInteger(1), values.NewInteger(2))
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, expected)
 }
 
 func TestBytevectorPorts(t *testing.T) {
@@ -651,7 +652,7 @@ func TestBytevectorPorts(t *testing.T) {
 
 	// "AB" as bytes
 	expected := values.ByteVector{{Value: 65}, {Value: 66}}
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, &expected)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, &expected)
 }
 
 func TestBytevectorInputPort(t *testing.T) {
@@ -679,7 +680,7 @@ func TestBytevectorInputPort(t *testing.T) {
 	err = mc.Run()
 	qt.Assert(t, err, qt.IsNil)
 
-	qt.Assert(t, mc.GetValue(), values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestPortPredicates(t *testing.T) {
@@ -761,7 +762,7 @@ func TestPortPredicates(t *testing.T) {
 			err = mc.Run()
 			qt.Assert(t, err, qt.IsNil)
 
-			qt.Assert(t, mc.GetValue(), values.SchemeEquals, tc.out)
+			qt.Assert(t, mc.GetValue(), valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_lcm_gcd_test.go
+++ b/registry/core/prim_lcm_gcd_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -68,7 +69,7 @@ func TestLcmExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -114,7 +115,7 @@ func TestGcdExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_list_test.go
+++ b/registry/core/prim_list_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -38,7 +39,7 @@ func TestCar(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -74,7 +75,7 @@ func TestCdr(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -123,7 +124,7 @@ func TestCons(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -139,7 +140,7 @@ func TestList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -159,7 +160,7 @@ func TestCar_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -175,7 +176,7 @@ func TestCdr_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -193,7 +194,7 @@ func TestCons_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -213,7 +214,7 @@ func TestSetCarBang_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -231,7 +232,7 @@ func TestSetCdrBang_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -249,7 +250,7 @@ func TestListRef_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -286,7 +287,7 @@ func TestListTail_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -320,7 +321,7 @@ func TestListSetBang_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -352,7 +353,7 @@ func TestMemq_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -380,7 +381,7 @@ func TestMemv_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -408,7 +409,7 @@ func TestMember_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -442,7 +443,7 @@ func TestAssq_ImproperAlist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -472,7 +473,7 @@ func TestAssv_ImproperAlist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -502,7 +503,7 @@ func TestAssoc_ImproperAlist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -932,7 +933,7 @@ func TestCxR_ImproperList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -977,7 +978,7 @@ func TestNullQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1004,7 +1005,7 @@ func TestPairQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1032,7 +1033,7 @@ func TestListQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1055,7 +1056,7 @@ func TestSetCarBang(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1091,7 +1092,7 @@ func TestSetCdrBang(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1129,7 +1130,7 @@ func TestListSetBang(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1170,7 +1171,7 @@ func TestMakeList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1222,7 +1223,7 @@ func TestAppend(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1245,7 +1246,7 @@ func TestLength(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1287,7 +1288,7 @@ func TestReverse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1321,7 +1322,7 @@ func TestListRef(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1361,7 +1362,7 @@ func TestListTail(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1404,7 +1405,7 @@ func TestMemq(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1431,7 +1432,7 @@ func TestMemv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1458,7 +1459,7 @@ func TestMember(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1504,7 +1505,7 @@ func TestMemberWithCompare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1532,7 +1533,7 @@ func TestAssq(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1555,7 +1556,7 @@ func TestAssv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1581,7 +1582,7 @@ func TestAssoc(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1631,7 +1632,7 @@ func TestAssocWithCompare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1668,7 +1669,7 @@ func TestListCopy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1687,7 +1688,7 @@ func TestListCopy_SpineIndependence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1706,7 +1707,7 @@ func TestListCopy_ElementSharing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_make_rectangular_test.go
+++ b/registry/core/prim_make_rectangular_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -50,7 +51,7 @@ func TestMakeRectangularComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_map_test.go
+++ b/registry/core/prim_map_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -62,7 +63,7 @@ func TestMapComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -96,7 +97,7 @@ func TestMapExceptionGuard(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_minmax_test.go
+++ b/registry/core/prim_minmax_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -94,7 +95,7 @@ func TestMinExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -170,7 +171,7 @@ func TestMaxExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_misc_test.go
+++ b/registry/core/prim_misc_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -68,7 +69,7 @@ func TestComplexPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -117,7 +118,7 @@ func TestRealPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -158,7 +159,7 @@ func TestRationalPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -229,7 +230,7 @@ func TestCurrentJiffyMonotonic(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestCurrentSecondReasonable(t *testing.T) {
@@ -238,7 +239,7 @@ func TestCurrentSecondReasonable(t *testing.T) {
 	code := "(> (current-second) 1577836800)"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 // ----------------------------------------------------------------------------
@@ -286,7 +287,7 @@ func TestNotPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -296,21 +297,21 @@ func TestListPredicateWithImproperList(t *testing.T) {
 	code := "(list? '(1 . 2))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestListPredicateWithProperList(t *testing.T) {
 	code := "(list? '(1 2 3))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestListPredicateWithEmptyList(t *testing.T) {
 	code := "(list? '())"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestProcedurePredicateComprehensive(t *testing.T) {
@@ -335,7 +336,7 @@ func TestProcedurePredicateComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_mutex_test.go
+++ b/registry/core/prim_mutex_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -58,7 +59,7 @@ func TestMutexQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -67,21 +68,21 @@ func TestMakeMutex(t *testing.T) {
 	// make-mutex should return a mutex
 	result, err := runSchemeCode(t, "(mutex? (make-mutex))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMakeMutexWithName(t *testing.T) {
 	code := `(mutex-name (make-mutex "test-mutex"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("test-mutex"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("test-mutex"))
 }
 
 func TestMutexName(t *testing.T) {
 	code := `(mutex-name (make-mutex "my-mutex"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("my-mutex"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("my-mutex"))
 }
 
 func TestMutexNameError(t *testing.T) {
@@ -94,7 +95,7 @@ func TestMutexSpecific(t *testing.T) {
 	code := `(void? (mutex-specific (make-mutex)))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMutexSpecificSet(t *testing.T) {
@@ -105,7 +106,7 @@ func TestMutexSpecificSet(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("my-data"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("my-data"))
 }
 
 func TestMutexSpecificError(t *testing.T) {
@@ -123,7 +124,7 @@ func TestMutexState(t *testing.T) {
 	code := "(mutex-state (make-mutex))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("not-owned"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("not-owned"))
 }
 
 func TestMutexStateError(t *testing.T) {
@@ -140,14 +141,14 @@ func TestMutexLockAndUnlock(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMutexLockReturnsTrue(t *testing.T) {
 	code := "(mutex-lock! (make-mutex))"
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMutexLockError(t *testing.T) {
@@ -169,7 +170,7 @@ func TestMutexLockWithTimeout(t *testing.T) {
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
 	// Should succeed since mutex is available
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMutexProtectsCriticalSection(t *testing.T) {
@@ -184,5 +185,5 @@ func TestMutexProtectsCriticalSection(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }

--- a/registry/core/prim_not_test.go
+++ b/registry/core/prim_not_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -57,7 +58,7 @@ func TestNotComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_numeric_conversion_test.go
+++ b/registry/core/prim_numeric_conversion_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -31,61 +32,61 @@ func TestIntegerQ(t *testing.T) {
 	t.Run("integer? on exact integer", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 42)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on inexact integer", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 3.0)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on non-integer float", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 3.5)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("integer? on non-integer rational", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 1/2)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("integer? on integer rational", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 1/1)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on complex with zero imaginary", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 3+0i)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on complex with non-zero imaginary", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 3+1i)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("integer? on negative integer", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? -5)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on zero", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? 0)")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 	})
 
 	t.Run("integer? on non-number", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(integer? \"hello\")")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 }
 
@@ -422,7 +423,7 @@ func TestStringToNumberExtended(t *testing.T) {
 	t.Run("string->number on invalid string", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(string->number \"xyz\")")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("string->number on float string", func(t *testing.T) {
@@ -468,7 +469,7 @@ func TestStringToNumberExtended(t *testing.T) {
 	t.Run("string->number on empty string", func(t *testing.T) {
 		result, err := runSchemeCode(t, "(string->number \"\")")
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("string->number on negative float string", func(t *testing.T) {
@@ -519,7 +520,7 @@ func TestStringToNumber_Prefixes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 
@@ -527,13 +528,13 @@ func TestStringToNumber_Prefixes(t *testing.T) {
 	t.Run("invalid prefix returns false", func(t *testing.T) {
 		result, err := runSchemeCode(t, `(string->number "#q42")`)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 
 	t.Run("empty after prefix returns false", func(t *testing.T) {
 		result, err := runSchemeCode(t, `(string->number "#x")`)
 		qt.Assert(t, err, qt.IsNil)
-		qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+		qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 	})
 }
 

--- a/registry/core/prim_numeric_extra_test.go
+++ b/registry/core/prim_numeric_extra_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -81,7 +82,7 @@ func TestExactnessPredicates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -159,7 +160,7 @@ func TestSpecialValuePredicates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -206,7 +207,7 @@ func TestExactnessConversions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -275,7 +276,7 @@ func TestExactIntegerSqrt(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 			// Result should be a list of two values
 			expected := values.List(tc.out1, tc.out2)
-			qt.Assert(t, result, values.SchemeEquals, expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, expected)
 		})
 	}
 }
@@ -310,7 +311,7 @@ func TestRationalize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -363,7 +364,7 @@ func TestFloorDivision(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 			// Result should be a list of two values
 			expected := values.List(tc.out1, tc.out2)
-			qt.Assert(t, result, values.SchemeEquals, expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, expected)
 		})
 	}
 }
@@ -389,7 +390,7 @@ func TestFloorQuotient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -415,7 +416,7 @@ func TestFloorRemainder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -468,7 +469,7 @@ func TestTruncateDivision(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 			// Result should be a list of two values
 			expected := values.List(tc.out1, tc.out2)
-			qt.Assert(t, result, values.SchemeEquals, expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, expected)
 		})
 	}
 }
@@ -494,7 +495,7 @@ func TestTruncateQuotient(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -520,7 +521,7 @@ func TestTruncateRemainder(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_open_binary_input_file_test.go
+++ b/registry/core/prim_open_binary_input_file_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -54,7 +55,7 @@ func TestOpenBinaryInputFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -74,7 +75,7 @@ func TestOpenBinaryInputFileAndClose(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOpenBinaryInputFileErrors(t *testing.T) {

--- a/registry/core/prim_open_binary_output_file_test.go
+++ b/registry/core/prim_open_binary_output_file_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -49,7 +50,7 @@ func TestOpenBinaryOutputFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 
 			// Clean up for next test
 			os.Remove(tmpfile) //nolint:errcheck
@@ -67,7 +68,7 @@ func TestOpenBinaryOutputFileAndClose(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOpenBinaryOutputFileErrors(t *testing.T) {

--- a/registry/core/prim_parameter_test.go
+++ b/registry/core/prim_parameter_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -79,7 +80,7 @@ func TestMakeParameter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -114,7 +115,7 @@ func TestMakeParameterWithConverter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -196,7 +197,7 @@ func TestParameterize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -214,7 +215,7 @@ func TestParameterizeRestoresOnException(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	// After the exception handler runs, we should see 'original
 	// because parameterize should restore the value
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("original"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("original"))
 }
 
 func TestParameterizeWithConverter(t *testing.T) {
@@ -236,7 +237,7 @@ func TestParameterizeWithConverter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -269,7 +270,7 @@ func TestParameterAsProcedure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -314,7 +315,7 @@ func TestParameterMutationViaCall(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -360,7 +361,7 @@ func TestParameterConverterErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -413,7 +414,7 @@ func TestDeeplyNestedParameterize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -457,7 +458,7 @@ func TestParameterizeWithCallCC(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -488,7 +489,7 @@ func TestCurrentPortParameters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_port_extra_test.go
+++ b/registry/core/prim_port_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -25,177 +26,177 @@ import (
 func TestPortPredicateWithInputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (open-input-string "test"))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestPortPredicateWithOutputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (open-output-string))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestPortPredicateWithNonPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? 42)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestPortPredicateWithString(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? "not a port")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestInputPortPredicateWithInputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port? (open-input-string "test"))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestInputPortPredicateWithOutputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port? (open-output-string))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestInputPortPredicateWithNonPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port? 42)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestOutputPortPredicateWithOutputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port? (open-output-string))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOutputPortPredicateWithInputPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port? (open-input-string "test"))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestOutputPortPredicateWithNonPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port? "not a port")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestInputPortOpenPredicate(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port-open? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOutputPortOpenPredicate(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port-open? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObject(t *testing.T) {
 	result, err := runSchemeCode(t, `(eof-object)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.EOFObject)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.EOFObject)
 }
 
 func TestEofObjectPredicateWithEof(t *testing.T) {
 	result, err := runSchemeCode(t, `(eof-object? (eof-object))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestEofObjectPredicateWithNonEof(t *testing.T) {
 	result, err := runSchemeCode(t, `(eof-object? 42)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestEofObjectPredicateWithString(t *testing.T) {
 	result, err := runSchemeCode(t, `(eof-object? "not eof")`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestEofObjectPredicateWithBoolean(t *testing.T) {
 	result, err := runSchemeCode(t, `(eof-object? #f)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestPortPredicatesOnBytevectorPorts(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (open-input-bytevector #u8(1 2 3)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(port? (open-output-bytevector))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(input-port? (open-input-bytevector #u8(1 2 3)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(output-port? (open-output-bytevector))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestPortOpenPredicatesOnBytevectorPorts(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port-open? (open-input-bytevector #u8(1 2 3)))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(output-port-open? (open-output-bytevector))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestPortOpenPredicatesOnStringPorts(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port-open? (open-input-string "test"))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(output-port-open? (open-output-string))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(let ((p (open-input-string "test"))) (close-input-port p) (input-port-open? p))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 
 	result, err = runSchemeCode(t, `(let ((p (open-output-string))) (close-output-port p) (output-port-open? p))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestPortPredicatesWithCurrentPorts(t *testing.T) {
 	result, err := runSchemeCode(t, `(port? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(port? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(input-port? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	result, err = runSchemeCode(t, `(output-port? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestInputPortOpenWithCurrentPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(input-port-open? (current-input-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOutputPortOpenWithCurrentPort(t *testing.T) {
 	result, err := runSchemeCode(t, `(output-port-open? (current-output-port))`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_port_ops_test.go
+++ b/registry/core/prim_port_ops_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -39,7 +40,7 @@ func TestOpenInputFile(t *testing.T) {
 		#t)`, f.Name())
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOpenInputFileAndRead(t *testing.T) {
@@ -58,7 +59,7 @@ func TestOpenInputFileAndRead(t *testing.T) {
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
 	expected := values.List(values.NewSymbol("+"), values.NewInteger(1), values.NewInteger(2))
-	qt.Assert(t, result, values.SchemeEquals, expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, expected)
 }
 
 func TestOpenOutputFile(t *testing.T) {
@@ -71,7 +72,7 @@ func TestOpenOutputFile(t *testing.T) {
 		#t)`, tmpfile)
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	content, err := os.ReadFile(tmpfile)
 	qt.Assert(t, err, qt.IsNil)
@@ -90,7 +91,7 @@ func TestOpenOutputFileWithMultipleWrites(t *testing.T) {
 		#t)`, tmpfile)
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	content, err := os.ReadFile(tmpfile)
 	qt.Assert(t, err, qt.IsNil)
@@ -111,7 +112,7 @@ func TestClosePortWithFileInputPort(t *testing.T) {
 		#t)`, f.Name())
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestClosePortWithFileOutputPort(t *testing.T) {
@@ -124,7 +125,7 @@ func TestClosePortWithFileOutputPort(t *testing.T) {
 		#t)`, tmpfile)
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 
 	content, err := os.ReadFile(tmpfile)
 	qt.Assert(t, err, qt.IsNil)

--- a/registry/core/prim_port_predicates_extra_test.go
+++ b/registry/core/prim_port_predicates_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -51,7 +52,7 @@ func TestPortPredicatesWithEmptyList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -83,7 +84,7 @@ func TestPortPredicatesWithVector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_predicate_test.go
+++ b/registry/core/prim_predicate_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -193,7 +194,7 @@ func TestTypePredicates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -273,7 +274,7 @@ func TestNumericPredicates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_promise_extra_test.go
+++ b/registry/core/prim_promise_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -54,7 +55,7 @@ func TestMakeLazyPromise(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -73,7 +74,7 @@ func TestPromiseMemoization(t *testing.T) {
 	`)
 	qt.Assert(t, err, qt.IsNil)
 	// count should be 1 because the promise body is only evaluated once
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 // TestForceIdempotent tests that force is idempotent
@@ -103,7 +104,7 @@ func TestForceIdempotent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -128,7 +129,7 @@ func TestPromiseWithSideEffects(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -173,7 +174,7 @@ func TestPromiseQEdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -206,7 +207,7 @@ func TestForceWithComplexExpressions(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -237,7 +238,7 @@ func TestMakePromiseIdentity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -290,10 +291,10 @@ func TestDelayForceTailCall(t *testing.T) {
 				// Just verify it returns a pair starting with 10
 				pair, ok := result.(*values.Pair)
 				qt.Assert(t, ok, qt.IsTrue)
-				qt.Assert(t, pair.Car(), values.SchemeEquals, values.NewInteger(10))
+				qt.Assert(t, pair.Car(), valuestest.SchemeEquals, values.NewInteger(10))
 			} else {
 				qt.Assert(t, err, qt.IsNil)
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -340,7 +341,7 @@ func TestForceExceptionInDelayBody(t *testing.T) {
 				qt.Assert(t, err, qt.IsNotNil)
 			} else {
 				qt.Assert(t, err, qt.IsNil)
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -379,7 +380,7 @@ func TestForceCircularPromise(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -417,7 +418,7 @@ func TestMakePromiseEdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_promise_test.go
+++ b/registry/core/prim_promise_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -62,7 +63,7 @@ func TestPromiseQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -98,7 +99,7 @@ func TestMakePromise(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -144,7 +145,7 @@ func TestForce(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -170,7 +171,7 @@ func TestDelayForce(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_read_extra_test.go
+++ b/registry/core/prim_read_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -30,7 +31,7 @@ func TestReadWithExplicitPort(t *testing.T) {
 			(read p))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestReadSyntaxReturnsSyntaxObject(t *testing.T) {
@@ -42,7 +43,7 @@ func TestReadSyntaxReturnsSyntaxObject(t *testing.T) {
 				(syntax->datum stx)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("foo"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("foo"))
 }
 
 func TestReadEOFOnExhaustedPort(t *testing.T) {
@@ -53,7 +54,7 @@ func TestReadEOFOnExhaustedPort(t *testing.T) {
 			(eof-object? (read p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestReadRepeatedEOF(t *testing.T) {
@@ -65,7 +66,7 @@ func TestReadRepeatedEOF(t *testing.T) {
 				(and (eof-object? a) (eof-object? b))))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestReadSyntaxEOFOnExhaustedPort(t *testing.T) {
@@ -75,7 +76,7 @@ func TestReadSyntaxEOFOnExhaustedPort(t *testing.T) {
 			(eof-object? (read-syntax p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestReadTokenEOFOnExhaustedPort(t *testing.T) {
@@ -85,7 +86,7 @@ func TestReadTokenEOFOnExhaustedPort(t *testing.T) {
 			(eof-object? (read-token p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestClosePortThenRead(t *testing.T) {
@@ -98,7 +99,7 @@ func TestClosePortThenRead(t *testing.T) {
 			(eof-object? (read p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestCallWithPortClosesOnReturn(t *testing.T) {
@@ -110,7 +111,7 @@ func TestCallWithPortClosesOnReturn(t *testing.T) {
 			(not (input-port-open? p)))
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestReadTokenReturnsToken(t *testing.T) {
@@ -121,5 +122,5 @@ func TestReadTokenReturnsToken(t *testing.T) {
 				(not (eof-object? tok))))  ; should not be eof
 	`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_real_part_test.go
+++ b/registry/core/prim_real_part_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -42,7 +43,7 @@ func TestRealPartExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_rounding_test.go
+++ b/registry/core/prim_rounding_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -356,7 +357,7 @@ func TestRounding(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tt.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tt.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tt.expected)
 		})
 	}
 }
@@ -494,7 +495,7 @@ func TestFloorQuotient_AllSigns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -512,7 +513,7 @@ func TestFloorRemainder_AllSigns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -530,7 +531,7 @@ func TestTruncateQuotient_AllSigns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -548,7 +549,7 @@ func TestTruncateRemainder_AllSigns(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_special_predicates_test.go
+++ b/registry/core/prim_special_predicates_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -252,7 +253,7 @@ func TestRealPartWithVariousTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_srfi18_time_test.go
+++ b/registry/core/prim_srfi18_time_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -71,7 +72,7 @@ func TestTimeQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -81,7 +82,7 @@ func TestTimeToSeconds(t *testing.T) {
 	code := "(> (time->seconds (current-time)) 0)"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestTimeToSecondsReturnsFloat(t *testing.T) {
@@ -132,7 +133,7 @@ func TestSecondsToTimeRoundTrip(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestSecondsToTimeError(t *testing.T) {
@@ -157,5 +158,5 @@ func TestCurrentTimeIncreasing(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_string_arity_test.go
+++ b/registry/core/prim_string_arity_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -97,7 +98,7 @@ func TestStrings_VariadicZeroArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_string_compare_test.go
+++ b/registry/core/prim_string_compare_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -58,7 +59,7 @@ func TestStringEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -104,7 +105,7 @@ func TestStringLessThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -145,7 +146,7 @@ func TestStringGreaterThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -186,7 +187,7 @@ func TestStringLessThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -227,7 +228,7 @@ func TestStringGreaterThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -271,7 +272,7 @@ func TestStringCIEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -313,7 +314,7 @@ func TestStringCILessThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -350,7 +351,7 @@ func TestStringCIGreaterThan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -387,7 +388,7 @@ func TestStringCILessThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -424,7 +425,7 @@ func TestStringCIGreaterThanOrEqual(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -499,7 +500,7 @@ func TestStringCICompareVariadic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -577,7 +578,7 @@ func TestStringEqualScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -648,7 +649,7 @@ func TestStringLessThanScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -713,7 +714,7 @@ func TestStringGreaterThanScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -768,7 +769,7 @@ func TestStringLessOrEqualScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -828,7 +829,7 @@ func TestStringGreaterOrEqualScheme(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -877,7 +878,7 @@ func TestStringCompareVariadic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_string_port_extra_test.go
+++ b/registry/core/prim_string_port_extra_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -35,7 +36,7 @@ func TestOpenInputStringReadMultiple(t *testing.T) {
 		values.NewSymbol("b"),
 		values.NewSymbol("c"),
 	)
-	qt.Assert(t, result, values.SchemeEquals, expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, expected)
 }
 
 func TestOpenInputStringWithNestedExpressions(t *testing.T) {
@@ -49,7 +50,7 @@ func TestOpenInputStringWithNestedExpressions(t *testing.T) {
 		values.NewSymbol("x"),
 		values.NewInteger(10),
 	)
-	qt.Assert(t, result, values.SchemeEquals, expected)
+	qt.Assert(t, result, valuestest.SchemeEquals, expected)
 }
 
 func TestOpenOutputStringMultipleWrites(t *testing.T) {

--- a/registry/core/prim_string_test.go
+++ b/registry/core/prim_string_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -111,7 +112,7 @@ func TestStringLength(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -137,7 +138,7 @@ func TestStringRef(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -163,7 +164,7 @@ func TestSubstring(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -194,7 +195,7 @@ func TestStringAppend(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -220,7 +221,7 @@ func TestStringToList(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -249,7 +250,7 @@ func TestListToString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -266,7 +267,7 @@ func TestListToStringUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -287,7 +288,7 @@ func TestStringToSymbol(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -309,7 +310,7 @@ func TestStringToSymbolEdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -341,7 +342,7 @@ func TestStringSymbolRoundTrip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -363,7 +364,7 @@ func TestSymbolToString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -385,7 +386,7 @@ func TestSymbolToStringEdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -411,7 +412,7 @@ func TestNumberToString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -437,7 +438,7 @@ func TestStringToNumber(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runProgramAST(t, tc.prog)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -508,7 +509,7 @@ func TestStringLengthExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -535,7 +536,7 @@ func TestStringRefExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -595,7 +596,7 @@ func TestSubstringExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -650,7 +651,7 @@ func TestMakeString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -704,7 +705,7 @@ func TestStringCopy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -775,7 +776,7 @@ func TestStringCase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -817,7 +818,7 @@ func TestStringPredicate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -849,7 +850,7 @@ func TestStringFoldcase(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -903,7 +904,7 @@ func TestStringFoldcaseUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -930,7 +931,7 @@ func TestStringConstructor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1011,7 +1012,7 @@ func TestStringUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1273,7 +1274,7 @@ func TestCharUnicode(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1307,7 +1308,7 @@ func TestStringSet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1360,7 +1361,7 @@ func TestStringFill(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1413,7 +1414,7 @@ func TestStringCopyTo(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1485,7 +1486,7 @@ func TestStringMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1546,7 +1547,7 @@ func TestStringForEach(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1587,7 +1588,7 @@ func TestStringToListOptional(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -1650,7 +1651,7 @@ func TestStringSetMutable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_sync_test.go
+++ b/registry/core/prim_sync_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -53,7 +54,7 @@ func TestWaitGroupQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -61,7 +62,7 @@ func TestWaitGroupQ(t *testing.T) {
 func TestMakeWaitGroup(t *testing.T) {
 	result, err := runSchemeCode(t, "(wait-group? (make-wait-group))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestWaitGroupAddDoneWait(t *testing.T) {
@@ -74,7 +75,7 @@ func TestWaitGroupAddDoneWait(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestWaitGroupAddError(t *testing.T) {
@@ -122,7 +123,7 @@ func TestRWMutexQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -130,14 +131,14 @@ func TestRWMutexQ(t *testing.T) {
 func TestMakeRWMutex(t *testing.T) {
 	result, err := runSchemeCode(t, "(rw-mutex? (make-rw-mutex))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMakeRWMutexWithName(t *testing.T) {
 	// Just test that it doesn't error - RWMutex may not have name accessor
 	result, err := runSchemeCode(t, "(rw-mutex? (make-rw-mutex \"test\"))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestRWMutexReadLockUnlock(t *testing.T) {
@@ -149,7 +150,7 @@ func TestRWMutexReadLockUnlock(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestRWMutexWriteLockUnlock(t *testing.T) {
@@ -161,7 +162,7 @@ func TestRWMutexWriteLockUnlock(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestRWMutexTryReadLock(t *testing.T) {
@@ -171,7 +172,7 @@ func TestRWMutexTryReadLock(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestRWMutexTryWriteLock(t *testing.T) {
@@ -181,7 +182,7 @@ func TestRWMutexTryWriteLock(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestRWMutexReadLockError(t *testing.T) {
@@ -244,7 +245,7 @@ func TestOnceQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -252,7 +253,7 @@ func TestOnceQ(t *testing.T) {
 func TestMakeOnce(t *testing.T) {
 	result, err := runSchemeCode(t, "(once? (make-once))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOnceDo(t *testing.T) {
@@ -263,7 +264,7 @@ func TestOnceDo(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestOnceDoOnlyOnce(t *testing.T) {
@@ -275,7 +276,7 @@ func TestOnceDoOnlyOnce(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestOnceDoError(t *testing.T) {
@@ -308,7 +309,7 @@ func TestOnceDoneQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -348,7 +349,7 @@ func TestAtomicQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -356,14 +357,14 @@ func TestAtomicQ(t *testing.T) {
 func TestMakeAtomic(t *testing.T) {
 	result, err := runSchemeCode(t, "(atomic? (make-atomic 42))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestAtomicLoad(t *testing.T) {
 	code := "(atomic-load (make-atomic 42))"
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestAtomicLoadError(t *testing.T) {
@@ -379,7 +380,7 @@ func TestAtomicStore(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(100))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(100))
 }
 
 func TestAtomicStoreError(t *testing.T) {
@@ -394,7 +395,7 @@ func TestAtomicSwap(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("old"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("old"))
 }
 
 func TestAtomicSwapUpdatesValue(t *testing.T) {
@@ -405,7 +406,7 @@ func TestAtomicSwapUpdatesValue(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("new"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("new"))
 }
 
 func TestAtomicSwapError(t *testing.T) {
@@ -420,7 +421,7 @@ func TestAtomicCompareAndSwapSuccess(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestAtomicCompareAndSwapFailure(t *testing.T) {
@@ -430,7 +431,7 @@ func TestAtomicCompareAndSwapFailure(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.FalseValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.FalseValue)
 }
 
 func TestAtomicCompareAndSwapUpdatesOnSuccess(t *testing.T) {
@@ -441,7 +442,7 @@ func TestAtomicCompareAndSwapUpdatesOnSuccess(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("new"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("new"))
 }
 
 func TestAtomicCompareAndSwapNoUpdateOnFailure(t *testing.T) {
@@ -452,7 +453,7 @@ func TestAtomicCompareAndSwapNoUpdateOnFailure(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("old"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("old"))
 }
 
 func TestAtomicCompareAndSwapError(t *testing.T) {
@@ -491,7 +492,7 @@ func TestAtomicWithDifferentTypes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_thread_test.go
+++ b/registry/core/prim_thread_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -58,7 +59,7 @@ func TestThreadQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -67,7 +68,7 @@ func TestMakeThread(t *testing.T) {
 	// make-thread should return a thread
 	result, err := runSchemeCode(t, "(thread? (make-thread (lambda () 'done)))")
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestMakeThreadWithName(t *testing.T) {
@@ -75,14 +76,14 @@ func TestMakeThreadWithName(t *testing.T) {
 	code := `(thread-name (make-thread (lambda () 'done) "test-thread"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("test-thread"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("test-thread"))
 }
 
 func TestThreadName(t *testing.T) {
 	code := `(thread-name (make-thread (lambda () 42) "my-thread"))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewString("my-thread"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewString("my-thread"))
 }
 
 func TestThreadNameError(t *testing.T) {
@@ -98,7 +99,7 @@ func TestThreadSpecific(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestThreadSpecificSet(t *testing.T) {
@@ -109,7 +110,7 @@ func TestThreadSpecificSet(t *testing.T) {
 	`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("my-data"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("my-data"))
 }
 
 func TestThreadSpecificError(t *testing.T) {
@@ -131,7 +132,7 @@ func TestThreadStartAndJoin(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(6))
 }
 
 func TestThreadStartReturnsThread(t *testing.T) {
@@ -141,7 +142,7 @@ func TestThreadStartReturnsThread(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestThreadStartError(t *testing.T) {
@@ -184,7 +185,7 @@ func TestThreadTerminate(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }
 
 func TestThreadTerminateError(t *testing.T) {
@@ -214,7 +215,7 @@ func TestThreadJoinWithTimeout(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("timed-out"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("timed-out"))
 }
 
 func TestMultipleThreads(t *testing.T) {
@@ -232,5 +233,5 @@ func TestMultipleThreads(t *testing.T) {
 	`
 	result, err := runSchemeCodeWithTimeout(t, code, 5*time.Second)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(6))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(6))
 }

--- a/registry/core/prim_trig_test.go
+++ b/registry/core/prim_trig_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -75,7 +76,7 @@ func TestSin(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -113,7 +114,7 @@ func TestCos(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -145,7 +146,7 @@ func TestTan(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -183,7 +184,7 @@ func TestAsin(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -221,7 +222,7 @@ func TestAcos(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -265,7 +266,7 @@ func TestAtan(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -303,7 +304,7 @@ func TestExp(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -346,7 +347,7 @@ func TestLog(t *testing.T) {
 			if tc.tolerance > 0 {
 				qt.Assert(t, withinTolerance(t, result, tc.out, tc.tolerance), qt.IsTrue)
 			} else {
-				qt.Assert(t, result, values.SchemeEquals, tc.out)
+				qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}

--- a/registry/core/prim_utf8_test.go
+++ b/registry/core/prim_utf8_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -48,7 +49,7 @@ func TestStringToUtf8Basic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -84,7 +85,7 @@ func TestStringToUtf8WithIndices(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -120,7 +121,7 @@ func TestStringToUtf8VerifyBytes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -151,7 +152,7 @@ func TestUtf8ToStringBasic(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -187,7 +188,7 @@ func TestUtf8ToStringWithIndices(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -218,7 +219,7 @@ func TestUtf8ToStringVerifyResult(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -254,7 +255,7 @@ func TestUtf8RoundTrip(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -285,7 +286,7 @@ func TestUtf8WithMultiByteCharacters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
@@ -316,7 +317,7 @@ func TestUtf8EdgeCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_values_test.go
+++ b/registry/core/prim_values_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -43,7 +44,7 @@ func TestValuesComprehensive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_vector_test.go
+++ b/registry/core/prim_vector_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -39,7 +40,7 @@ func TestVector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -60,7 +61,7 @@ func TestMakeVectorExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -91,7 +92,7 @@ func TestVectorLengthExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -123,7 +124,7 @@ func TestVectorRefExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -162,7 +163,7 @@ func TestVectorSet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -220,7 +221,7 @@ func TestListToVectorExtended(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -259,7 +260,7 @@ func TestVectorCopy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -272,7 +273,7 @@ func TestVectorCopy_Independence(t *testing.T) {
                  (vector-ref orig 0)))`
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestVectorCopy_Errors(t *testing.T) {
@@ -314,7 +315,7 @@ func TestVectorCopyTo(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -357,7 +358,7 @@ func TestVectorFill(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -399,7 +400,7 @@ func TestVectorAppend(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -446,7 +447,7 @@ func TestVectorMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -496,7 +497,7 @@ func TestVectorForEach(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -529,7 +530,7 @@ func TestVectorToString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }
@@ -570,7 +571,7 @@ func TestStringToVector(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.expected)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/core/prim_void_q_test.go
+++ b/registry/core/prim_void_q_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -78,7 +79,7 @@ func TestVoidQ(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			qt.Assert(t, err, qt.IsNil)
-			qt.Assert(t, result, values.SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }

--- a/registry/core/prim_with_input_from_file_test.go
+++ b/registry/core/prim_with_input_from_file_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -42,7 +43,7 @@ func TestWithInputFromFile(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewInteger(42))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestWithInputFromFileReturnsResult(t *testing.T) {
@@ -59,7 +60,7 @@ func TestWithInputFromFileReturnsResult(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("done"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("done"))
 }
 
 func TestWithInputFromFileErrors(t *testing.T) {

--- a/registry/core/prim_with_output_to_file_test.go
+++ b/registry/core/prim_with_output_to_file_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -54,7 +55,7 @@ func TestWithOutputToFileReturnsResult(t *testing.T) {
 
 	result, err := runSchemeCode(t, code)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.NewSymbol("result"))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewSymbol("result"))
 }
 
 func TestWithOutputToFileErrors(t *testing.T) {

--- a/registry/core/prim_write_shared_test.go
+++ b/registry/core/prim_write_shared_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -82,5 +83,5 @@ func TestWriteSharedDefaultPort(t *testing.T) {
 	// write-shared with only one argument should use current-output-port
 	result, err := runSchemeCode(t, `(begin (write-shared 42) #t)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/prim_write_simple_test.go
+++ b/registry/core/prim_write_simple_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -111,5 +112,5 @@ func TestWriteSimpleDefaultPort(t *testing.T) {
 	// We can't easily capture stdout, so we just verify it doesn't error
 	result, err := runSchemeCode(t, `(begin (write-simple 42) #t)`)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, result, values.SchemeEquals, values.TrueValue)
+	qt.Assert(t, result, valuestest.SchemeEquals, values.TrueValue)
 }

--- a/registry/core/void_as_argument_test.go
+++ b/registry/core/void_as_argument_test.go
@@ -20,6 +20,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestVoidReturningExpressionAsArgument is a regression test for a bug where
@@ -100,7 +101,7 @@ func TestVoidReturningExpressionAsArgument(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := runSchemeCode(t, tc.code)
 			c.Assert(err, qt.IsNil)
-			c.Assert(result, values.SchemeEquals, tc.expected)
+			c.Assert(result, valuestest.SchemeEquals, tc.expected)
 		})
 	}
 }

--- a/registry/helpers/char_test.go
+++ b/registry/helpers/char_test.go
@@ -21,6 +21,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func charLT(a, b rune) bool {
@@ -85,7 +86,7 @@ func TestCharCompare(t *testing.T) {
 			mc := makeMC(tc.a, tc.b)
 			err := CharCompare(mc, "test", tc.cmp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -186,7 +187,7 @@ func TestCharCompareVariadic(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := CharCompareVariadic(mc, "test", tc.cmp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/helpers/integer_test.go
+++ b/registry/helpers/integer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aalpar/wile/environment"
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // makeMC constructs a MachineContext with the given values as local bindings.
@@ -332,7 +333,7 @@ func TestIntegerFold_GCD(t *testing.T) {
 			mc := makeMC(tc.args)
 			err := IntegerFold(mc, FoldOpGCD, 0, gcdCombiner)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -367,7 +368,7 @@ func TestIntegerFold_GCD_Inexact(t *testing.T) {
 			mc := makeMC(tc.args)
 			err := IntegerFold(mc, FoldOpGCD, 0, gcdCombiner)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -436,7 +437,7 @@ func TestIntegerFold_LCM(t *testing.T) {
 			mc := makeMC(tc.args)
 			err := IntegerFold(mc, FoldOpLCM, 1, lcmCombiner)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -512,7 +513,7 @@ func TestIntegerFold_LCM_Inexact(t *testing.T) {
 			mc := makeMC(tc.args)
 			err := IntegerFold(mc, FoldOpLCM, 1, lcmCombiner)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/helpers/list_test.go
+++ b/registry/helpers/list_test.go
@@ -21,6 +21,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // ── ListToVector ─────────────────────────────────────────────────────
@@ -60,7 +61,7 @@ func TestListToVector(t *testing.T) {
 			mc := makeMC(tc.arg)
 			err := ListToVector(mc, "test")
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -233,7 +234,7 @@ func TestAssocLookup(t *testing.T) {
 			mc := makeMC(tc.key, tc.list)
 			err := AssocLookup(mc, "test", tc.eq)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/helpers/numeric_test.go
+++ b/registry/helpers/numeric_test.go
@@ -22,6 +22,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // ── binOps used by tests ─────────────────────────────────────────────
@@ -141,7 +142,7 @@ func TestNumericFoldVariadic(t *testing.T) {
 			mc := makeMC(tc.args)
 			err := NumericFoldVariadic(mc, "test", tc.identity, tc.binOp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -256,7 +257,7 @@ func TestNumericFoldWithFirst(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := NumericFoldWithFirst(mc, "test", tc.unaryOp, tc.binOp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -382,7 +383,7 @@ func TestNumericChainCompare(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := NumericChainCompare(mc, "test", tc.fails)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -467,7 +468,7 @@ func TestNumericChainCompareReal(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := NumericChainCompareReal(mc, "test", tc.fails)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -585,7 +586,7 @@ func TestNumericExtremum(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := NumericExtremum(mc, "test", tc.isBetter)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -713,7 +714,7 @@ func TestMaybeToInexact(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			result := MaybeToInexact(tc.n, tc.hasInexact)
-			c.Assert(result, values.SchemeEquals, tc.want)
+			c.Assert(result, valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/helpers/sequence_test.go
+++ b/registry/helpers/sequence_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aalpar/wile/machine"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // ── SequenceLength ───────────────────────────────────────────────────
@@ -56,7 +57,7 @@ func TestSequenceLength_Vector(t *testing.T) {
 			mc := makeMC(tc.vec)
 			err := SequenceLength[*values.Vector](mc, values.ErrNotAVector, "vector-length")
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -86,7 +87,7 @@ func TestSequenceLength_ByteVector(t *testing.T) {
 			mc := makeMC(tc.bv)
 			err := SequenceLength[*values.ByteVector](mc, values.ErrNotAByteVector, "bytevector-length")
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -147,7 +148,7 @@ func TestSequenceRef_Vector(t *testing.T) {
 			mc := makeMC(vec, tc.idx)
 			err := SequenceRef[*values.Vector](mc, values.ErrNotAVector, "vector-ref", vectorGet)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -240,7 +241,7 @@ func TestSequenceSet_Vector(t *testing.T) {
 			err := SequenceSet[*values.Vector](mc, values.ErrNotAVector, "vector-set!", vectorSet)
 			c.Assert(err, qt.IsNil)
 			c.Assert(mc.GetValue(), qt.Equals, values.Void)
-			c.Assert(vec.Get(int(tc.idx)), values.SchemeEquals, tc.wantAt)
+			c.Assert(vec.Get(int(tc.idx)), valuestest.SchemeEquals, tc.wantAt)
 		})
 	}
 }

--- a/registry/helpers/string_test.go
+++ b/registry/helpers/string_test.go
@@ -21,6 +21,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func strLT(a, b string) bool {
@@ -92,7 +93,7 @@ func TestStringCompare(t *testing.T) {
 			mc := makeMC(tc.a, tc.b)
 			err := StringCompare(mc, "test", tc.cmp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -193,7 +194,7 @@ func TestStringCompareVariadic(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := StringCompareVariadic(mc, "test", tc.cmp)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/helpers/type_test.go
+++ b/registry/helpers/type_test.go
@@ -22,6 +22,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // ── MakeTypePredicate ────────────────────────────────────────────────
@@ -50,7 +51,7 @@ func TestMakeTypePredicate(t *testing.T) {
 			mc := makeMC(tc.arg)
 			err := isInteger(context.Background(), mc)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -83,7 +84,7 @@ func TestMakeNumericPredicate(t *testing.T) {
 			mc := makeMC(tc.arg)
 			err := isExact(context.Background(), mc)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -177,7 +178,7 @@ func TestChainEquality(t *testing.T) {
 			mc := makeMC(tc.arg0, tc.arg1)
 			err := ChainEquality(mc, "boolean=?", boolTypeCheck, boolEquals)
 			c.Assert(err, qt.IsNil)
-			c.Assert(mc.GetValue(), values.SchemeEquals, tc.want)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/registry/testhelpers/doc.go
+++ b/registry/testhelpers/doc.go
@@ -18,7 +18,7 @@
 //
 //	result, err := testhelpers.RunSchemeCode(t, "(+ 1 2)")
 //	c.Assert(err, qt.IsNil)
-//	c.Assert(result, values.SchemeEquals, values.NewInteger(3))
+//	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(3))
 //
 // # Helpers
 //

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/runtime"
 	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func newEnv(t *testing.T) *environment.EnvironmentFrame {
@@ -103,7 +104,7 @@ func TestRun(t *testing.T) {
 			result, err := runtime.Run(context.Background(), tpl, env)
 			c.Assert(err, qt.IsNil)
 			c.Assert(len(result) > 0, qt.IsTrue)
-			c.Assert(result[0], values.SchemeEquals, tc.want)
+			c.Assert(result[0], valuestest.SchemeEquals, tc.want)
 		})
 	}
 }

--- a/values/array_list_test.go
+++ b/values/array_list_test.go
@@ -12,29 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"context"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestArrayList_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  *ArrayList
+		in  *values.ArrayList
 		out string
 	}{
 		{nil, "#<void>"},
-		{NewArrayList(EmptyList), "()"},
-		{NewArrayList(NewCons(nil, nil)), "(#<void> . #<void>)"},
-		{NewArrayList(NewArrayList(EmptyList)), "()"},
-		{NewArrayList(EmptyList), "()"},
-		{NewArrayList(NewInteger(1), NewInteger(2), EmptyList), "(1 2)"},
-		{NewArrayList(NewInteger(1), NewInteger(2), NewInteger(3), EmptyList), "(1 2 3)"},
-		{NewArrayList(NewArrayList(NewInteger(1), NewInteger(2)), EmptyList), "((1 . 2))"},
-		{NewArrayList(NewArrayList(NewInteger(1), nil), EmptyList), "((1 . #<void>))"},
+		{values.NewArrayList(values.EmptyList), "()"},
+		{values.NewArrayList(values.NewCons(nil, nil)), "(#<void> . #<void>)"},
+		{values.NewArrayList(values.NewArrayList(values.EmptyList)), "()"},
+		{values.NewArrayList(values.EmptyList), "()"},
+		{values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.EmptyList), "(1 2)"},
+		{values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3), values.EmptyList), "(1 2 3)"},
+		{values.NewArrayList(values.NewArrayList(values.NewInteger(1), values.NewInteger(2)), values.EmptyList), "((1 . 2))"},
+		{values.NewArrayList(values.NewArrayList(values.NewInteger(1), nil), values.EmptyList), "((1 . #<void>))"},
 	}
 
 	for _, tc := range tcs {
@@ -47,83 +50,83 @@ func TestArrayList_SchemeString(t *testing.T) {
 
 func TestArrayLis_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 *ArrayList
-		in1 *ArrayList
+		in0 *values.ArrayList
+		in1 *values.ArrayList
 		out bool
 	}{
 		{
-			in0: (*ArrayList)(nil),
-			in1: (*ArrayList)(nil),
+			in0: (*values.ArrayList)(nil),
+			in1: (*values.ArrayList)(nil),
 			out: true,
 		},
 		{
-			in0: NewArrayList(EmptyList),
-			in1: NewArrayList(EmptyList),
+			in0: values.NewArrayList(values.EmptyList),
+			in1: values.NewArrayList(values.EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(EmptyList),
-			in1: NewArrayList(EmptyList),
+			in0: values.NewArrayList(values.EmptyList),
+			in1: values.NewArrayList(values.EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), EmptyList),
-			in1: NewArrayList(NewInteger(10), EmptyList),
+			in0: values.NewArrayList(values.NewInteger(10), values.EmptyList),
+			in1: values.NewArrayList(values.NewInteger(10), values.EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), (*Pair)(nil)),
-			in1: NewArrayList(NewInteger(10), Value(nil)),
+			in0: values.NewArrayList(values.NewInteger(10), (*values.Pair)(nil)),
+			in1: values.NewArrayList(values.NewInteger(10), values.Value(nil)),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), (*Pair)(nil)),
-			in1: NewArrayList(NewInteger(10), Void),
+			in0: values.NewArrayList(values.NewInteger(10), (*values.Pair)(nil)),
+			in1: values.NewArrayList(values.NewInteger(10), values.Void),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList),
-			in1: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList),
+			in0: values.NewArrayList(values.NewArrayList(values.NewInteger(10), values.EmptyList), values.EmptyList),
+			in1: values.NewArrayList(values.NewArrayList(values.NewInteger(10), values.EmptyList), values.EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
-			in1: NewArrayList(NewInteger(10), NewInteger(30), EmptyList),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(30), values.EmptyList),
 			out: false,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(30), EmptyList),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(30), values.EmptyList),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
 			out: false,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 			out: true,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
 			out: false,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 			out: false,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), Void),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.Void),
 			out: false,
 		},
 		{
-			in0: NewArrayList(NewInteger(10), NewInteger(20), Void),
-			in1: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in0: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.Void),
+			in1: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 			out: false,
 		},
 	}
@@ -137,16 +140,16 @@ func TestArrayLis_EqualTo(t *testing.T) {
 
 func TestArrayList_IsList(t *testing.T) {
 	tcs := []struct {
-		in  *ArrayList
+		in  *values.ArrayList
 		out bool
 	}{
 		{in: nil, out: false},
-		{in: NewArrayList(EmptyList), out: true},
-		{in: NewArrayList(NewInteger(10), EmptyList), out: true},
-		{in: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList), out: true},
-		{in: NewArrayList(NewInteger(10), NewInteger(20), EmptyList), out: true},
+		{in: values.NewArrayList(values.EmptyList), out: true},
+		{in: values.NewArrayList(values.NewInteger(10), values.EmptyList), out: true},
+		{in: values.NewArrayList(values.NewArrayList(values.NewInteger(10), values.EmptyList), values.EmptyList), out: true},
+		{in: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList), out: true},
 		{
-			in:  NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in:  values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 			out: false,
 		},
 	}
@@ -160,7 +163,7 @@ func TestArrayList_IsList(t *testing.T) {
 
 func TestArrayLis_Length(t *testing.T) {
 	tcs := []struct {
-		in           *ArrayList
+		in           *values.ArrayList
 		out          int
 		panicMatches string
 	}{
@@ -169,12 +172,12 @@ func TestArrayLis_Length(t *testing.T) {
 			panicMatches: "not a list",
 			out:          -1,
 		},
-		{in: NewArrayList(EmptyList), out: 0},
-		{in: NewArrayList(NewInteger(10), EmptyList), out: 1},
-		{in: NewArrayList(NewArrayList(NewInteger(10), EmptyList), EmptyList), out: 1},
-		{in: NewArrayList(NewInteger(10), NewInteger(20), EmptyList), out: 2},
+		{in: values.NewArrayList(values.EmptyList), out: 0},
+		{in: values.NewArrayList(values.NewInteger(10), values.EmptyList), out: 1},
+		{in: values.NewArrayList(values.NewArrayList(values.NewInteger(10), values.EmptyList), values.EmptyList), out: 1},
+		{in: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList), out: 2},
 		{
-			in:           NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in:           values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 			panicMatches: "not a list",
 			out:          -1,
 		},
@@ -193,11 +196,11 @@ func TestArrayLis_Length(t *testing.T) {
 
 func TestArrayLis_IsVoid(t *testing.T) {
 	tcs := []struct {
-		in  *ArrayList
+		in  *values.ArrayList
 		out bool
 	}{
 		{in: nil, out: true},
-		{in: NewArrayList(EmptyList), out: false},
+		{in: values.NewArrayList(values.EmptyList), out: false},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
@@ -209,11 +212,11 @@ func TestArrayLis_IsVoid(t *testing.T) {
 
 func TestArrayLis_IsEmptyList(t *testing.T) {
 	tcs := []struct {
-		in  *ArrayList
+		in  *values.ArrayList
 		out bool
 	}{
 		{in: nil, out: false},
-		{in: NewArrayList(EmptyList), out: true},
+		{in: values.NewArrayList(values.EmptyList), out: true},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
@@ -225,46 +228,46 @@ func TestArrayLis_IsEmptyList(t *testing.T) {
 
 func TestArrayList_Append(t *testing.T) {
 	tcs := []struct {
-		in           *ArrayList
-		vs           *ArrayList
-		out          *ArrayList
+		in           *values.ArrayList
+		vs           *values.ArrayList
+		out          *values.ArrayList
 		panicMatches string
 	}{
 		{
-			in:           (*ArrayList)(nil),
-			vs:           (*ArrayList)(nil),
-			out:          (*ArrayList)(nil),
+			in:           (*values.ArrayList)(nil),
+			vs:           (*values.ArrayList)(nil),
+			out:          (*values.ArrayList)(nil),
 			panicMatches: "not a list",
 		},
 		{
-			in:  NewArrayList(EmptyList),
-			vs:  (*ArrayList)(nil),
-			out: (*ArrayList)(nil),
+			in:  values.NewArrayList(values.EmptyList),
+			vs:  (*values.ArrayList)(nil),
+			out: (*values.ArrayList)(nil),
 		},
 		{
-			in:  NewArrayList(EmptyList),
-			vs:  (*ArrayList)(nil),
-			out: (*ArrayList)(nil),
+			in:  values.NewArrayList(values.EmptyList),
+			vs:  (*values.ArrayList)(nil),
+			out: (*values.ArrayList)(nil),
 		},
 		{
-			in:  NewArrayList(EmptyList),
-			vs:  NewArrayList(NewInteger(10), EmptyList),
-			out: NewArrayList(NewInteger(10), EmptyList),
+			in:  values.NewArrayList(values.EmptyList),
+			vs:  values.NewArrayList(values.NewInteger(10), values.EmptyList),
+			out: values.NewArrayList(values.NewInteger(10), values.EmptyList),
 		},
 		{
-			in:  NewArrayList(NewInteger(10), EmptyList),
-			vs:  NewArrayList(EmptyList),
-			out: NewArrayList(NewInteger(10), EmptyList),
+			in:  values.NewArrayList(values.NewInteger(10), values.EmptyList),
+			vs:  values.NewArrayList(values.EmptyList),
+			out: values.NewArrayList(values.NewInteger(10), values.EmptyList),
 		},
 		{
-			in:  NewArrayList(NewInteger(10), EmptyList),
-			vs:  NewArrayList(NewInteger(20), EmptyList),
-			out: NewArrayList(NewInteger(10), NewInteger(20), EmptyList),
+			in:  values.NewArrayList(values.NewInteger(10), values.EmptyList),
+			vs:  values.NewArrayList(values.NewInteger(20), values.EmptyList),
+			out: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.EmptyList),
 		},
 		{
-			in:  NewArrayList(NewInteger(10), EmptyList),
-			vs:  NewArrayList(NewInteger(20), NewInteger(30)),
-			out: NewArrayList(NewInteger(10), NewInteger(20), NewInteger(30)),
+			in:  values.NewArrayList(values.NewInteger(10), values.EmptyList),
+			vs:  values.NewArrayList(values.NewInteger(20), values.NewInteger(30)),
+			out: values.NewArrayList(values.NewInteger(10), values.NewInteger(20), values.NewInteger(30)),
 		},
 	}
 	for _, tc := range tcs {
@@ -275,7 +278,7 @@ func TestArrayList_Append(t *testing.T) {
 				}, qt.PanicMatches, tc.panicMatches)
 			} else {
 				got := tc.in.AppendList(tc.vs)
-				qt.Assert(t, got, SchemeEquals, tc.out)
+				qt.Assert(t, got, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -283,45 +286,45 @@ func TestArrayList_Append(t *testing.T) {
 
 func TestArrayList_AsList(t *testing.T) {
 	tcs := []struct {
-		in  *ArrayList
-		out Value
+		in  *values.ArrayList
+		out values.Value
 	}{
 		{
-			in:  NewArrayList(NewSymbol("first"), NewSymbol("second"), NewSymbol("third"), EmptyList),
-			out: List(NewSymbol("first"), NewSymbol("second"), NewSymbol("third")),
+			in:  values.NewArrayList(values.NewSymbol("first"), values.NewSymbol("second"), values.NewSymbol("third"), values.EmptyList),
+			out: values.List(values.NewSymbol("first"), values.NewSymbol("second"), values.NewSymbol("third")),
 		},
 		{
-			in:  NewArrayList(NewSymbol("first"), NewSymbol("second"), EmptyList),
-			out: List(NewSymbol("first"), NewSymbol("second")),
+			in:  values.NewArrayList(values.NewSymbol("first"), values.NewSymbol("second"), values.EmptyList),
+			out: values.List(values.NewSymbol("first"), values.NewSymbol("second")),
 		},
 		{
-			in:  NewArrayList(NewSymbol("first"), EmptyList),
-			out: List(NewSymbol("first")),
+			in:  values.NewArrayList(values.NewSymbol("first"), values.EmptyList),
+			out: values.List(values.NewSymbol("first")),
 		},
 		{
-			in:  NewArrayList(NewSymbol("first"), NewSymbol("cdr")),
-			out: NewCons(NewSymbol("first"), NewSymbol("cdr")),
+			in:  values.NewArrayList(values.NewSymbol("first"), values.NewSymbol("cdr")),
+			out: values.NewCons(values.NewSymbol("first"), values.NewSymbol("cdr")),
 		},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
 			q := tc.in.AsList()
-			qt.Assert(t, q, SchemeEquals, tc.out)
+			qt.Assert(t, q, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
 
 func TestArrayList_Datum(t *testing.T) {
-	a := NewArrayList(NewInteger(1), NewInteger(2))
+	a := values.NewArrayList(values.NewInteger(1), values.NewInteger(2))
 	datum := a.Datum()
 	qt.Assert(t, len(datum), qt.Equals, 2)
-	qt.Assert(t, datum[0], SchemeEquals, NewInteger(1))
-	qt.Assert(t, datum[1], SchemeEquals, NewInteger(2))
+	qt.Assert(t, datum[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, datum[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestArrayList_Car(t *testing.T) {
-	a := NewArrayList(NewInteger(42), NewInteger(99))
-	qt.Assert(t, a.Car(), SchemeEquals, NewInteger(42))
+	a := values.NewArrayList(values.NewInteger(42), values.NewInteger(99))
+	qt.Assert(t, a.Car(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestArrayList_Cdr(t *testing.T) {
@@ -329,41 +332,41 @@ func TestArrayList_Cdr(t *testing.T) {
 
 	t.Run("proper list", func(t *testing.T) {
 		// (1 2 3)
-		a := NewArrayList(NewInteger(1), NewInteger(2), NewInteger(3), EmptyList)
+		a := values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3), values.EmptyList)
 		cdr := a.Cdr()
-		cdrList, ok := cdr.(*ArrayList)
+		cdrList, ok := cdr.(*values.ArrayList)
 		c.Assert(ok, qt.IsTrue, qt.Commentf("Cdr of multi-element proper list should return ArrayList"))
 		c.Assert(len(*cdrList), qt.Equals, 3)
-		c.Assert((*cdrList)[0], SchemeEquals, NewInteger(2))
-		c.Assert((*cdrList)[1], SchemeEquals, NewInteger(3))
-		c.Assert((*cdrList)[2], SchemeEquals, EmptyList)
+		c.Assert((*cdrList)[0], valuestest.SchemeEquals, values.NewInteger(2))
+		c.Assert((*cdrList)[1], valuestest.SchemeEquals, values.NewInteger(3))
+		c.Assert((*cdrList)[2], valuestest.SchemeEquals, values.EmptyList)
 	})
 
 	t.Run("improper list", func(t *testing.T) {
 		// (42 . 99)
-		a := NewArrayList(NewInteger(42), NewInteger(99))
+		a := values.NewArrayList(values.NewInteger(42), values.NewInteger(99))
 		cdr := a.Cdr()
 		// Should return the direct value, not wrapped in ArrayList
-		c.Assert(cdr, SchemeEquals, NewInteger(99), qt.Commentf("Cdr of improper list should return terminator directly"))
+		c.Assert(cdr, valuestest.SchemeEquals, values.NewInteger(99), qt.Commentf("Cdr of improper list should return terminator directly"))
 	})
 
 	t.Run("single element proper list", func(t *testing.T) {
 		// (42)
-		a := NewArrayList(NewInteger(42), EmptyList)
+		a := values.NewArrayList(values.NewInteger(42), values.EmptyList)
 		cdr := a.Cdr()
-		c.Assert(cdr, SchemeEquals, EmptyList, qt.Commentf("Cdr of (42) should return EmptyList"))
+		c.Assert(cdr, valuestest.SchemeEquals, values.EmptyList, qt.Commentf("Cdr of (42) should return EmptyList"))
 	})
 }
 
 func TestArrayList_ForEach(t *testing.T) {
 	// ArrayList: [1, 2, EmptyList] - proper list (1 2)
 	// ForEach should visit elements 1 and 2, NOT the EmptyList terminator
-	a := NewArrayList(NewInteger(1), NewInteger(2), EmptyList)
+	a := values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.EmptyList)
 	count := 0
 	sum := int64(0)
-	a.ForEach(context.TODO(), func(_ context.Context, _ int, _ bool, v Value) error { //nolint:errcheck
+	a.ForEach(context.TODO(), func(_ context.Context, _ int, _ bool, v values.Value) error { //nolint:errcheck
 		count++
-		intVal, ok := v.(*Integer)
+		intVal, ok := v.(*values.Integer)
 		if ok {
 			sum += intVal.Value
 		}
@@ -380,85 +383,85 @@ func TestArrayList_ForEach_TupleContract(t *testing.T) {
 
 	t.Run("proper list - terminator not visited", func(t *testing.T) {
 		// ArrayList: [5, 10, EmptyList]
-		list := NewArrayList(NewInteger(5), NewInteger(10), EmptyList)
+		list := values.NewArrayList(values.NewInteger(5), values.NewInteger(10), values.EmptyList)
 
-		visited := []Value{}
-		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		visited := []values.Value{}
+		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			visited = append(visited, v)
 			return nil
 		})
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(visited), qt.Equals, 2, qt.Commentf("should visit 2 elements, not 3"))
-		c.Assert(visited[0], SchemeEquals, NewInteger(5))
-		c.Assert(visited[1], SchemeEquals, NewInteger(10))
-		c.Assert(tail, SchemeEquals, EmptyList, qt.Commentf("should return EmptyList as tail"))
+		c.Assert(visited[0], valuestest.SchemeEquals, values.NewInteger(5))
+		c.Assert(visited[1], valuestest.SchemeEquals, values.NewInteger(10))
+		c.Assert(tail, valuestest.SchemeEquals, values.EmptyList, qt.Commentf("should return EmptyList as tail"))
 	})
 
 	t.Run("improper list - terminator not visited", func(t *testing.T) {
 		// ArrayList: [5, 10, 999] (improper, 999 is the cdr)
-		improperCdr := NewInteger(999)
-		list := NewArrayList(NewInteger(5), NewInteger(10), improperCdr)
+		improperCdr := values.NewInteger(999)
+		list := values.NewArrayList(values.NewInteger(5), values.NewInteger(10), improperCdr)
 
-		visited := []Value{}
-		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		visited := []values.Value{}
+		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			visited = append(visited, v)
 			return nil
 		})
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(visited), qt.Equals, 2, qt.Commentf("should visit 2 elements, not 3"))
-		c.Assert(visited[0], SchemeEquals, NewInteger(5))
-		c.Assert(visited[1], SchemeEquals, NewInteger(10))
-		c.Assert(tail, SchemeEquals, improperCdr, qt.Commentf("should return improper cdr as tail"))
+		c.Assert(visited[0], valuestest.SchemeEquals, values.NewInteger(5))
+		c.Assert(visited[1], valuestest.SchemeEquals, values.NewInteger(10))
+		c.Assert(tail, valuestest.SchemeEquals, improperCdr, qt.Commentf("should return improper cdr as tail"))
 	})
 
 	t.Run("single element list", func(t *testing.T) {
 		// ArrayList: [42, EmptyList]
-		list := NewArrayList(NewInteger(42), EmptyList)
+		list := values.NewArrayList(values.NewInteger(42), values.EmptyList)
 
-		visited := []Value{}
-		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		visited := []values.Value{}
+		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			visited = append(visited, v)
 			return nil
 		})
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(visited), qt.Equals, 1)
-		c.Assert(visited[0], SchemeEquals, NewInteger(42))
-		c.Assert(tail, SchemeEquals, EmptyList)
+		c.Assert(visited[0], valuestest.SchemeEquals, values.NewInteger(42))
+		c.Assert(tail, valuestest.SchemeEquals, values.EmptyList)
 	})
 
 	t.Run("empty list", func(t *testing.T) {
 		// ArrayList: [EmptyList] (just the terminator)
-		list := NewArrayList(EmptyList)
+		list := values.NewArrayList(values.EmptyList)
 
-		visited := []Value{}
-		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		visited := []values.Value{}
+		tail, err := list.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			visited = append(visited, v)
 			return nil
 		})
 
 		c.Assert(err, qt.IsNil)
 		c.Assert(len(visited), qt.Equals, 0, qt.Commentf("empty list should not visit any elements"))
-		c.Assert(tail, SchemeEquals, EmptyList)
+		c.Assert(tail, valuestest.SchemeEquals, values.EmptyList)
 	})
 
 	t.Run("matches Pair.ForEach semantics", func(t *testing.T) {
 		// Create equivalent Pair and ArrayList for (5 10)
-		pair := List(NewInteger(5), NewInteger(10))
-		arraylist := NewArrayList(NewInteger(5), NewInteger(10), EmptyList)
+		pair := values.List(values.NewInteger(5), values.NewInteger(10))
+		arraylist := values.NewArrayList(values.NewInteger(5), values.NewInteger(10), values.EmptyList)
 
 		// Collect elements from Pair
-		pairElements := []Value{}
-		pairTail, pairErr := pair.(*Pair).ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		pairElements := []values.Value{}
+		pairTail, pairErr := pair.(*values.Pair).ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			pairElements = append(pairElements, v)
 			return nil
 		})
 
 		// Collect elements from ArrayList
-		arraylistElements := []Value{}
-		arraylistTail, arraylistErr := arraylist.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v Value) error {
+		arraylistElements := []values.Value{}
+		arraylistTail, arraylistErr := arraylist.ForEach(context.Background(), func(_ context.Context, _ int, _ bool, v values.Value) error {
 			arraylistElements = append(arraylistElements, v)
 			return nil
 		})
@@ -467,28 +470,28 @@ func TestArrayList_ForEach_TupleContract(t *testing.T) {
 		c.Assert(pairErr, qt.IsNil)
 		c.Assert(arraylistErr, qt.IsNil)
 		c.Assert(len(arraylistElements), qt.Equals, len(pairElements), qt.Commentf("should visit same number of elements"))
-		c.Assert(arraylistElements[0], SchemeEquals, pairElements[0])
-		c.Assert(arraylistElements[1], SchemeEquals, pairElements[1])
-		c.Assert(arraylistTail, SchemeEquals, pairTail, qt.Commentf("should return same tail"))
+		c.Assert(arraylistElements[0], valuestest.SchemeEquals, pairElements[0])
+		c.Assert(arraylistElements[1], valuestest.SchemeEquals, pairElements[1])
+		c.Assert(arraylistTail, valuestest.SchemeEquals, pairTail, qt.Commentf("should return same tail"))
 	})
 }
 
 func TestArrayList_AsVector(t *testing.T) {
-	a := NewArrayList(NewInteger(1), NewInteger(2), NewInteger(3))
+	a := values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
 	v := a.AsVector()
 	qt.Assert(t, len(*v), qt.Equals, 3)
-	qt.Assert(t, (*v)[0], SchemeEquals, NewInteger(1))
-	qt.Assert(t, (*v)[1], SchemeEquals, NewInteger(2))
-	qt.Assert(t, (*v)[2], SchemeEquals, NewInteger(3))
+	qt.Assert(t, (*v)[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, (*v)[1], valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, (*v)[2], valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 func TestArrayList_Append_Single(t *testing.T) {
-	a := NewArrayList(NewInteger(1), NewInteger(2))
-	result := a.Append(NewInteger(3))
-	resultList, ok := result.(*ArrayList)
+	a := values.NewArrayList(values.NewInteger(1), values.NewInteger(2))
+	result := a.Append(values.NewInteger(3))
+	resultList, ok := result.(*values.ArrayList)
 	qt.Assert(t, ok, qt.IsTrue)
 	qt.Assert(t, len(*resultList), qt.Equals, 3)
-	qt.Assert(t, (*resultList)[2], SchemeEquals, NewInteger(3))
+	qt.Assert(t, (*resultList)[2], valuestest.SchemeEquals, values.NewInteger(3))
 }
 
 // TestArrayList_PairEquivalence verifies that Pair and ArrayList are indistinguishable
@@ -497,39 +500,39 @@ func TestArrayList_PairEquivalence(t *testing.T) {
 	c := qt.New(t)
 
 	t.Run("proper list (1 2 3)", func(t *testing.T) {
-		pair := NewCons(NewInteger(1), NewCons(NewInteger(2), NewCons(NewInteger(3), EmptyList)))
-		arraylist := NewArrayList(NewInteger(1), NewInteger(2), NewInteger(3), EmptyList)
+		pair := values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.NewCons(values.NewInteger(3), values.EmptyList)))
+		arraylist := values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3), values.EmptyList)
 
 		// Car should be identical
-		c.Assert(pair.Car(), SchemeEquals, arraylist.Car())
+		c.Assert(pair.Car(), valuestest.SchemeEquals, arraylist.Car())
 
 		// Cdr should return equivalent structures
-		pairCdr := pair.Cdr().(*Pair)
-		arraylistCdr := arraylist.Cdr().(*ArrayList)
-		c.Assert(pairCdr.Car(), SchemeEquals, arraylistCdr.Car())
-		c.Assert(pairCdr.Cdr().(*Pair).Car(), SchemeEquals, arraylistCdr.Cdr().(*ArrayList).Car())
+		pairCdr := pair.Cdr().(*values.Pair)
+		arraylistCdr := arraylist.Cdr().(*values.ArrayList)
+		c.Assert(pairCdr.Car(), valuestest.SchemeEquals, arraylistCdr.Car())
+		c.Assert(pairCdr.Cdr().(*values.Pair).Car(), valuestest.SchemeEquals, arraylistCdr.Cdr().(*values.ArrayList).Car())
 	})
 
 	t.Run("improper list (1 . 2)", func(t *testing.T) {
-		pair := NewCons(NewInteger(1), NewInteger(2))
-		arraylist := NewArrayList(NewInteger(1), NewInteger(2))
+		pair := values.NewCons(values.NewInteger(1), values.NewInteger(2))
+		arraylist := values.NewArrayList(values.NewInteger(1), values.NewInteger(2))
 
 		// Car should be identical
-		c.Assert(pair.Car(), SchemeEquals, arraylist.Car())
+		c.Assert(pair.Car(), valuestest.SchemeEquals, arraylist.Car())
 
 		// Cdr should return the direct value, not a wrapped structure
-		c.Assert(pair.Cdr(), SchemeEquals, NewInteger(2))
-		c.Assert(arraylist.Cdr(), SchemeEquals, NewInteger(2))
-		c.Assert(pair.Cdr(), SchemeEquals, arraylist.Cdr(), qt.Commentf("Pair and ArrayList Cdr must return identical values for improper lists"))
+		c.Assert(pair.Cdr(), valuestest.SchemeEquals, values.NewInteger(2))
+		c.Assert(arraylist.Cdr(), valuestest.SchemeEquals, values.NewInteger(2))
+		c.Assert(pair.Cdr(), valuestest.SchemeEquals, arraylist.Cdr(), qt.Commentf("Pair and ArrayList Cdr must return identical values for improper lists"))
 	})
 
 	t.Run("single element proper list (42)", func(t *testing.T) {
-		pair := NewCons(NewInteger(42), EmptyList)
-		arraylist := NewArrayList(NewInteger(42), EmptyList)
+		pair := values.NewCons(values.NewInteger(42), values.EmptyList)
+		arraylist := values.NewArrayList(values.NewInteger(42), values.EmptyList)
 
-		c.Assert(pair.Car(), SchemeEquals, arraylist.Car())
-		c.Assert(pair.Cdr(), SchemeEquals, EmptyList)
-		c.Assert(arraylist.Cdr(), SchemeEquals, EmptyList)
-		c.Assert(pair.Cdr(), SchemeEquals, arraylist.Cdr())
+		c.Assert(pair.Car(), valuestest.SchemeEquals, arraylist.Car())
+		c.Assert(pair.Cdr(), valuestest.SchemeEquals, values.EmptyList)
+		c.Assert(arraylist.Cdr(), valuestest.SchemeEquals, values.EmptyList)
+		c.Assert(pair.Cdr(), valuestest.SchemeEquals, arraylist.Cdr())
 	})
 }

--- a/values/atomic_test.go
+++ b/values/atomic_test.go
@@ -12,104 +12,107 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // --- AtomicBox ---
 
 func TestAtomicBox_NewAtomicBox(t *testing.T) {
-	a := NewAtomicBox(NewInteger(42))
+	a := values.NewAtomicBox(values.NewInteger(42))
 	qt.Assert(t, a, qt.Not(qt.IsNil))
 	qt.Assert(t, a.ID() > 0, qt.IsTrue)
 }
 
 func TestAtomicBox_LoadStore(t *testing.T) {
-	a := NewAtomicBox(NewInteger(1))
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(1))
+	a := values.NewAtomicBox(values.NewInteger(1))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(1))
 
-	a.Store(NewInteger(2))
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(2))
+	a.Store(values.NewInteger(2))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestAtomicBox_NilInitial(t *testing.T) {
-	a := NewAtomicBox(nil)
+	a := values.NewAtomicBox(nil)
 	qt.Assert(t, a.Load() == nil, qt.IsTrue)
 }
 
 func TestAtomicBox_Swap(t *testing.T) {
-	a := NewAtomicBox(NewInteger(1))
-	old := a.Swap(NewInteger(2))
-	qt.Assert(t, old, SchemeEquals, NewInteger(1))
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(2))
+	a := values.NewAtomicBox(values.NewInteger(1))
+	old := a.Swap(values.NewInteger(2))
+	qt.Assert(t, old, valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestAtomicBox_SwapFromNil(t *testing.T) {
-	a := NewAtomicBox(nil)
-	old := a.Swap(NewInteger(1))
+	a := values.NewAtomicBox(nil)
+	old := a.Swap(values.NewInteger(1))
 	qt.Assert(t, old == nil, qt.IsTrue)
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(1))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestAtomicBox_CompareAndSwap(t *testing.T) {
-	a := NewAtomicBox(NewInteger(1))
+	a := values.NewAtomicBox(values.NewInteger(1))
 
 	// Successful CAS
-	ok := a.CompareAndSwap(NewInteger(1), NewInteger(2))
+	ok := a.CompareAndSwap(values.NewInteger(1), values.NewInteger(2))
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(2))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(2))
 
 	// Failed CAS (old value doesn't match)
-	ok = a.CompareAndSwap(NewInteger(1), NewInteger(3))
+	ok = a.CompareAndSwap(values.NewInteger(1), values.NewInteger(3))
 	qt.Assert(t, ok, qt.IsFalse)
-	qt.Assert(t, a.Load(), SchemeEquals, NewInteger(2))
+	qt.Assert(t, a.Load(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestAtomicBox_IsVoid(t *testing.T) {
-	a := NewAtomicBox(NewInteger(1))
+	a := values.NewAtomicBox(values.NewInteger(1))
 	qt.Assert(t, a.IsVoid(), qt.IsFalse)
 
-	var nilA *AtomicBox
+	var nilA *values.AtomicBox
 	qt.Assert(t, nilA.IsVoid(), qt.IsTrue)
 }
 
 func TestAtomicBox_EqualTo(t *testing.T) {
-	a1 := NewAtomicBox(NewInteger(1))
-	a2 := NewAtomicBox(NewInteger(1))
+	a1 := values.NewAtomicBox(values.NewInteger(1))
+	a2 := values.NewAtomicBox(values.NewInteger(1))
 	qt.Assert(t, a1.EqualTo(a1), qt.IsTrue)
 	qt.Assert(t, a1.EqualTo(a2), qt.IsFalse)
-	qt.Assert(t, a1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, a1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestAtomicBox_SchemeString(t *testing.T) {
-	a := NewAtomicBox(NewInteger(42))
+	a := values.NewAtomicBox(values.NewInteger(42))
 	s := a.SchemeString()
 	qt.Assert(t, strings.Contains(s, "atomic"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "42"), qt.IsTrue)
 
-	a2 := NewAtomicBox(nil)
+	a2 := values.NewAtomicBox(nil)
 	s2 := a2.SchemeString()
 	qt.Assert(t, strings.Contains(s2, "void"), qt.IsTrue)
 
-	var nilA *AtomicBox
+	var nilA *values.AtomicBox
 	qt.Assert(t, nilA.SchemeString(), qt.Equals, "#<atomic:void>")
 }
 
 // --- AtomicInt64 ---
 
 func TestAtomicInt64_NewAtomicInt64(t *testing.T) {
-	a := NewAtomicInt64(42)
+	a := values.NewAtomicInt64(42)
 	qt.Assert(t, a, qt.Not(qt.IsNil))
 	qt.Assert(t, a.ID() > 0, qt.IsTrue)
 }
 
 func TestAtomicInt64_LoadStore(t *testing.T) {
-	a := NewAtomicInt64(1)
+	a := values.NewAtomicInt64(1)
 	qt.Assert(t, a.Load(), qt.Equals, int64(1))
 
 	a.Store(2)
@@ -117,7 +120,7 @@ func TestAtomicInt64_LoadStore(t *testing.T) {
 }
 
 func TestAtomicInt64_Add(t *testing.T) {
-	a := NewAtomicInt64(10)
+	a := values.NewAtomicInt64(10)
 	result := a.Add(5)
 	qt.Assert(t, result, qt.Equals, int64(15))
 	qt.Assert(t, a.Load(), qt.Equals, int64(15))
@@ -127,14 +130,14 @@ func TestAtomicInt64_Add(t *testing.T) {
 }
 
 func TestAtomicInt64_Swap(t *testing.T) {
-	a := NewAtomicInt64(1)
+	a := values.NewAtomicInt64(1)
 	old := a.Swap(2)
 	qt.Assert(t, old, qt.Equals, int64(1))
 	qt.Assert(t, a.Load(), qt.Equals, int64(2))
 }
 
 func TestAtomicInt64_CompareAndSwap(t *testing.T) {
-	a := NewAtomicInt64(1)
+	a := values.NewAtomicInt64(1)
 
 	ok := a.CompareAndSwap(1, 2)
 	qt.Assert(t, ok, qt.IsTrue)
@@ -146,27 +149,27 @@ func TestAtomicInt64_CompareAndSwap(t *testing.T) {
 }
 
 func TestAtomicInt64_IsVoid(t *testing.T) {
-	a := NewAtomicInt64(0)
+	a := values.NewAtomicInt64(0)
 	qt.Assert(t, a.IsVoid(), qt.IsFalse)
 
-	var nilA *AtomicInt64
+	var nilA *values.AtomicInt64
 	qt.Assert(t, nilA.IsVoid(), qt.IsTrue)
 }
 
 func TestAtomicInt64_EqualTo(t *testing.T) {
-	a1 := NewAtomicInt64(1)
-	a2 := NewAtomicInt64(1)
+	a1 := values.NewAtomicInt64(1)
+	a2 := values.NewAtomicInt64(1)
 	qt.Assert(t, a1.EqualTo(a1), qt.IsTrue)
 	qt.Assert(t, a1.EqualTo(a2), qt.IsFalse)
-	qt.Assert(t, a1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, a1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestAtomicInt64_SchemeString(t *testing.T) {
-	a := NewAtomicInt64(42)
+	a := values.NewAtomicInt64(42)
 	s := a.SchemeString()
 	qt.Assert(t, strings.Contains(s, "atomic-int64"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "42"), qt.IsTrue)
 
-	var nilA *AtomicInt64
+	var nilA *values.AtomicInt64
 	qt.Assert(t, nilA.SchemeString(), qt.Equals, "#<atomic-int64:void>")
 }

--- a/values/big_complex_test.go
+++ b/values/big_complex_test.go
@@ -12,40 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestBigComplex_Constructors(t *testing.T) {
 	c := qt.New(t)
 
 	// From BigIntegers (exact)
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	c.Assert(bc1.Real().(*BigInteger).Int64(), qt.Equals, int64(3))
-	c.Assert(bc1.Imag().(*BigInteger).Int64(), qt.Equals, int64(4))
+	c.Assert(bc1.Real().(*values.BigInteger).Int64(), qt.Equals, int64(3))
+	c.Assert(bc1.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(4))
 	c.Assert(bc1.IsExact(), qt.IsTrue)
 
 	// From BigFloats (inexact)
-	bc2 := NewBigComplexFromBigFloats(
-		NewBigFloatFromFloat64(1.5),
-		NewBigFloatFromFloat64(2.5),
+	bc2 := values.NewBigComplexFromBigFloats(
+		values.NewBigFloatFromFloat64(1.5),
+		values.NewBigFloatFromFloat64(2.5),
 	)
 	c.Assert(bc2.RealAsBigFloat().Float64(), qt.Equals, 1.5)
 	c.Assert(bc2.ImagAsBigFloat().Float64(), qt.Equals, 2.5)
 	c.Assert(bc2.IsExact(), qt.IsFalse)
 
 	// Mixed parts (inexact due to BigFloat)
-	bc3 := NewBigComplex(
-		NewBigIntegerFromInt64(1),
-		NewBigFloatFromFloat64(2.0),
+	bc3 := values.NewBigComplex(
+		values.NewBigIntegerFromInt64(1),
+		values.NewBigFloatFromFloat64(2.0),
 	)
 	c.Assert(bc3.IsExact(), qt.IsFalse)
 }
@@ -53,69 +56,69 @@ func TestBigComplex_Constructors(t *testing.T) {
 func TestBigComplex_Arithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(1),
-		NewBigIntegerFromInt64(2),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(1),
+		values.NewBigIntegerFromInt64(2),
 	)
 
 	// Add: (3+4i) + (1+2i) = (4+6i)
 	sum := bc1.Add(bc2)
 	c.Assert(sum, qt.IsNotNil)
-	bc := sum.(*BigComplex)
-	c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(4))
-	c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(6))
+	bc := sum.(*values.BigComplex)
+	c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(4))
+	c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(6))
 
 	// Subtract: (3+4i) - (1+2i) = (2+2i)
 	diff := bc1.Subtract(bc2)
 	c.Assert(diff, qt.IsNotNil)
-	bc = diff.(*BigComplex)
-	c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(2))
-	c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(2))
+	bc = diff.(*values.BigComplex)
+	c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(2))
+	c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(2))
 
 	// Multiply: (3+4i) * (1+2i) = (3*1 - 4*2) + (3*2 + 4*1)i = -5 + 10i
 	prod := bc1.Multiply(bc2)
 	c.Assert(prod, qt.IsNotNil)
-	bc = prod.(*BigComplex)
-	c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(-5))
-	c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(10))
+	bc = prod.(*values.BigComplex)
+	c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(-5))
+	c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(10))
 
 	// Negate
 	neg := bc1.Negate()
 	c.Assert(neg, qt.IsNotNil)
-	bc = neg.(*BigComplex)
-	c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(-3))
-	c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(-4))
+	bc = neg.(*values.BigComplex)
+	c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(-3))
+	c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(-4))
 }
 
 func TestBigComplex_Division(t *testing.T) {
 	c := qt.New(t)
 
 	// (3+4i) / (1+2i) = ((3*1+4*2) + (4*1-3*2)i) / (1+4) = (11 - 2i) / 5 = 2.2 - 0.4i
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(1),
-		NewBigIntegerFromInt64(2),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(1),
+		values.NewBigIntegerFromInt64(2),
 	)
 
 	quot := bc1.Divide(bc2)
 	c.Assert(quot, qt.IsNotNil)
 	// Division always produces BigFloat parts
-	realPart := quot.(*BigComplex).RealAsBigFloat().Float64()
-	imagPart := quot.(*BigComplex).ImagAsBigFloat().Float64()
+	realPart := quot.(*values.BigComplex).RealAsBigFloat().Float64()
+	imagPart := quot.(*values.BigComplex).ImagAsBigFloat().Float64()
 	c.Assert(math.Abs(realPart-2.2) < 0.0001, qt.IsTrue)
 	c.Assert(math.Abs(imagPart-(-0.4)) < 0.0001, qt.IsTrue)
 
 	// Division by zero panics
-	zero := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(0),
-		NewBigIntegerFromInt64(0),
+	zero := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(0),
+		values.NewBigIntegerFromInt64(0),
 	)
 	c.Assert(func() { bc1.Divide(zero) }, qt.PanicMatches, "division by zero")
 }
@@ -123,67 +126,67 @@ func TestBigComplex_Division(t *testing.T) {
 func TestBigComplex_MixedArithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
 
 	// Add with BigInteger: (3+4i) + 5 = (8+4i)
-	sum1 := bc.Add(NewBigIntegerFromInt64(5))
-	c.Assert(sum1.(*BigComplex).Real().(*BigInteger).Int64(), qt.Equals, int64(8))
-	c.Assert(sum1.(*BigComplex).Imag().(*BigInteger).Int64(), qt.Equals, int64(4))
+	sum1 := bc.Add(values.NewBigIntegerFromInt64(5))
+	c.Assert(sum1.(*values.BigComplex).Real().(*values.BigInteger).Int64(), qt.Equals, int64(8))
+	c.Assert(sum1.(*values.BigComplex).Imag().(*values.BigInteger).Int64(), qt.Equals, int64(4))
 
 	// Add with BigFloat: (3+4i) + 1.5 = (4.5+4i) - becomes inexact
-	sum2 := bc.Add(NewBigFloatFromFloat64(1.5))
-	c.Assert(sum2.(*BigComplex).IsExact(), qt.IsFalse)
-	c.Assert(sum2.(*BigComplex).RealAsBigFloat().Float64(), qt.Equals, 4.5)
+	sum2 := bc.Add(values.NewBigFloatFromFloat64(1.5))
+	c.Assert(sum2.(*values.BigComplex).IsExact(), qt.IsFalse)
+	c.Assert(sum2.(*values.BigComplex).RealAsBigFloat().Float64(), qt.Equals, 4.5)
 
 	// Add with Integer: promotes Integer to BigInteger
-	sum3 := bc.Add(NewInteger(10))
-	c.Assert(sum3.(*BigComplex).Real().(*BigInteger).Int64(), qt.Equals, int64(13))
+	sum3 := bc.Add(values.NewInteger(10))
+	c.Assert(sum3.(*values.BigComplex).Real().(*values.BigInteger).Int64(), qt.Equals, int64(13))
 
 	// Add with Float: becomes inexact
-	sum4 := bc.Add(NewFloat(2.5))
-	c.Assert(sum4.(*BigComplex).IsExact(), qt.IsFalse)
+	sum4 := bc.Add(values.NewFloat(2.5))
+	c.Assert(sum4.(*values.BigComplex).IsExact(), qt.IsFalse)
 
 	// Add with Complex
-	cplx := NewComplexFromParts(1.0, 1.0)
+	cplx := values.NewComplexFromParts(1.0, 1.0)
 	sum5 := bc.Add(cplx)
-	c.Assert(sum5.(*BigComplex).RealAsBigFloat().Float64(), qt.Equals, 4.0)
-	c.Assert(sum5.(*BigComplex).ImagAsBigFloat().Float64(), qt.Equals, 5.0)
+	c.Assert(sum5.(*values.BigComplex).RealAsBigFloat().Float64(), qt.Equals, 4.0)
+	c.Assert(sum5.(*values.BigComplex).ImagAsBigFloat().Float64(), qt.Equals, 5.0)
 }
 
 func TestBigComplex_Exactness(t *testing.T) {
 	c := qt.New(t)
 
 	// Exact complex (both parts BigInteger)
-	exact := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	exact := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
 	c.Assert(exact.IsExact(), qt.IsTrue)
 
 	// Inexact complex (both parts BigFloat)
-	inexact := NewBigComplexFromBigFloats(
-		NewBigFloatFromFloat64(3.0),
-		NewBigFloatFromFloat64(4.0),
+	inexact := values.NewBigComplexFromBigFloats(
+		values.NewBigFloatFromFloat64(3.0),
+		values.NewBigFloatFromFloat64(4.0),
 	)
 	c.Assert(inexact.IsExact(), qt.IsFalse)
 
 	// Mixed (one BigInteger, one BigFloat) - inexact
-	mixed := NewBigComplex(
-		NewBigIntegerFromInt64(3),
-		NewBigFloatFromFloat64(4.0),
+	mixed := values.NewBigComplex(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigFloatFromFloat64(4.0),
 	)
 	c.Assert(mixed.IsExact(), qt.IsFalse)
 
 	// ToInexact
 	inexactFromExact := exact.ToInexact()
-	c.Assert(inexactFromExact.(*BigComplex).IsExact(), qt.IsFalse)
+	c.Assert(inexactFromExact.(*values.BigComplex).IsExact(), qt.IsFalse)
 
 	// ToExact
 	exactFromInexact := inexact.ToExact()
-	c.Assert(exactFromInexact.(*BigComplex).IsExact(), qt.IsTrue)
+	c.Assert(exactFromInexact.(*values.BigComplex).IsExact(), qt.IsTrue)
 }
 
 // TestBigComplex_ToExactFractionalParts tests H4 regression:
@@ -257,9 +260,9 @@ func TestBigComplex_ToExactFractionalParts(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			bc := NewBigComplexFromBigFloats(
-				NewBigFloatFromFloat64(tc.real),
-				NewBigFloatFromFloat64(tc.imag),
+			bc := values.NewBigComplexFromBigFloats(
+				values.NewBigFloatFromFloat64(tc.real),
+				values.NewBigFloatFromFloat64(tc.imag),
 			)
 			exact := bc.ToExact()
 			c.Assert(exact.IsExact(), qt.IsTrue)
@@ -268,14 +271,14 @@ func TestBigComplex_ToExactFractionalParts(t *testing.T) {
 			if tc.simplifiesToReal {
 				switch tc.wantRealType {
 				case "Rational":
-					rat, ok := exact.(*Rational)
+					rat, ok := exact.(*values.Rational)
 					c.Assert(ok, qt.IsTrue, qt.Commentf("Result should be Rational, got %T: %v", exact, exact.SchemeString()))
 					c.Assert(rat.Float64(), qt.Equals, tc.wantRealValue)
 				case "Integer":
 					switch v := exact.(type) {
-					case *Integer:
+					case *values.Integer:
 						c.Assert(float64(v.Value), qt.Equals, tc.wantRealValue)
-					case *BigInteger:
+					case *values.BigInteger:
 						c.Assert(float64(v.Int64()), qt.Equals, tc.wantRealValue)
 					default:
 						t.Fatalf("Result should be Integer or BigInteger, got %T: %v", exact, exact.SchemeString())
@@ -285,7 +288,7 @@ func TestBigComplex_ToExactFractionalParts(t *testing.T) {
 			}
 
 			// Otherwise, result should be BigComplex
-			bcExact, ok := exact.(*BigComplex)
+			bcExact, ok := exact.(*values.BigComplex)
 			c.Assert(ok, qt.IsTrue, qt.Commentf("Result should be BigComplex, got %T: %v", exact, exact.SchemeString()))
 
 			// Check real part
@@ -294,15 +297,15 @@ func TestBigComplex_ToExactFractionalParts(t *testing.T) {
 			case "zero":
 				c.Assert(realPart.IsZero(), qt.IsTrue, qt.Commentf("Real part should be zero"))
 			case "Rational":
-				rat, ok := realPart.(*Rational)
+				rat, ok := realPart.(*values.Rational)
 				c.Assert(ok, qt.IsTrue, qt.Commentf("Real part should be Rational, got %T: %v", realPart, realPart.SchemeString()))
 				c.Assert(rat.Float64(), qt.Equals, tc.wantRealValue)
 			case "Integer":
 				// Could be Integer or BigInteger depending on value
 				switch v := realPart.(type) {
-				case *Integer:
+				case *values.Integer:
 					c.Assert(float64(v.Value), qt.Equals, tc.wantRealValue)
-				case *BigInteger:
+				case *values.BigInteger:
 					c.Assert(float64(v.Int64()), qt.Equals, tc.wantRealValue)
 				default:
 					t.Fatalf("Real part should be Integer or BigInteger, got %T: %v", realPart, realPart.SchemeString())
@@ -315,14 +318,14 @@ func TestBigComplex_ToExactFractionalParts(t *testing.T) {
 			case "zero":
 				c.Assert(imagPart.IsZero(), qt.IsTrue, qt.Commentf("Imaginary part should be zero"))
 			case "Rational":
-				rat, ok := imagPart.(*Rational)
+				rat, ok := imagPart.(*values.Rational)
 				c.Assert(ok, qt.IsTrue, qt.Commentf("Imaginary part should be Rational, got %T: %v", imagPart, imagPart.SchemeString()))
 				c.Assert(rat.Float64(), qt.Equals, tc.wantImagValue)
 			case "Integer":
 				switch v := imagPart.(type) {
-				case *Integer:
+				case *values.Integer:
 					c.Assert(float64(v.Value), qt.Equals, tc.wantImagValue)
-				case *BigInteger:
+				case *values.BigInteger:
 					c.Assert(float64(v.Int64()), qt.Equals, tc.wantImagValue)
 				default:
 					t.Fatalf("Imaginary part should be Integer or BigInteger, got %T: %v", imagPart, imagPart.SchemeString())
@@ -336,29 +339,29 @@ func TestBigComplex_Simplification(t *testing.T) {
 	c := qt.New(t)
 
 	// When imaginary part becomes 0, should simplify to real number
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(2),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(2),
 	)
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(0),
-		NewBigIntegerFromInt64(2),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(0),
+		values.NewBigIntegerFromInt64(2),
 	)
 
 	// (3+2i) - (0+2i) = 3 (should simplify to BigInteger)
 	result := bc1.Subtract(bc2)
-	_, isBigInt := result.(*BigInteger)
+	_, isBigInt := result.(*values.BigInteger)
 	c.Assert(isBigInt, qt.IsTrue)
-	c.Assert(result.(*BigInteger).Int64(), qt.Equals, int64(3))
+	c.Assert(result.(*values.BigInteger).Int64(), qt.Equals, int64(3))
 }
 
 func TestBigComplex_MagnitudePhase(t *testing.T) {
 	c := qt.New(t)
 
 	// 3+4i has magnitude 5 and phase atan2(4, 3)
-	bc := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
 
 	mag := bc.Magnitude()
@@ -370,58 +373,58 @@ func TestBigComplex_MagnitudePhase(t *testing.T) {
 
 	// Conjugate: (3+4i)* = 3-4i
 	conj := bc.Conjugate()
-	c.Assert(conj.Real().(*BigInteger).Int64(), qt.Equals, int64(3))
-	c.Assert(conj.Imag().(*BigInteger).Int64(), qt.Equals, int64(-4))
+	c.Assert(conj.Real().(*values.BigInteger).Int64(), qt.Equals, int64(3))
+	c.Assert(conj.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(-4))
 }
 
 func TestBigComplex_EqualTo(t *testing.T) {
 	c := qt.New(t)
 
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	bc3 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(1),
-		NewBigIntegerFromInt64(2),
+	bc3 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(1),
+		values.NewBigIntegerFromInt64(2),
 	)
 
 	c.Assert(bc1.EqualTo(bc2), qt.IsTrue)
 	c.Assert(bc1.EqualTo(bc3), qt.IsFalse)
 
 	// Equal to regular Complex with same values
-	cplx := NewComplexFromParts(3.0, 4.0)
+	cplx := values.NewComplexFromParts(3.0, 4.0)
 	c.Assert(bc1.EqualTo(cplx), qt.IsTrue)
 
 	// Not equal to different type
-	c.Assert(bc1.EqualTo(NewInteger(3)), qt.IsFalse)
+	c.Assert(bc1.EqualTo(values.NewInteger(3)), qt.IsFalse)
 }
 
 func TestBigComplex_SchemeString(t *testing.T) {
 	c := qt.New(t)
 
 	// Positive imaginary
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
 	c.Assert(bc1.SchemeString(), qt.Equals, "3+4i")
 
 	// Negative imaginary
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(-4),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(-4),
 	)
 	c.Assert(bc2.SchemeString(), qt.Equals, "3-4i")
 
 	// With BigFloat parts
-	bc3 := NewBigComplexFromBigFloats(
-		NewBigFloatFromFloat64(1.5),
-		NewBigFloatFromFloat64(2.5),
+	bc3 := values.NewBigComplexFromBigFloats(
+		values.NewBigFloatFromFloat64(1.5),
+		values.NewBigFloatFromFloat64(2.5),
 	)
 	str := bc3.SchemeString()
 	c.Assert(str, qt.Contains, "1.5")
@@ -432,17 +435,17 @@ func TestBigComplex_SchemeString(t *testing.T) {
 func TestBigComplex_Properties(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	zero := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(0),
-		NewBigIntegerFromInt64(0),
+	zero := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(0),
+		values.NewBigIntegerFromInt64(0),
 	)
-	realOnly := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(5),
-		NewBigIntegerFromInt64(0),
+	realOnly := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(5),
+		values.NewBigIntegerFromInt64(0),
 	)
 
 	c.Assert(bc.IsZero(), qt.IsFalse)
@@ -450,23 +453,23 @@ func TestBigComplex_Properties(t *testing.T) {
 	c.Assert(bc.IsReal(), qt.IsFalse)
 	c.Assert(realOnly.IsReal(), qt.IsTrue)
 	c.Assert(bc.IsVoid(), qt.IsFalse)
-	c.Assert((*BigComplex)(nil).IsVoid(), qt.IsTrue)
+	c.Assert((*values.BigComplex)(nil).IsVoid(), qt.IsTrue)
 }
 
 func TestBigComplex_Comparison(t *testing.T) {
 	c := qt.New(t)
 
-	bc1 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc1 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	bc2 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(5),
-		NewBigIntegerFromInt64(1),
+	bc2 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(5),
+		values.NewBigIntegerFromInt64(1),
 	)
-	bc3 := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(100),
+	bc3 := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(100),
 	)
 
 	// Compare by real parts only
@@ -475,27 +478,27 @@ func TestBigComplex_Comparison(t *testing.T) {
 	c.Assert(bc1.LessThan(bc3), qt.IsFalse) // 3 == 3 (imaginary ignored)
 
 	// Compare with other numeric types
-	c.Assert(bc1.Compare(NewBigIntegerFromInt64(5)), qt.Equals, -1) // 3 < 5
-	c.Assert(bc1.Compare(NewBigIntegerFromInt64(2)), qt.Equals, 1)  // 3 > 2
-	c.Assert(bc1.Compare(NewBigIntegerFromInt64(3)), qt.Equals, 0)  // 3 == 3
+	c.Assert(bc1.Compare(values.NewBigIntegerFromInt64(5)), qt.Equals, -1) // 3 < 5
+	c.Assert(bc1.Compare(values.NewBigIntegerFromInt64(2)), qt.Equals, 1)  // 3 > 2
+	c.Assert(bc1.Compare(values.NewBigIntegerFromInt64(3)), qt.Equals, 0)  // 3 == 3
 }
 
 func TestBigComplex_ZeroOptimizations(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplexFromBigIntegers(
-		NewBigIntegerFromInt64(3),
-		NewBigIntegerFromInt64(4),
+	bc := values.NewBigComplexFromBigIntegers(
+		values.NewBigIntegerFromInt64(3),
+		values.NewBigIntegerFromInt64(4),
 	)
-	zero := NewBigIntegerFromInt64(0)
+	zero := values.NewBigIntegerFromInt64(0)
 
 	// Add zero returns equal value (not necessarily same pointer)
 	result := bc.Add(zero)
-	c.Assert(result, SchemeEquals, bc)
+	c.Assert(result, valuestest.SchemeEquals, bc)
 
 	// Subtract zero returns equal value (not necessarily same pointer)
 	result = bc.Subtract(zero)
-	c.Assert(result, SchemeEquals, bc)
+	c.Assert(result, valuestest.SchemeEquals, bc)
 
 	// Multiply by zero returns zero
 	result = bc.Multiply(zero)
@@ -506,23 +509,23 @@ func TestBigComplex_RationalParts(t *testing.T) {
 	c := qt.New(t)
 
 	// Create BigComplex with Rational parts (exact)
-	bc := NewBigComplex(
-		NewRational(3, 2), // 3/2
-		NewRational(1, 2), // 1/2
+	bc := values.NewBigComplex(
+		values.NewRational(3, 2), // 3/2
+		values.NewRational(1, 2), // 1/2
 	)
 
 	// Should be exact
 	c.Assert(bc.IsExact(), qt.IsTrue)
-	c.Assert(bc.Real().(*Rational).Float64(), qt.Equals, 1.5)
-	c.Assert(bc.Imag().(*Rational).Float64(), qt.Equals, 0.5)
+	c.Assert(bc.Real().(*values.Rational).Float64(), qt.Equals, 1.5)
+	c.Assert(bc.Imag().(*values.Rational).Float64(), qt.Equals, 0.5)
 
 	// SchemeString should format correctly
 	c.Assert(bc.SchemeString(), qt.Equals, "3/2+1/2i")
 
 	// Negative imaginary
-	bcNeg := NewBigComplex(
-		NewRational(3, 2),
-		NewRational(-1, 2),
+	bcNeg := values.NewBigComplex(
+		values.NewRational(3, 2),
+		values.NewRational(-1, 2),
 	)
 	c.Assert(bcNeg.SchemeString(), qt.Equals, "3/2-1/2i")
 }
@@ -530,36 +533,36 @@ func TestBigComplex_RationalParts(t *testing.T) {
 func TestBigComplex_RationalArithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bc1 := NewBigComplex(
-		NewRational(3, 2), // 3/2
-		NewRational(1, 2), // 1/2
+	bc1 := values.NewBigComplex(
+		values.NewRational(3, 2), // 3/2
+		values.NewRational(1, 2), // 1/2
 	)
-	bc2 := NewBigComplex(
-		NewRational(1, 2), // 1/2
-		NewRational(1, 4), // 1/4
+	bc2 := values.NewBigComplex(
+		values.NewRational(1, 2), // 1/2
+		values.NewRational(1, 4), // 1/4
 	)
 
 	// Add: (3/2 + 1/2i) + (1/2 + 1/4i) = (2 + 3/4i)
 	sum := bc1.Add(bc2)
-	c.Assert(sum.(*BigComplex).IsExact(), qt.IsTrue)
-	realPart := sum.(*BigComplex).Real().(*Rational)
-	imagPart := sum.(*BigComplex).Imag().(*Rational)
+	c.Assert(sum.(*values.BigComplex).IsExact(), qt.IsTrue)
+	realPart := sum.(*values.BigComplex).Real().(*values.Rational)
+	imagPart := sum.(*values.BigComplex).Imag().(*values.Rational)
 	c.Assert(realPart.Float64(), qt.Equals, 2.0)
 	c.Assert(imagPart.Float64(), qt.Equals, 0.75)
 
 	// Subtract: (3/2 + 1/2i) - (1/2 + 1/4i) = (1 + 1/4i)
 	diff := bc1.Subtract(bc2)
-	c.Assert(diff.(*BigComplex).IsExact(), qt.IsTrue)
-	realPart = diff.(*BigComplex).Real().(*Rational)
-	imagPart = diff.(*BigComplex).Imag().(*Rational)
+	c.Assert(diff.(*values.BigComplex).IsExact(), qt.IsTrue)
+	realPart = diff.(*values.BigComplex).Real().(*values.Rational)
+	imagPart = diff.(*values.BigComplex).Imag().(*values.Rational)
 	c.Assert(realPart.Float64(), qt.Equals, 1.0)
 	c.Assert(imagPart.Float64(), qt.Equals, 0.25)
 
 	// Multiply: (3/2 + 1/2i) * (1/2 + 1/4i) = (3/4 - 1/8) + (3/8 + 1/4)i = 5/8 + 5/8i
 	prod := bc1.Multiply(bc2)
-	c.Assert(prod.(*BigComplex).IsExact(), qt.IsTrue)
-	realPart = prod.(*BigComplex).Real().(*Rational)
-	imagPart = prod.(*BigComplex).Imag().(*Rational)
+	c.Assert(prod.(*values.BigComplex).IsExact(), qt.IsTrue)
+	realPart = prod.(*values.BigComplex).Real().(*values.Rational)
+	imagPart = prod.(*values.BigComplex).Imag().(*values.Rational)
 	c.Assert(realPart.Float64(), qt.Equals, 0.625) // 5/8
 	c.Assert(imagPart.Float64(), qt.Equals, 0.625) // 5/8
 }
@@ -567,26 +570,26 @@ func TestBigComplex_RationalArithmetic(t *testing.T) {
 func TestBigComplex_RationalWithScalar(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplex(
-		NewRational(3, 2), // 3/2
-		NewRational(1, 2), // 1/2
+	bc := values.NewBigComplex(
+		values.NewRational(3, 2), // 3/2
+		values.NewRational(1, 2), // 1/2
 	)
 
 	// Add Rational: (3/2 + 1/2i) + 1/4 = (7/4 + 1/2i)
-	sum := bc.Add(NewRational(1, 4))
-	c.Assert(sum.(*BigComplex).IsExact(), qt.IsTrue)
-	realPart := sum.(*BigComplex).Real().(*Rational)
+	sum := bc.Add(values.NewRational(1, 4))
+	c.Assert(sum.(*values.BigComplex).IsExact(), qt.IsTrue)
+	realPart := sum.(*values.BigComplex).Real().(*values.Rational)
 	c.Assert(realPart.Float64(), qt.Equals, 1.75) // 7/4
 
 	// Multiply Rational: (3/2 + 1/2i) * 2 = (3 + 1i)
-	prod := bc.Multiply(NewRational(2, 1))
-	c.Assert(prod.(*BigComplex).IsExact(), qt.IsTrue)
+	prod := bc.Multiply(values.NewRational(2, 1))
+	c.Assert(prod.(*values.BigComplex).IsExact(), qt.IsTrue)
 
 	// Divide by Rational: (3/2 + 1/2i) / (1/2) = (3 + 1i)
-	quot := bc.Divide(NewRational(1, 2))
-	c.Assert(quot.(*BigComplex).IsExact(), qt.IsTrue)
-	realPart = quot.(*BigComplex).Real().(*Rational)
-	imagPart := quot.(*BigComplex).Imag().(*Rational)
+	quot := bc.Divide(values.NewRational(1, 2))
+	c.Assert(quot.(*values.BigComplex).IsExact(), qt.IsTrue)
+	realPart = quot.(*values.BigComplex).Real().(*values.Rational)
+	imagPart := quot.(*values.BigComplex).Imag().(*values.Rational)
 	c.Assert(realPart.Float64(), qt.Equals, 3.0)
 	c.Assert(imagPart.Float64(), qt.Equals, 1.0)
 }
@@ -594,49 +597,49 @@ func TestBigComplex_RationalWithScalar(t *testing.T) {
 func TestBigComplex_RationalExactnessContagion(t *testing.T) {
 	c := qt.New(t)
 
-	exact := NewBigComplex(
-		NewRational(3, 2),
-		NewRational(1, 2),
+	exact := values.NewBigComplex(
+		values.NewRational(3, 2),
+		values.NewRational(1, 2),
 	)
 
 	// Adding a Float makes it inexact
-	sumFloat := exact.Add(NewFloat(1.0))
-	c.Assert(sumFloat.(*BigComplex).IsExact(), qt.IsFalse)
+	sumFloat := exact.Add(values.NewFloat(1.0))
+	c.Assert(sumFloat.(*values.BigComplex).IsExact(), qt.IsFalse)
 
 	// Adding a BigFloat makes it inexact
-	sumBigFloat := exact.Add(NewBigFloatFromFloat64(1.0))
-	c.Assert(sumBigFloat.(*BigComplex).IsExact(), qt.IsFalse)
+	sumBigFloat := exact.Add(values.NewBigFloatFromFloat64(1.0))
+	c.Assert(sumBigFloat.(*values.BigComplex).IsExact(), qt.IsFalse)
 
 	// Adding an Integer keeps it exact (Integer promotes to BigInteger)
-	sumInt := exact.Add(NewInteger(1))
-	c.Assert(sumInt.(*BigComplex).IsExact(), qt.IsTrue)
+	sumInt := exact.Add(values.NewInteger(1))
+	c.Assert(sumInt.(*values.BigComplex).IsExact(), qt.IsTrue)
 
 	// Adding a BigInteger keeps it exact
-	sumBigInt := exact.Add(NewBigIntegerFromInt64(1))
-	c.Assert(sumBigInt.(*BigComplex).IsExact(), qt.IsTrue)
+	sumBigInt := exact.Add(values.NewBigIntegerFromInt64(1))
+	c.Assert(sumBigInt.(*values.BigComplex).IsExact(), qt.IsTrue)
 
 	// Adding another exact Rational keeps it exact
-	sumRat := exact.Add(NewRational(1, 4))
-	c.Assert(sumRat.(*BigComplex).IsExact(), qt.IsTrue)
+	sumRat := exact.Add(values.NewRational(1, 4))
+	c.Assert(sumRat.(*values.BigComplex).IsExact(), qt.IsTrue)
 }
 
 func TestBigComplex_MixedRationalBigInteger(t *testing.T) {
 	c := qt.New(t)
 
 	// Mixed: Rational real, BigInteger imag
-	bc := NewBigComplex(
-		NewRational(3, 2),
-		NewBigIntegerFromInt64(4),
+	bc := values.NewBigComplex(
+		values.NewRational(3, 2),
+		values.NewBigIntegerFromInt64(4),
 	)
 
 	// Should still be exact
 	c.Assert(bc.IsExact(), qt.IsTrue)
 
 	// Add another mixed
-	bc2 := NewBigComplex(
-		NewBigIntegerFromInt64(1),
-		NewRational(1, 2),
+	bc2 := values.NewBigComplex(
+		values.NewBigIntegerFromInt64(1),
+		values.NewRational(1, 2),
 	)
 	sum := bc.Add(bc2)
-	c.Assert(sum.(*BigComplex).IsExact(), qt.IsTrue)
+	c.Assert(sum.(*values.BigComplex).IsExact(), qt.IsTrue)
 }

--- a/values/big_integer_precision_test.go
+++ b/values/big_integer_precision_test.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math/big"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // TestBigIntegerCompareFloatPrecision verifies that BigInteger.Compare
@@ -32,50 +34,50 @@ func TestBigIntegerCompareFloatPrecision(t *testing.T) {
 
 	tcs := []struct {
 		name           string
-		bigInt         *BigInteger
-		float          *Float
+		bigInt         *values.BigInteger
+		float          *values.Float
 		expectedResult int // -1, 0, or 1
 	}{
 		{
 			name:           "2^53 + 1 > 2^53 (exact in float64)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
-			float:          NewFloat(9007199254740992.0),                           // 2^53 (exact in float64)
-			expectedResult: 1,                                                      // BigInteger is larger
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
+			float:          values.NewFloat(9007199254740992.0),                           // 2^53 (exact in float64)
+			expectedResult: 1,                                                             // BigInteger is larger
 		},
 		{
 			name:           "2^53 == 2^53.0",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(9007199254740992)), // 2^53
-			float:          NewFloat(9007199254740992.0),                           // 2^53
-			expectedResult: 0,                                                      // Equal
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(9007199254740992)), // 2^53
+			float:          values.NewFloat(9007199254740992.0),                           // 2^53
+			expectedResult: 0,                                                             // Equal
 		},
 		{
 			name:           "2^53 - 1 < 2^53.0",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(9007199254740991)), // 2^53 - 1
-			float:          NewFloat(9007199254740992.0),                           // 2^53
-			expectedResult: -1,                                                     // BigInteger is smaller
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(9007199254740991)), // 2^53 - 1
+			float:          values.NewFloat(9007199254740992.0),                           // 2^53
+			expectedResult: -1,                                                            // BigInteger is smaller
 		},
 		{
 			name:           "2^54 > 2^53.0",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(18014398509481984)), // 2^54
-			float:          NewFloat(9007199254740992.0),                            // 2^53
-			expectedResult: 1,                                                       // BigInteger is larger
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(18014398509481984)), // 2^54
+			float:          values.NewFloat(9007199254740992.0),                            // 2^53
+			expectedResult: 1,                                                              // BigInteger is larger
 		},
 		{
 			name:           "negative: -(2^53 + 1) < -(2^53)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(-9007199254740993)), // -(2^53 + 1)
-			float:          NewFloat(-9007199254740992.0),                           // -(2^53)
-			expectedResult: -1,                                                      // BigInteger is smaller (more negative)
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(-9007199254740993)), // -(2^53 + 1)
+			float:          values.NewFloat(-9007199254740992.0),                           // -(2^53)
+			expectedResult: -1,                                                             // BigInteger is smaller (more negative)
 		},
 		{
 			name:           "small values: 42 == 42.0",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(42)),
-			float:          NewFloat(42.0),
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(42)),
+			float:          values.NewFloat(42.0),
 			expectedResult: 0, // Equal
 		},
 		{
 			name:           "zero: 0 == 0.0",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(0)),
-			float:          NewFloat(0.0),
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(0)),
+			float:          values.NewFloat(0.0),
 			expectedResult: 0, // Equal
 		},
 	}
@@ -99,32 +101,32 @@ func TestBigIntegerCompareComplexPrecision(t *testing.T) {
 
 	tcs := []struct {
 		name           string
-		bigInt         *BigInteger
-		complex        *Complex
+		bigInt         *values.BigInteger
+		complex        *values.Complex
 		expectedResult int // -1, 0, or 1
 	}{
 		{
 			name:           "2^53 + 1 > complex(2^53, 0)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
-			complex:        NewComplex(complex(9007199254740992.0, 0)),             // 2^53 + 0i
-			expectedResult: 1,                                                      // BigInteger is larger
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
+			complex:        values.NewComplex(complex(9007199254740992.0, 0)),             // 2^53 + 0i
+			expectedResult: 1,                                                             // BigInteger is larger
 		},
 		{
 			name:           "2^53 == complex(2^53, 0)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(9007199254740992)), // 2^53
-			complex:        NewComplex(complex(9007199254740992.0, 0)),             // 2^53 + 0i
-			expectedResult: 0,                                                      // Equal
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(9007199254740992)), // 2^53
+			complex:        values.NewComplex(complex(9007199254740992.0, 0)),             // 2^53 + 0i
+			expectedResult: 0,                                                             // Equal
 		},
 		{
 			name:           "42 == complex(42, 0)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(42)),
-			complex:        NewComplex(complex(42.0, 0)),
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(42)),
+			complex:        values.NewComplex(complex(42.0, 0)),
 			expectedResult: 0, // Equal
 		},
 		{
 			name:           "100 < complex(200, 50i)",
-			bigInt:         NewBigInteger(new(big.Int).SetInt64(100)),
-			complex:        NewComplex(complex(200.0, 50.0)),
+			bigInt:         values.NewBigInteger(new(big.Int).SetInt64(100)),
+			complex:        values.NewComplex(complex(200.0, 50.0)),
 			expectedResult: -1, // Real part comparison: 100 < 200
 		},
 	}
@@ -143,21 +145,21 @@ func TestBigIntegerArithmeticFloatPrecision(t *testing.T) {
 	c := qt.New(t)
 
 	// Use 2^54 which is beyond float64 precision boundary
-	bigInt := NewBigInteger(new(big.Int).SetInt64(18014398509481984)) // 2^54
-	floatOne := NewFloat(1.0)
+	bigInt := values.NewBigInteger(new(big.Int).SetInt64(18014398509481984)) // 2^54
+	floatOne := values.NewFloat(1.0)
 
 	t.Run("Add: 2^54 + 1.0", func(t *testing.T) {
 		result := bigInt.Add(floatOne)
 		// Result should be BigFloat (inexact) to preserve exactness contagion
 		c.Assert(result, qt.Not(qt.IsNil))
 
-		bf, ok := result.(*BigFloat)
+		bf, ok := result.(*values.BigFloat)
 		c.Assert(ok, qt.IsTrue, qt.Commentf("Expected *BigFloat, got %T", result))
 
 		// Verify the value is correct
 		expected := new(big.Float).SetInt64(18014398509481984)
 		expected.Add(expected, new(big.Float).SetFloat64(1.0))
-		c.Assert(bf.value.Cmp(expected), qt.Equals, 0)
+		c.Assert(bf.BigFloatValue().Cmp(expected), qt.Equals, 0)
 
 		// Verify it's inexact
 		c.Assert(bf.IsExact(), qt.Equals, false)
@@ -170,14 +172,14 @@ func TestBigIntegerArithmeticFloatPrecision(t *testing.T) {
 	})
 
 	t.Run("Multiply: 2^54 * 2.0", func(t *testing.T) {
-		floatTwo := NewFloat(2.0)
+		floatTwo := values.NewFloat(2.0)
 		result := bigInt.Multiply(floatTwo)
 		c.Assert(result, qt.Not(qt.IsNil))
 		// Result should be 2^55
 	})
 
 	t.Run("Divide: 2^54 / 2.0", func(t *testing.T) {
-		floatTwo := NewFloat(2.0)
+		floatTwo := values.NewFloat(2.0)
 		result := bigInt.Divide(floatTwo)
 		c.Assert(result, qt.Not(qt.IsNil))
 		// Result should be 2^53
@@ -190,32 +192,32 @@ func TestBigIntegerLessThanFloat(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		bigInt   *BigInteger
-		float    *Float
+		bigInt   *values.BigInteger
+		float    *values.Float
 		expected bool
 	}{
 		{
 			name:     "2^53 + 1 is not less than 2^53.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
-			float:    NewFloat(9007199254740992.0),                           // 2^53
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(9007199254740993)), // 2^53 + 1
+			float:    values.NewFloat(9007199254740992.0),                           // 2^53
 			expected: false,
 		},
 		{
 			name:     "2^53 - 1 is less than 2^53.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(9007199254740991)), // 2^53 - 1
-			float:    NewFloat(9007199254740992.0),                           // 2^53
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(9007199254740991)), // 2^53 - 1
+			float:    values.NewFloat(9007199254740992.0),                           // 2^53
 			expected: true,
 		},
 		{
 			name:     "42 is not less than 42.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(42)),
-			float:    NewFloat(42.0),
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(42)),
+			float:    values.NewFloat(42.0),
 			expected: false,
 		},
 		{
 			name:     "10 is less than 20.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(10)),
-			float:    NewFloat(20.0),
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(10)),
+			float:    values.NewFloat(20.0),
 			expected: true,
 		},
 	}
@@ -234,26 +236,26 @@ func TestBigIntegerEqualToFloat(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		bigInt   *BigInteger
-		other    Value
+		bigInt   *values.BigInteger
+		other    values.Value
 		expected bool
 	}{
 		{
 			name:     "2^53 + 1 is not equal to 2^53.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(9007199254740993)),
-			other:    NewFloat(9007199254740992.0),
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(9007199254740993)),
+			other:    values.NewFloat(9007199254740992.0),
 			expected: false, // Different values
 		},
 		{
 			name:     "2^53 equals 2^53.0",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(9007199254740992)),
-			other:    NewFloat(9007199254740992.0),
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(9007199254740992)),
+			other:    values.NewFloat(9007199254740992.0),
 			expected: false, // EqualTo doesn't compare across exact/inexact
 		},
 		{
 			name:     "42 equals Integer 42",
-			bigInt:   NewBigInteger(new(big.Int).SetInt64(42)),
-			other:    NewInteger(42),
+			bigInt:   values.NewBigInteger(new(big.Int).SetInt64(42)),
+			other:    values.NewInteger(42),
 			expected: true, // Same exact value
 		},
 	}

--- a/values/big_number_test.go
+++ b/values/big_number_test.go
@@ -12,54 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math/big"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestBigInteger_Constructors(t *testing.T) {
 	c := qt.New(t)
 
 	// From int64
-	bi1 := NewBigIntegerFromInt64(42)
+	bi1 := values.NewBigIntegerFromInt64(42)
 	c.Assert(bi1.Int64(), qt.Equals, int64(42))
 
 	// From string
-	bi2 := NewBigIntegerFromString("12345678901234567890", 10)
+	bi2 := values.NewBigIntegerFromString("12345678901234567890", 10)
 	c.Assert(bi2, qt.IsNotNil)
 	c.Assert(bi2.BigInt().String(), qt.Equals, "12345678901234567890")
 
 	// From big.Int
 	bigVal := big.NewInt(99)
-	bi3 := NewBigInteger(bigVal)
+	bi3 := values.NewBigInteger(bigVal)
 	c.Assert(bi3.Int64(), qt.Equals, int64(99))
 
 	// Invalid string returns nil
-	bi4 := NewBigIntegerFromString("invalid", 10)
+	bi4 := values.NewBigIntegerFromString("invalid", 10)
 	c.Assert(bi4, qt.IsNil)
 }
 
 func TestBigInteger_Arithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bi1 := NewBigIntegerFromInt64(100)
-	bi2 := NewBigIntegerFromInt64(50)
+	bi1 := values.NewBigIntegerFromInt64(100)
+	bi2 := values.NewBigIntegerFromInt64(50)
 
 	// Add
 	sum := bi1.Add(bi2)
-	c.Assert(sum.(*BigInteger).Int64(), qt.Equals, int64(150))
+	c.Assert(sum.(*values.BigInteger).Int64(), qt.Equals, int64(150))
 
 	// Subtract
 	diff := bi1.Subtract(bi2)
-	c.Assert(diff.(*BigInteger).Int64(), qt.Equals, int64(50))
+	c.Assert(diff.(*values.BigInteger).Int64(), qt.Equals, int64(50))
 
 	// Multiply
 	prod := bi1.Multiply(bi2)
-	c.Assert(prod.(*BigInteger).Int64(), qt.Equals, int64(5000))
+	c.Assert(prod.(*values.BigInteger).Int64(), qt.Equals, int64(5000))
 
 	// Divide (returns Rational for exact division)
 	quot := bi1.Divide(bi2)
@@ -67,15 +70,15 @@ func TestBigInteger_Arithmetic(t *testing.T) {
 
 	// Negate
 	neg := bi1.Negate()
-	c.Assert(neg.(*BigInteger).Int64(), qt.Equals, int64(-100))
+	c.Assert(neg.(*values.BigInteger).Int64(), qt.Equals, int64(-100))
 }
 
 func TestBigInteger_Comparison(t *testing.T) {
 	c := qt.New(t)
 
-	bi1 := NewBigIntegerFromInt64(100)
-	bi2 := NewBigIntegerFromInt64(50)
-	bi3 := NewBigIntegerFromInt64(100)
+	bi1 := values.NewBigIntegerFromInt64(100)
+	bi2 := values.NewBigIntegerFromInt64(50)
+	bi3 := values.NewBigIntegerFromInt64(100)
 
 	c.Assert(bi1.Compare(bi2), qt.Equals, 1)
 	c.Assert(bi2.Compare(bi1), qt.Equals, -1)
@@ -88,9 +91,9 @@ func TestBigInteger_Comparison(t *testing.T) {
 func TestBigInteger_Properties(t *testing.T) {
 	c := qt.New(t)
 
-	positive := NewBigIntegerFromInt64(42)
-	negative := NewBigIntegerFromInt64(-42)
-	zero := NewBigIntegerFromInt64(0)
+	positive := values.NewBigIntegerFromInt64(42)
+	negative := values.NewBigIntegerFromInt64(-42)
+	zero := values.NewBigIntegerFromInt64(0)
 
 	c.Assert(positive.IsPositive(), qt.IsTrue)
 	c.Assert(positive.IsNegative(), qt.IsFalse)
@@ -110,14 +113,14 @@ func TestBigInteger_Properties(t *testing.T) {
 func TestBigInteger_Conversions(t *testing.T) {
 	c := qt.New(t)
 
-	bi := NewBigIntegerFromInt64(42)
+	bi := values.NewBigIntegerFromInt64(42)
 
 	// ToExact should return itself
-	c.Assert(bi.ToExact(), SchemeEquals, bi)
+	c.Assert(bi.ToExact(), valuestest.SchemeEquals, bi)
 
 	// ToInexact should return Float
 	inexact := bi.ToInexact()
-	f, ok := inexact.(*Float)
+	f, ok := inexact.(*values.Float)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(f.Value, qt.Equals, float64(42))
 
@@ -128,37 +131,37 @@ func TestBigInteger_Conversions(t *testing.T) {
 func TestBigInteger_EqualTo(t *testing.T) {
 	c := qt.New(t)
 
-	bi1 := NewBigIntegerFromInt64(42)
-	bi2 := NewBigIntegerFromInt64(42)
-	bi3 := NewBigIntegerFromInt64(99)
-	int1 := NewInteger(42)
+	bi1 := values.NewBigIntegerFromInt64(42)
+	bi2 := values.NewBigIntegerFromInt64(42)
+	bi3 := values.NewBigIntegerFromInt64(99)
+	int1 := values.NewInteger(42)
 
 	c.Assert(bi1.EqualTo(bi2), qt.IsTrue)
 	c.Assert(bi1.EqualTo(bi3), qt.IsFalse)
 	c.Assert(bi1.EqualTo(int1), qt.IsTrue) // Should equal regular Integer
-	c.Assert(bi1.EqualTo(NewFloat(42.0)), qt.IsFalse)
+	c.Assert(bi1.EqualTo(values.NewFloat(42.0)), qt.IsFalse)
 }
 
 func TestBigInteger_MixedArithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bi := NewBigIntegerFromInt64(100)
+	bi := values.NewBigIntegerFromInt64(100)
 
 	// Add with Integer
-	sum := bi.Add(NewInteger(50))
-	c.Assert(sum.(*BigInteger).Int64(), qt.Equals, int64(150))
+	sum := bi.Add(values.NewInteger(50))
+	c.Assert(sum.(*values.BigInteger).Int64(), qt.Equals, int64(150))
 
 	// Add with Float - now returns BigFloat for precision preservation
-	sumF := bi.Add(NewFloat(0.5))
+	sumF := bi.Add(values.NewFloat(0.5))
 	// Result must be BigFloat (inexact) to preserve exactness contagion
-	bf, ok := sumF.(*BigFloat)
+	bf, ok := sumF.(*values.BigFloat)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("Expected *BigFloat, got %T", sumF))
 	c.Assert(bf.Float64(), qt.Equals, float64(100.5))
 	c.Assert(bf.IsExact(), qt.Equals, false) // Must be inexact
 
 	// Add with Complex
-	sumC := bi.Add(NewComplex(complex(1, 2)))
-	comp, ok := sumC.(*Complex)
+	sumC := bi.Add(values.NewComplex(complex(1, 2)))
+	comp, ok := sumC.(*values.Complex)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(real(comp.Datum()), qt.Equals, float64(101))
 }
@@ -167,56 +170,56 @@ func TestBigFloat_Constructors(t *testing.T) {
 	c := qt.New(t)
 
 	// From float64
-	bf1 := NewBigFloatFromFloat64(3.14)
+	bf1 := values.NewBigFloatFromFloat64(3.14)
 	c.Assert(bf1.Float64(), qt.Equals, float64(3.14))
 
 	// From string
-	bf2 := NewBigFloatFromString("3.14159265358979323846")
+	bf2 := values.NewBigFloatFromString("3.14159265358979323846")
 	c.Assert(bf2, qt.IsNotNil)
 
 	// From big.Float
 	bigVal := big.NewFloat(2.71)
-	bf3 := NewBigFloat(bigVal)
+	bf3 := values.NewBigFloat(bigVal)
 	c.Assert(bf3.Float64(), qt.Equals, float64(2.71))
 
 	// Invalid string returns nil
-	bf4 := NewBigFloatFromString("invalid")
+	bf4 := values.NewBigFloatFromString("invalid")
 	c.Assert(bf4, qt.IsNil)
 }
 
 func TestBigFloat_Arithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bf1 := NewBigFloatFromFloat64(100.0)
-	bf2 := NewBigFloatFromFloat64(50.0)
+	bf1 := values.NewBigFloatFromFloat64(100.0)
+	bf2 := values.NewBigFloatFromFloat64(50.0)
 
 	// Add
 	sum := bf1.Add(bf2)
-	c.Assert(sum.(*BigFloat).Float64(), qt.Equals, float64(150.0))
+	c.Assert(sum.(*values.BigFloat).Float64(), qt.Equals, float64(150.0))
 
 	// Subtract
 	diff := bf1.Subtract(bf2)
-	c.Assert(diff.(*BigFloat).Float64(), qt.Equals, float64(50.0))
+	c.Assert(diff.(*values.BigFloat).Float64(), qt.Equals, float64(50.0))
 
 	// Multiply
 	prod := bf1.Multiply(bf2)
-	c.Assert(prod.(*BigFloat).Float64(), qt.Equals, float64(5000.0))
+	c.Assert(prod.(*values.BigFloat).Float64(), qt.Equals, float64(5000.0))
 
 	// Divide
 	quot := bf1.Divide(bf2)
-	c.Assert(quot.(*BigFloat).Float64(), qt.Equals, float64(2.0))
+	c.Assert(quot.(*values.BigFloat).Float64(), qt.Equals, float64(2.0))
 
 	// Negate
 	neg := bf1.Negate()
-	c.Assert(neg.(*BigFloat).Float64(), qt.Equals, float64(-100.0))
+	c.Assert(neg.(*values.BigFloat).Float64(), qt.Equals, float64(-100.0))
 }
 
 func TestBigFloat_Comparison(t *testing.T) {
 	c := qt.New(t)
 
-	bf1 := NewBigFloatFromFloat64(100.0)
-	bf2 := NewBigFloatFromFloat64(50.0)
-	bf3 := NewBigFloatFromFloat64(100.0)
+	bf1 := values.NewBigFloatFromFloat64(100.0)
+	bf2 := values.NewBigFloatFromFloat64(50.0)
+	bf3 := values.NewBigFloatFromFloat64(100.0)
 
 	c.Assert(bf1.Compare(bf2), qt.Equals, 1)
 	c.Assert(bf2.Compare(bf1), qt.Equals, -1)
@@ -229,9 +232,9 @@ func TestBigFloat_Comparison(t *testing.T) {
 func TestBigFloat_Properties(t *testing.T) {
 	c := qt.New(t)
 
-	positive := NewBigFloatFromFloat64(3.14)
-	negative := NewBigFloatFromFloat64(-3.14)
-	zero := NewBigFloatFromFloat64(0.0)
+	positive := values.NewBigFloatFromFloat64(3.14)
+	negative := values.NewBigFloatFromFloat64(-3.14)
+	zero := values.NewBigFloatFromFloat64(0.0)
 
 	c.Assert(positive.IsPositive(), qt.IsTrue)
 	c.Assert(positive.IsNegative(), qt.IsFalse)
@@ -251,14 +254,14 @@ func TestBigFloat_Properties(t *testing.T) {
 func TestBigFloat_Conversions(t *testing.T) {
 	c := qt.New(t)
 
-	bf := NewBigFloatFromFloat64(3.14)
+	bf := values.NewBigFloatFromFloat64(3.14)
 
 	// ToInexact should return itself
-	c.Assert(bf.ToInexact(), SchemeEquals, bf)
+	c.Assert(bf.ToInexact(), valuestest.SchemeEquals, bf)
 
 	// ToExact should return Rational
 	exact := bf.ToExact()
-	_, ok := exact.(*Rational)
+	_, ok := exact.(*values.Rational)
 	c.Assert(ok, qt.IsTrue)
 
 	// SchemeString
@@ -268,48 +271,48 @@ func TestBigFloat_Conversions(t *testing.T) {
 func TestBigFloat_EqualTo(t *testing.T) {
 	c := qt.New(t)
 
-	bf1 := NewBigFloatFromFloat64(3.14)
-	bf2 := NewBigFloatFromFloat64(3.14)
-	bf3 := NewBigFloatFromFloat64(2.71)
-	f1 := NewFloat(3.14)
+	bf1 := values.NewBigFloatFromFloat64(3.14)
+	bf2 := values.NewBigFloatFromFloat64(3.14)
+	bf3 := values.NewBigFloatFromFloat64(2.71)
+	f1 := values.NewFloat(3.14)
 
 	c.Assert(bf1.EqualTo(bf2), qt.IsTrue)
 	c.Assert(bf1.EqualTo(bf3), qt.IsFalse)
 	c.Assert(bf1.EqualTo(f1), qt.IsTrue) // Should equal regular Float
-	c.Assert(bf1.EqualTo(NewInteger(3)), qt.IsFalse)
+	c.Assert(bf1.EqualTo(values.NewInteger(3)), qt.IsFalse)
 }
 
 func TestBigFloat_MixedArithmetic(t *testing.T) {
 	c := qt.New(t)
 
-	bf := NewBigFloatFromFloat64(100.0)
+	bf := values.NewBigFloatFromFloat64(100.0)
 
 	// Add with Integer
-	sum := bf.Add(NewInteger(50))
-	c.Assert(sum.(*BigFloat).Float64(), qt.Equals, float64(150.0))
+	sum := bf.Add(values.NewInteger(50))
+	c.Assert(sum.(*values.BigFloat).Float64(), qt.Equals, float64(150.0))
 
 	// Add with Float
-	sumF := bf.Add(NewFloat(0.5))
-	c.Assert(sumF.(*BigFloat).Float64(), qt.Equals, float64(100.5))
+	sumF := bf.Add(values.NewFloat(0.5))
+	c.Assert(sumF.(*values.BigFloat).Float64(), qt.Equals, float64(100.5))
 
 	// Add with BigInteger
-	sumBI := bf.Add(NewBigIntegerFromInt64(25))
-	c.Assert(sumBI.(*BigFloat).Float64(), qt.Equals, float64(125.0))
+	sumBI := bf.Add(values.NewBigIntegerFromInt64(25))
+	c.Assert(sumBI.(*values.BigFloat).Float64(), qt.Equals, float64(125.0))
 
 	// Add with Complex (returns BigComplex to preserve BigFloat precision)
-	sumC := bf.Add(NewComplex(complex(1, 2)))
-	bc, ok := sumC.(*BigComplex)
+	sumC := bf.Add(values.NewComplex(complex(1, 2)))
+	bc, ok := sumC.(*values.BigComplex)
 	c.Assert(ok, qt.IsTrue)
 	// Real part should be 100 + 1 = 101
 	realPart := bc.Real()
-	c.Assert(realPart.(*BigFloat).Float64(), qt.Equals, float64(101))
+	c.Assert(realPart.(*values.BigFloat).Float64(), qt.Equals, float64(101))
 }
 
 func TestBigInteger_DivisionByZero(t *testing.T) {
 	c := qt.New(t)
 
-	bi := NewBigIntegerFromInt64(100)
-	zero := NewBigIntegerFromInt64(0)
+	bi := values.NewBigIntegerFromInt64(100)
+	zero := values.NewBigIntegerFromInt64(0)
 
 	c.Assert(func() { bi.Divide(zero) }, qt.PanicMatches, "division by zero")
 }
@@ -317,8 +320,8 @@ func TestBigInteger_DivisionByZero(t *testing.T) {
 func TestBigFloat_DivisionByZero(t *testing.T) {
 	c := qt.New(t)
 
-	bf := NewBigFloatFromFloat64(100.0)
-	zero := NewBigFloatFromFloat64(0.0)
+	bf := values.NewBigFloatFromFloat64(100.0)
+	zero := values.NewBigFloatFromFloat64(0.0)
 
 	c.Assert(func() { bf.Divide(zero) }, qt.PanicMatches, "division by zero")
 }
@@ -326,36 +329,36 @@ func TestBigFloat_DivisionByZero(t *testing.T) {
 func TestBigInteger_IsVoid(t *testing.T) {
 	c := qt.New(t)
 
-	bi := NewBigIntegerFromInt64(42)
+	bi := values.NewBigIntegerFromInt64(42)
 	c.Assert(bi.IsVoid(), qt.IsFalse)
 
-	var nilBI *BigInteger
+	var nilBI *values.BigInteger
 	c.Assert(nilBI.IsVoid(), qt.IsTrue)
 }
 
 func TestBigFloat_IsVoid(t *testing.T) {
 	c := qt.New(t)
 
-	bf := NewBigFloatFromFloat64(3.14)
+	bf := values.NewBigFloatFromFloat64(3.14)
 	c.Assert(bf.IsVoid(), qt.IsFalse)
 
-	var nilBF *BigFloat
+	var nilBF *values.BigFloat
 	c.Assert(nilBF.IsVoid(), qt.IsTrue)
 }
 
 func TestBigInteger_ZeroOptimizations(t *testing.T) {
 	c := qt.New(t)
 
-	bi := NewBigIntegerFromInt64(100)
-	zero := NewBigIntegerFromInt64(0)
+	bi := values.NewBigIntegerFromInt64(100)
+	zero := values.NewBigIntegerFromInt64(0)
 
 	// Add with zero returns original
 	sum := bi.Add(zero)
-	c.Assert(sum, SchemeEquals, bi)
+	c.Assert(sum, valuestest.SchemeEquals, bi)
 
 	// Zero + bi returns bi
 	sum2 := zero.Add(bi)
-	c.Assert(sum2, SchemeEquals, bi)
+	c.Assert(sum2, valuestest.SchemeEquals, bi)
 
 	// Multiply by zero — returns exact zero (may be Integer due to R7RS exact-zero rule)
 	prod := bi.Multiply(zero)
@@ -366,18 +369,18 @@ func TestBigInteger_ZeroOptimizations(t *testing.T) {
 func TestBigFloat_ZeroOptimizations(t *testing.T) {
 	c := qt.New(t)
 
-	bf := NewBigFloatFromFloat64(100.0)
-	zero := NewBigFloatFromFloat64(0.0)
+	bf := values.NewBigFloatFromFloat64(100.0)
+	zero := values.NewBigFloatFromFloat64(0.0)
 
 	// Add with zero returns original
 	sum := bf.Add(zero)
-	c.Assert(sum, SchemeEquals, bf)
+	c.Assert(sum, valuestest.SchemeEquals, bf)
 
 	// Zero + bf returns bf
 	sum2 := zero.Add(bf)
-	c.Assert(sum2, SchemeEquals, bf)
+	c.Assert(sum2, valuestest.SchemeEquals, bf)
 
 	// Multiply by zero
 	prod := bf.Multiply(zero)
-	c.Assert(prod.(*BigFloat).IsZero(), qt.IsTrue)
+	c.Assert(prod.(*values.BigFloat).IsZero(), qt.IsTrue)
 }

--- a/values/binary_port_test.go
+++ b/values/binary_port_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"bytes"
@@ -22,12 +22,14 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // --- BinaryInputPort ---
 
 func TestBinaryInputPort_ReadByte(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{42, 99}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{42, 99}))
 
 	b1, err := port.ReadByte()
 	qt.Assert(t, err, qt.IsNil)
@@ -42,7 +44,7 @@ func TestBinaryInputPort_ReadByte(t *testing.T) {
 }
 
 func TestBinaryInputPort_Read(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1, 2, 3, 4, 5}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1, 2, 3, 4, 5}))
 
 	buf := make([]byte, 3)
 	n, err := port.Read(buf)
@@ -52,7 +54,7 @@ func TestBinaryInputPort_Read(t *testing.T) {
 }
 
 func TestBinaryInputPort_UnreadByte(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1, 2}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1, 2}))
 
 	b, _ := port.ReadByte()
 	qt.Assert(t, b, qt.Equals, byte(1))
@@ -65,55 +67,55 @@ func TestBinaryInputPort_UnreadByte(t *testing.T) {
 }
 
 func TestBinaryInputPort_Close(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	err := port.Close()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, port.IsClosed(), qt.IsTrue)
 
 	// Operations after close return ErrPortClosed
 	_, err = port.ReadByte()
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 
 	err = port.UnreadByte()
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 
 	_, err = port.Read(make([]byte, 1))
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 }
 
 func TestBinaryInputPort_CloseWithCloser(t *testing.T) {
 	// io.ReadCloser integrates Closer
 	rc := io.NopCloser(bytes.NewReader([]byte{1}))
-	port := NewBinaryInputPortFromReader(rc)
+	port := values.NewBinaryInputPortFromReader(rc)
 	err := port.Close()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, port.IsClosed(), qt.IsTrue)
 }
 
 func TestBinaryInputPort_IsVoid(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *BinaryInputPort
+	var nilPort *values.BinaryInputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestBinaryInputPort_EqualTo(t *testing.T) {
-	port1 := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
-	port2 := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port1 := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port2 := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
-	qt.Assert(t, port1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, port1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestBinaryInputPort_SchemeString(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "binary-input-port"), qt.IsTrue)
 }
 
 func TestBinaryInputPort_Datum(t *testing.T) {
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	qt.Assert(t, port.Datum(), qt.Not(qt.IsNil))
 }
 
@@ -121,7 +123,7 @@ func TestBinaryInputPort_Datum(t *testing.T) {
 
 func TestBinaryOutputPort_WriteByte(t *testing.T) {
 	buf := &bytes.Buffer{}
-	port := NewBinaryOutputPortFromWriter(buf)
+	port := values.NewBinaryOutputPortFromWriter(buf)
 
 	err := port.WriteByte(42)
 	qt.Assert(t, err, qt.IsNil)
@@ -134,7 +136,7 @@ func TestBinaryOutputPort_WriteByte(t *testing.T) {
 
 func TestBinaryOutputPort_Write(t *testing.T) {
 	buf := &bytes.Buffer{}
-	port := NewBinaryOutputPortFromWriter(buf)
+	port := values.NewBinaryOutputPortFromWriter(buf)
 
 	n, err := port.Write([]byte{1, 2, 3})
 	qt.Assert(t, err, qt.IsNil)
@@ -147,46 +149,46 @@ func TestBinaryOutputPort_Write(t *testing.T) {
 
 func TestBinaryOutputPort_Close(t *testing.T) {
 	buf := &bytes.Buffer{}
-	port := NewBinaryOutputPortFromWriter(buf)
+	port := values.NewBinaryOutputPortFromWriter(buf)
 	err := port.Close()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, port.IsClosed(), qt.IsTrue)
 
 	// Operations after close return ErrPortClosed
 	err = port.WriteByte(1)
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 
 	_, err = port.Write([]byte{1})
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 
 	err = port.Flush()
-	qt.Assert(t, errors.Is(err, ErrPortClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrPortClosed), qt.IsTrue)
 }
 
 func TestBinaryOutputPort_IsVoid(t *testing.T) {
 	buf := &bytes.Buffer{}
-	port := NewBinaryOutputPortFromWriter(buf)
+	port := values.NewBinaryOutputPortFromWriter(buf)
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *BinaryOutputPort
+	var nilPort *values.BinaryOutputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestBinaryOutputPort_EqualTo(t *testing.T) {
-	port1 := NewBinaryOutputPortFromWriter(&bytes.Buffer{})
-	port2 := NewBinaryOutputPortFromWriter(&bytes.Buffer{})
+	port1 := values.NewBinaryOutputPortFromWriter(&bytes.Buffer{})
+	port2 := values.NewBinaryOutputPortFromWriter(&bytes.Buffer{})
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
-	qt.Assert(t, port1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, port1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestBinaryOutputPort_SchemeString(t *testing.T) {
-	port := NewBinaryOutputPortFromWriter(&bytes.Buffer{})
+	port := values.NewBinaryOutputPortFromWriter(&bytes.Buffer{})
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "binary-output-port"), qt.IsTrue)
 }
 
 func TestBinaryOutputPort_Datum(t *testing.T) {
-	port := NewBinaryOutputPortFromWriter(&bytes.Buffer{})
+	port := values.NewBinaryOutputPortFromWriter(&bytes.Buffer{})
 	qt.Assert(t, port.Datum(), qt.Not(qt.IsNil))
 }

--- a/values/boolean_test.go
+++ b/values/boolean_test.go
@@ -12,47 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestBoolean_New(t *testing.T) {
 	tcs := []struct {
 		in  bool
-		out Value
+		out values.Value
 	}{
 		{
 			in:  true,
-			out: NewBoolean(true),
+			out: values.NewBoolean(true),
 		},
 		{
 			in:  false,
-			out: NewBoolean(false),
+			out: values.NewBoolean(false),
 		},
 	}
 	for _, tc := range tcs {
 		t.Run("", func(t *testing.T) {
-			v := NewBoolean(tc.in)
-			qt.Assert(t, v, SchemeEquals, tc.out)
+			v := values.NewBoolean(tc.in)
+			qt.Assert(t, v, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
 
 func TestBoolean_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewBoolean(true),
+			in:  values.NewBoolean(true),
 			out: "#t",
 		},
 		{
-			in:  NewBoolean(false),
+			in:  values.NewBoolean(false),
 			out: "#f",
 		},
 	}
@@ -65,23 +68,23 @@ func TestBoolean_SchemeString(t *testing.T) {
 
 func TestBoolean_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewBoolean(true),
-			in1: NewBoolean(true),
+			in0: values.NewBoolean(true),
+			in1: values.NewBoolean(true),
 			out: true,
 		},
 		{
-			in0: NewBoolean(true),
-			in1: NewBoolean(false),
+			in0: values.NewBoolean(true),
+			in1: values.NewBoolean(false),
 			out: false,
 		},
 		{
-			in0: NewBoolean(false),
-			in1: NewBoolean(false),
+			in0: values.NewBoolean(false),
+			in1: values.NewBoolean(false),
 			out: true,
 		},
 	}
@@ -93,10 +96,10 @@ func TestBoolean_EqualTo(t *testing.T) {
 }
 
 func TestBoolean_Datum(t *testing.T) {
-	b := NewBoolean(true)
+	b := values.NewBoolean(true)
 	qt.Assert(t, b.Datum(), qt.Equals, true)
 
-	b2 := NewBoolean(false)
+	b2 := values.NewBoolean(false)
 	qt.Assert(t, b2.Datum(), qt.Equals, false)
 }
 
@@ -104,23 +107,23 @@ func TestBoolToBoolean(t *testing.T) {
 	tcs := []struct {
 		name string
 		in   bool
-		out  *Boolean
+		out  *values.Boolean
 	}{
 		{
 			name: "true returns TrueValue",
 			in:   true,
-			out:  TrueValue,
+			out:  values.TrueValue,
 		},
 		{
 			name: "false returns FalseValue",
 			in:   false,
-			out:  FalseValue,
+			out:  values.FalseValue,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
-			result := BoolToBoolean(tc.in)
+			result := values.BoolToBoolean(tc.in)
 			c.Assert(result, qt.Equals, tc.out)
 		})
 	}
@@ -129,79 +132,79 @@ func TestBoolToBoolean(t *testing.T) {
 func TestValueToBool(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  bool
 	}{
 		{
 			name: "boolean false returns false",
-			in:   FalseValue,
+			in:   values.FalseValue,
 			out:  false,
 		},
 		{
 			name: "boolean true returns true",
-			in:   TrueValue,
+			in:   values.TrueValue,
 			out:  true,
 		},
 		{
 			name: "integer returns true (Scheme semantics)",
-			in:   NewInteger(0),
+			in:   values.NewInteger(0),
 			out:  true,
 		},
 		{
 			name: "negative integer returns true",
-			in:   NewInteger(-1),
+			in:   values.NewInteger(-1),
 			out:  true,
 		},
 		{
 			name: "positive integer returns true",
-			in:   NewInteger(42),
+			in:   values.NewInteger(42),
 			out:  true,
 		},
 		{
 			name: "empty string returns true",
-			in:   NewString(""),
+			in:   values.NewString(""),
 			out:  true,
 		},
 		{
 			name: "non-empty string returns true",
-			in:   NewString("hello"),
+			in:   values.NewString("hello"),
 			out:  true,
 		},
 		{
 			name: "empty list returns true",
-			in:   EmptyList,
+			in:   values.EmptyList,
 			out:  true,
 		},
 		{
 			name: "pair returns true",
-			in:   NewCons(NewInteger(1), NewInteger(2)),
+			in:   values.NewCons(values.NewInteger(1), values.NewInteger(2)),
 			out:  true,
 		},
 		{
 			name: "symbol returns true",
-			in:   NewSymbol("foo"),
+			in:   values.NewSymbol("foo"),
 			out:  true,
 		},
 		{
 			name: "void returns true",
-			in:   Void,
+			in:   values.Void,
 			out:  true,
 		},
 		{
 			name: "character returns true",
-			in:   NewCharacter('a'),
+			in:   values.NewCharacter('a'),
 			out:  true,
 		},
 		{
 			name: "float zero returns true",
-			in:   NewFloat(0.0),
+			in:   values.NewFloat(0.0),
 			out:  true,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
-			result := ValueToBool(tc.in)
+			result := values.ValueToBool(tc.in)
 			c.Assert(result, qt.Equals, tc.out)
 		})
 	}
@@ -210,44 +213,44 @@ func TestValueToBool(t *testing.T) {
 func TestValueToBoolean(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
-		out  *Boolean
+		in   values.Value
+		out  *values.Boolean
 	}{
 		{
 			name: "boolean false returns FalseValue",
-			in:   FalseValue,
-			out:  FalseValue,
+			in:   values.FalseValue,
+			out:  values.FalseValue,
 		},
 		{
 			name: "boolean true returns TrueValue",
-			in:   TrueValue,
-			out:  TrueValue,
+			in:   values.TrueValue,
+			out:  values.TrueValue,
 		},
 		{
 			name: "integer returns TrueValue (Scheme semantics)",
-			in:   NewInteger(0),
-			out:  TrueValue,
+			in:   values.NewInteger(0),
+			out:  values.TrueValue,
 		},
 		{
 			name: "string returns TrueValue",
-			in:   NewString(""),
-			out:  TrueValue,
+			in:   values.NewString(""),
+			out:  values.TrueValue,
 		},
 		{
 			name: "empty list returns TrueValue",
-			in:   EmptyList,
-			out:  TrueValue,
+			in:   values.EmptyList,
+			out:  values.TrueValue,
 		},
 		{
 			name: "symbol returns TrueValue",
-			in:   NewSymbol("bar"),
-			out:  TrueValue,
+			in:   values.NewSymbol("bar"),
+			out:  values.TrueValue,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			c := qt.New(t)
-			result := ValueToBoolean(tc.in)
+			result := values.ValueToBoolean(tc.in)
 			c.Assert(result, qt.Equals, tc.out)
 		})
 	}

--- a/values/box_test.go
+++ b/values/box_test.go
@@ -12,25 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestBox_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewBox(NewBoolean(true)),
+			in:  values.NewBox(values.NewBoolean(true)),
 			out: "#&#t",
 		},
 		{
-			in:  NewBox(NewBoolean(false)),
+			in:  values.NewBox(values.NewBoolean(false)),
 			out: "#&#f",
 		},
 	}
@@ -43,23 +46,23 @@ func TestBox_SchemeString(t *testing.T) {
 
 func TestBox_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewBox(NewInteger(10)),
-			in1: NewBox(NewInteger(20)),
+			in0: values.NewBox(values.NewInteger(10)),
+			in1: values.NewBox(values.NewInteger(20)),
 			out: false,
 		},
 		{
-			in0: NewBox(NewInteger(10)),
-			in1: NewBox(NewInteger(10)),
+			in0: values.NewBox(values.NewInteger(10)),
+			in1: values.NewBox(values.NewInteger(10)),
 			out: true,
 		},
 		{
-			in0: NewBox(nil),
-			in1: NewBox(nil),
+			in0: values.NewBox(nil),
+			in1: values.NewBox(nil),
 			out: true,
 		},
 	}
@@ -71,22 +74,22 @@ func TestBox_EqualTo(t *testing.T) {
 }
 
 func TestBox_Unbox(t *testing.T) {
-	b := NewBox(NewInteger(42))
-	qt.Assert(t, b.Unbox(), SchemeEquals, NewInteger(42))
+	b := values.NewBox(values.NewInteger(42))
+	qt.Assert(t, b.Unbox(), valuestest.SchemeEquals, values.NewInteger(42))
 
-	b2 := NewBox(NewString("test"))
-	qt.Assert(t, b2.Unbox(), SchemeEquals, NewString("test"))
+	b2 := values.NewBox(values.NewString("test"))
+	qt.Assert(t, b2.Unbox(), valuestest.SchemeEquals, values.NewString("test"))
 }
 
 func TestBox_Datum(t *testing.T) {
-	b := NewBox(NewInteger(99))
-	qt.Assert(t, b.Datum(), SchemeEquals, NewInteger(99))
+	b := values.NewBox(values.NewInteger(99))
+	qt.Assert(t, b.Datum(), valuestest.SchemeEquals, values.NewInteger(99))
 }
 
 func TestBox_IsVoid(t *testing.T) {
-	b := NewBox(NewInteger(1))
+	b := values.NewBox(values.NewInteger(1))
 	qt.Assert(t, b.IsVoid(), qt.IsFalse)
 
-	var nilBox *Box
+	var nilBox *values.Box
 	qt.Assert(t, nilBox.IsVoid(), qt.IsTrue)
 }

--- a/values/byte_test.go
+++ b/values/byte_test.go
@@ -12,25 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestByte_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewByte(10),
+			in:  values.NewByte(10),
 			out: "10",
 		},
 		{
-			in:  NewByte(20),
+			in:  values.NewByte(20),
 			out: "20",
 		},
 	}
@@ -43,18 +45,18 @@ func TestByte_SchemeString(t *testing.T) {
 
 func TestByte_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewByte(1),
-			in1: NewByte(1),
+			in0: values.NewByte(1),
+			in1: values.NewByte(1),
 			out: true,
 		},
 		{
-			in0: NewByte(1),
-			in1: NewByte(0),
+			in0: values.NewByte(1),
+			in1: values.NewByte(0),
 			out: false,
 		},
 	}

--- a/values/byte_vector_port_test.go
+++ b/values/byte_vector_port_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"bytes"
@@ -20,9 +20,11 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
-func toBytes(bv *ByteVector) []byte {
+func toBytes(bv *values.ByteVector) []byte {
 	out := make([]byte, len(*bv))
 	for i, v := range *bv {
 		out[i] = v.Value
@@ -31,14 +33,14 @@ func toBytes(bv *ByteVector) []byte {
 }
 
 func TestBytevectorInputPort_NewBytevectorInputPort(t *testing.T) {
-	bv := NewByteVectorFromBytes(1, 2, 3)
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
+	bv := values.NewByteVectorFromBytes(1, 2, 3)
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestBytevectorInputPort_Read(t *testing.T) {
-	bv := NewByteVectorFromBytes(1, 2, 3, 4, 5)
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
+	bv := values.NewByteVectorFromBytes(1, 2, 3, 4, 5)
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
 
 	buf := make([]byte, 3)
 	n, err := port.Read(buf)
@@ -48,95 +50,95 @@ func TestBytevectorInputPort_Read(t *testing.T) {
 }
 
 func TestBytevectorInputPort_ReadByte(t *testing.T) {
-	bv := NewByteVectorFromBytes(42, 99)
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
+	bv := values.NewByteVectorFromBytes(42, 99)
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
 
 	b1, err := port.ReadByte()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, b1, qt.Equals, NewByte(42).Value)
+	qt.Assert(t, b1, qt.Equals, values.NewByte(42).Value)
 
 	b2, err := port.ReadByte()
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, b2, qt.Equals, NewByte(99).Value)
+	qt.Assert(t, b2, qt.Equals, values.NewByte(99).Value)
 }
 
 func TestBytevectorInputPort_UnreadByte(t *testing.T) {
-	bv := NewByteVectorFromBytes(1, 2)
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
+	bv := values.NewByteVectorFromBytes(1, 2)
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(bv)))
 
 	b1, _ := port.ReadByte()
-	qt.Assert(t, b1, qt.Equals, NewByte(1).Value)
+	qt.Assert(t, b1, qt.Equals, values.NewByte(1).Value)
 
 	err := port.UnreadByte()
 	qt.Assert(t, err, qt.IsNil)
 
 	b2, _ := port.ReadByte()
-	qt.Assert(t, b2, qt.Equals, NewByte(1).Value)
+	qt.Assert(t, b2, qt.Equals, values.NewByte(1).Value)
 }
 
 func TestBytevectorInputPort_IsVoid(t *testing.T) {
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(NewByteVectorFromBytes(1))))
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(values.NewByteVectorFromBytes(1))))
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *ByteVectorInputPort
+	var nilPort *values.ByteVectorInputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestBytevectorInputPort_Datum(t *testing.T) {
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(NewByteVectorFromBytes(1))))
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(values.NewByteVectorFromBytes(1))))
 	datum := port.Datum()
 	qt.Assert(t, datum, qt.Not(qt.IsNil))
 }
 
 func TestBytevectorInputPort_EqualTo(t *testing.T) {
-	port1 := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(NewByteVectorFromBytes(1))))
-	port2 := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(NewByteVectorFromBytes(1))))
+	port1 := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(values.NewByteVectorFromBytes(1))))
+	port2 := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(values.NewByteVectorFromBytes(1))))
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
 }
 
 func TestBytevectorInputPort_SchemeString(t *testing.T) {
-	port := NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(NewByteVectorFromBytes(1))))
+	port := values.NewByteVectorInputPortFromReader(bytes.NewBuffer(toBytes(values.NewByteVectorFromBytes(1))))
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "bytevector-input-port"), qt.IsTrue)
 }
 
 func TestBytevectorOutputPort_NewBytevectorOutputPort(t *testing.T) {
-	port := NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
+	port := values.NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestBytevectorOutputPort_Write(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	port := NewByteVectorOutputPortFromWriter(buf)
-	n, err := port.Write(NewByteVectorFromBytes(1, 2, 3).AsBytes())
+	port := values.NewByteVectorOutputPortFromWriter(buf)
+	n, err := port.Write(values.NewByteVectorFromBytes(1, 2, 3).AsBytes())
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, n, qt.Equals, 3)
 	port.Flush()
 
 	bv := buf.Bytes()
-	qt.Assert(t, bv, qt.DeepEquals, NewByteVectorFromBytes(1, 2, 3).AsBytes())
+	qt.Assert(t, bv, qt.DeepEquals, values.NewByteVectorFromBytes(1, 2, 3).AsBytes())
 }
 
 func TestBytevectorOutputPort_WriteByte(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	port := NewByteVectorOutputPortFromWriter(buf)
-	err := port.WriteByte(NewByte(42).Value)
+	port := values.NewByteVectorOutputPortFromWriter(buf)
+	err := port.WriteByte(values.NewByte(42).Value)
 	qt.Assert(t, err, qt.IsNil)
 	port.Flush()
 
 	bv := buf.Bytes()
-	qt.Assert(t, bv, qt.DeepEquals, NewByteVectorFromBytes(42).AsBytes())
+	qt.Assert(t, bv, qt.DeepEquals, values.NewByteVectorFromBytes(42).AsBytes())
 }
 
 func TestBytevectorOutputPort_GetBytevector(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	port := NewByteVectorOutputPortFromWriter(buf)
+	port := values.NewByteVectorOutputPortFromWriter(buf)
 	// write using helpers; ignore errors where intended
-	_, _ = port.Write(NewByteVectorFromBytes(1, 2).AsBytes())
-	_ = port.WriteByte(NewByte(3).Value)
-	_, _ = port.Write(NewByteVectorFromBytes(4, 5).AsBytes())
+	_, _ = port.Write(values.NewByteVectorFromBytes(1, 2).AsBytes())
+	_ = port.WriteByte(values.NewByte(3).Value)
+	_, _ = port.Write(values.NewByteVectorFromBytes(4, 5).AsBytes())
 	_ = port.Flush()
 
 	bv := buf.Bytes()
@@ -145,29 +147,29 @@ func TestBytevectorOutputPort_GetBytevector(t *testing.T) {
 
 func TestBytevectorOutputPort_IsVoid(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	port := NewByteVectorOutputPortFromWriter(buf)
+	port := values.NewByteVectorOutputPortFromWriter(buf)
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *ByteVectorOutputPort
+	var nilPort *values.ByteVectorOutputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestBytevectorOutputPort_Datum(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	port := NewByteVectorOutputPortFromWriter(buf)
+	port := values.NewByteVectorOutputPortFromWriter(buf)
 	datum := port.Datum()
 	qt.Assert(t, datum, qt.Not(qt.IsNil))
 }
 
 func TestBytevectorOutputPort_EqualTo(t *testing.T) {
-	port1 := NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
-	port2 := NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
+	port1 := values.NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
+	port2 := values.NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
 }
 
 func TestBytevectorOutputPort_SchemeString(t *testing.T) {
-	port := NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
+	port := values.NewByteVectorOutputPortFromWriter(bytes.NewBuffer(nil))
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "bytevector-output-port"), qt.IsTrue)
 }

--- a/values/byte_vector_test.go
+++ b/values/byte_vector_test.go
@@ -12,26 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestByteVector_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewByteVector(NewByte(10)),
+			in:  values.NewByteVector(values.NewByte(10)),
 			out: "#u8( 10 )",
 		},
 		{
-			in:  NewByteVector(NewByte(10), NewByte(20)),
+			in:  values.NewByteVector(values.NewByte(10), values.NewByte(20)),
 			out: "#u8( 10 20 )",
 		},
 	}
@@ -44,18 +47,18 @@ func TestByteVector_SchemeString(t *testing.T) {
 
 func TestByteVector_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewByteVector(NewByte(10)),
-			in1: NewByteVector(NewByte(20)),
+			in0: values.NewByteVector(values.NewByte(10)),
+			in1: values.NewByteVector(values.NewByte(20)),
 			out: false,
 		},
 		{
-			in0: NewByteVector(NewByte(10)),
-			in1: NewByteVector(NewByte(10)),
+			in0: values.NewByteVector(values.NewByte(10)),
+			in1: values.NewByteVector(values.NewByte(10)),
 			out: true,
 		},
 	}
@@ -68,24 +71,24 @@ func TestByteVector_EqualTo(t *testing.T) {
 
 func TestByteVector_Get(t *testing.T) {
 	c := qt.New(t)
-	bv := NewByteVector(NewByte(10), NewByte(20), NewByte(30))
-	c.Assert(bv.Get(0), SchemeEquals, NewByte(10))
-	c.Assert(bv.Get(1), SchemeEquals, NewByte(20))
-	c.Assert(bv.Get(2), SchemeEquals, NewByte(30))
+	bv := values.NewByteVector(values.NewByte(10), values.NewByte(20), values.NewByte(30))
+	c.Assert(bv.Get(0), valuestest.SchemeEquals, values.NewByte(10))
+	c.Assert(bv.Get(1), valuestest.SchemeEquals, values.NewByte(20))
+	c.Assert(bv.Get(2), valuestest.SchemeEquals, values.NewByte(30))
 }
 
 func TestByteVector_Set(t *testing.T) {
 	c := qt.New(t)
-	bv := NewByteVector(NewByte(10), NewByte(20), NewByte(30))
-	bv.Set(1, NewByte(99))
-	c.Assert(bv.Get(1), SchemeEquals, NewByte(99))
+	bv := values.NewByteVector(values.NewByte(10), values.NewByte(20), values.NewByte(30))
+	bv.Set(1, values.NewByte(99))
+	c.Assert(bv.Get(1), valuestest.SchemeEquals, values.NewByte(99))
 	c.Assert(bv.SchemeString(), qt.Equals, "#u8( 10 99 30 )")
 }
 
 func TestByteVector_Set_Error(t *testing.T) {
 	c := qt.New(t)
-	bv := NewByteVector(NewByte(10))
-	err := bv.Set(0, NewInteger(42))
+	bv := values.NewByteVector(values.NewByte(10))
+	err := bv.Set(0, values.NewInteger(42))
 	c.Assert(err, qt.Not(qt.IsNil))
 	c.Assert(err, qt.ErrorMatches, ".*bytevector element must be a byte.*")
 }
@@ -95,22 +98,22 @@ func TestByteVector_AsList(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		bv       *ByteVector
+		bv       *values.ByteVector
 		expected string // SchemeString representation
 	}{
 		{
 			name:     "empty bytevector",
-			bv:       NewByteVector(),
+			bv:       values.NewByteVector(),
 			expected: "()",
 		},
 		{
 			name:     "single element",
-			bv:       NewByteVector(NewByte(42)),
+			bv:       values.NewByteVector(values.NewByte(42)),
 			expected: "(42)",
 		},
 		{
 			name:     "multiple elements",
-			bv:       NewByteVector(NewByte(10), NewByte(20), NewByte(30)),
+			bv:       values.NewByteVector(values.NewByte(10), values.NewByte(20), values.NewByte(30)),
 			expected: "(10 20 30)",
 		},
 	}
@@ -125,19 +128,19 @@ func TestByteVector_AsList(t *testing.T) {
 
 func TestByteVector_AsList_Void(t *testing.T) {
 	c := qt.New(t)
-	var bv *ByteVector
+	var bv *values.ByteVector
 	list := bv.AsList()
 	c.Assert(list, qt.IsNil)
 }
 
 func TestByteVector_Datum(t *testing.T) {
 	c := qt.New(t)
-	bv := NewByteVector(NewByte(10), NewByte(20), NewByte(30))
+	bv := values.NewByteVector(values.NewByte(10), values.NewByte(20), values.NewByte(30))
 	datum := bv.Datum()
 	c.Assert(len(datum), qt.Equals, 3)
-	c.Assert(datum[0], SchemeEquals, NewByte(10))
-	c.Assert(datum[1], SchemeEquals, NewByte(20))
-	c.Assert(datum[2], SchemeEquals, NewByte(30))
+	c.Assert(datum[0], valuestest.SchemeEquals, values.NewByte(10))
+	c.Assert(datum[1], valuestest.SchemeEquals, values.NewByte(20))
+	c.Assert(datum[2], valuestest.SchemeEquals, values.NewByte(30))
 }
 
 func TestByteVector_IsVoid(t *testing.T) {
@@ -145,7 +148,7 @@ func TestByteVector_IsVoid(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		bv       *ByteVector
+		bv       *values.ByteVector
 		expected bool
 	}{
 		{
@@ -155,12 +158,12 @@ func TestByteVector_IsVoid(t *testing.T) {
 		},
 		{
 			name:     "empty bytevector",
-			bv:       NewByteVector(),
+			bv:       values.NewByteVector(),
 			expected: false,
 		},
 		{
 			name:     "non-empty bytevector",
-			bv:       NewByteVector(NewByte(42)),
+			bv:       values.NewByteVector(values.NewByte(42)),
 			expected: false,
 		},
 	}
@@ -177,7 +180,7 @@ func TestNewByteVectorFromIntegers(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		ints []*Integer
+		ints []*values.Integer
 		want string
 	}{
 		{
@@ -187,18 +190,18 @@ func TestNewByteVectorFromIntegers(t *testing.T) {
 		},
 		{
 			name: "single byte",
-			ints: []*Integer{NewInteger(42)},
+			ints: []*values.Integer{values.NewInteger(42)},
 			want: "#u8( 42 )",
 		},
 		{
 			name: "boundary values",
-			ints: []*Integer{NewInteger(0), NewInteger(255)},
+			ints: []*values.Integer{values.NewInteger(0), values.NewInteger(255)},
 			want: "#u8( 0 255 )",
 		},
 	}
 	for _, tc := range tcs {
 		c.Run(tc.name, func(c *qt.C) {
-			bv, err := NewByteVectorFromIntegers(tc.ints...)
+			bv, err := values.NewByteVectorFromIntegers(tc.ints...)
 			c.Assert(err, qt.IsNil)
 			c.Assert(bv.SchemeString(), qt.Equals, tc.want)
 		})
@@ -208,30 +211,30 @@ func TestNewByteVectorFromIntegers(t *testing.T) {
 func TestNewByteVectorFromIntegers_Overflow(t *testing.T) {
 	tcs := []struct {
 		name string
-		ints []*Integer
+		ints []*values.Integer
 	}{
 		{
 			name: "negative value",
-			ints: []*Integer{NewInteger(-1)},
+			ints: []*values.Integer{values.NewInteger(-1)},
 		},
 		{
 			name: "above 255",
-			ints: []*Integer{NewInteger(256)},
+			ints: []*values.Integer{values.NewInteger(256)},
 		},
 		{
 			name: "large positive",
-			ints: []*Integer{NewInteger(1000)},
+			ints: []*values.Integer{values.NewInteger(1000)},
 		},
 		{
 			name: "valid then invalid",
-			ints: []*Integer{NewInteger(10), NewInteger(300)},
+			ints: []*values.Integer{values.NewInteger(10), values.NewInteger(300)},
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewByteVectorFromIntegers(tc.ints...)
+			_, err := values.NewByteVectorFromIntegers(tc.ints...)
 			qt.Assert(t, err, qt.IsNotNil)
-			qt.Assert(t, errors.Is(err, ErrNotAByte), qt.IsTrue)
+			qt.Assert(t, errors.Is(err, values.ErrNotAByte), qt.IsTrue)
 		})
 	}
 }

--- a/values/channel_test.go
+++ b/values/channel_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"errors"
@@ -21,62 +21,65 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // --- Channel primitive tests ---
 
 func TestChannel_NewChannel(t *testing.T) {
-	ch := NewChannel(0)
+	ch := values.NewChannel(0)
 	qt.Assert(t, ch, qt.Not(qt.IsNil))
 	qt.Assert(t, ch.BufferSize(), qt.Equals, 0)
 	qt.Assert(t, ch.Cap(), qt.Equals, 0)
 	qt.Assert(t, ch.ID() > 0, qt.IsTrue)
 
-	ch2 := NewChannel(5)
+	ch2 := values.NewChannel(5)
 	qt.Assert(t, ch2.BufferSize(), qt.Equals, 5)
 	qt.Assert(t, ch2.Cap(), qt.Equals, 5)
 }
 
 func TestChannel_NewChannel_NegativeBuffer(t *testing.T) {
-	ch := NewChannel(-1)
+	ch := values.NewChannel(-1)
 	qt.Assert(t, ch.BufferSize(), qt.Equals, 0)
 }
 
 func TestChannel_SendReceive_Buffered(t *testing.T) {
-	ch := NewChannel(2)
+	ch := values.NewChannel(2)
 
-	err := ch.Send(NewInteger(1))
+	err := ch.Send(values.NewInteger(1))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ch.Len(), qt.Equals, 1)
 
-	err = ch.Send(NewInteger(2))
+	err = ch.Send(values.NewInteger(2))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ch.Len(), qt.Equals, 2)
 
 	v, ok := ch.Receive()
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, v, SchemeEquals, NewInteger(1))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(1))
 
 	v, ok = ch.Receive()
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, v, SchemeEquals, NewInteger(2))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestChannel_TrySend_FullBuffer(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 
-	ok, err := ch.TrySend(NewInteger(1))
+	ok, err := ch.TrySend(values.NewInteger(1))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ok, qt.IsTrue)
 
 	// Buffer is full, should not block
-	ok, err = ch.TrySend(NewInteger(2))
+	ok, err = ch.TrySend(values.NewInteger(2))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, ok, qt.IsFalse)
 }
 
 func TestChannel_TryReceive_Empty(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 
 	v, received, ok := ch.TryReceive()
 	qt.Assert(t, received, qt.IsFalse)
@@ -85,17 +88,17 @@ func TestChannel_TryReceive_Empty(t *testing.T) {
 }
 
 func TestChannel_TryReceive_WithData(t *testing.T) {
-	ch := NewChannel(1)
-	_ = ch.Send(NewInteger(42))
+	ch := values.NewChannel(1)
+	_ = ch.Send(values.NewInteger(42))
 
 	v, received, ok := ch.TryReceive()
 	qt.Assert(t, received, qt.IsTrue)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, v, SchemeEquals, NewInteger(42))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestChannel_Close(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	qt.Assert(t, ch.IsClosed(), qt.IsFalse)
 
 	err := ch.Close()
@@ -104,32 +107,32 @@ func TestChannel_Close(t *testing.T) {
 }
 
 func TestChannel_DoubleClose(t *testing.T) {
-	ch := NewChannel(0)
+	ch := values.NewChannel(0)
 	err := ch.Close()
 	qt.Assert(t, err, qt.IsNil)
 
 	err = ch.Close()
-	qt.Assert(t, errors.Is(err, ErrChannelClosed), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrChannelClosed), qt.IsTrue)
 }
 
 func TestChannel_SendAfterClose(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	_ = ch.Close()
 
-	err := ch.Send(NewInteger(1))
-	qt.Assert(t, errors.Is(err, ErrChannelClosed), qt.IsTrue)
+	err := ch.Send(values.NewInteger(1))
+	qt.Assert(t, errors.Is(err, values.ErrChannelClosed), qt.IsTrue)
 }
 
 func TestChannel_TrySendAfterClose(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	_ = ch.Close()
 
-	_, err := ch.TrySend(NewInteger(1))
-	qt.Assert(t, errors.Is(err, ErrChannelClosed), qt.IsTrue)
+	_, err := ch.TrySend(values.NewInteger(1))
+	qt.Assert(t, errors.Is(err, values.ErrChannelClosed), qt.IsTrue)
 }
 
 func TestChannel_TryReceiveAfterClose(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	_ = ch.Close()
 
 	_, _, ok := ch.TryReceive()
@@ -137,14 +140,14 @@ func TestChannel_TryReceiveAfterClose(t *testing.T) {
 }
 
 func TestChannel_ReceiveAfterClose(t *testing.T) {
-	ch := NewChannel(1)
-	_ = ch.Send(NewInteger(42))
+	ch := values.NewChannel(1)
+	_ = ch.Send(values.NewInteger(42))
 	_ = ch.Close()
 
 	// Can still receive buffered values
 	v, ok := ch.Receive()
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, v, SchemeEquals, NewInteger(42))
+	qt.Assert(t, v, valuestest.SchemeEquals, values.NewInteger(42))
 
 	// Then closed
 	_, ok = ch.Receive()
@@ -152,33 +155,33 @@ func TestChannel_ReceiveAfterClose(t *testing.T) {
 }
 
 func TestChannel_Chan(t *testing.T) {
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	qt.Assert(t, ch.Chan(), qt.Not(qt.IsNil))
 }
 
 func TestChannel_IsVoid(t *testing.T) {
-	ch := NewChannel(0)
+	ch := values.NewChannel(0)
 	qt.Assert(t, ch.IsVoid(), qt.IsFalse)
 
-	var nilCh *Channel
+	var nilCh *values.Channel
 	qt.Assert(t, nilCh.IsVoid(), qt.IsTrue)
 }
 
 func TestChannel_EqualTo(t *testing.T) {
-	ch1 := NewChannel(0)
-	ch2 := NewChannel(0)
+	ch1 := values.NewChannel(0)
+	ch2 := values.NewChannel(0)
 	qt.Assert(t, ch1.EqualTo(ch1), qt.IsTrue)
 	qt.Assert(t, ch1.EqualTo(ch2), qt.IsFalse)
-	qt.Assert(t, ch1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, ch1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestChannel_SchemeString(t *testing.T) {
-	ch := NewChannel(0)
+	ch := values.NewChannel(0)
 	s := ch.SchemeString()
 	qt.Assert(t, strings.Contains(s, "unbuffered"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "open"), qt.IsTrue)
 
-	ch2 := NewChannel(5)
+	ch2 := values.NewChannel(5)
 	s2 := ch2.SchemeString()
 	qt.Assert(t, strings.Contains(s2, "buffered[5]"), qt.IsTrue)
 
@@ -186,7 +189,7 @@ func TestChannel_SchemeString(t *testing.T) {
 	s3 := ch.SchemeString()
 	qt.Assert(t, strings.Contains(s3, "closed"), qt.IsTrue)
 
-	var nilCh *Channel
+	var nilCh *values.Channel
 	qt.Assert(t, nilCh.SchemeString(), qt.Equals, "#<channel:void>")
 }
 
@@ -195,52 +198,52 @@ func TestChannel_SchemeString(t *testing.T) {
 func TestChannelSelectReceive(t *testing.T) {
 	c := qt.New(t)
 
-	ch1 := NewChannel(1)
-	ch2 := NewChannel(1)
+	ch1 := values.NewChannel(1)
+	ch2 := values.NewChannel(1)
 
 	// Send to ch2 so it's ready
-	err := ch2.Send(NewInteger(42))
+	err := ch2.Send(values.NewInteger(42))
 	c.Assert(err, qt.IsNil)
 
-	cases := []SelectCase{
+	cases := []values.SelectCase{
 		{Channel: ch1, IsSend: false},
 		{Channel: ch2, IsSend: false},
 	}
 
-	idx, val, ok := ChannelSelect(cases)
+	idx, val, ok := values.ChannelSelect(cases)
 	c.Assert(idx, qt.Equals, 1)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(val, SchemeEquals, NewInteger(42))
+	c.Assert(val, valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestChannelSelectSend(t *testing.T) {
 	c := qt.New(t)
 
-	ch := NewChannel(1)
-	cases := []SelectCase{
-		{Channel: ch, IsSend: true, Value: NewString("hello")},
+	ch := values.NewChannel(1)
+	cases := []values.SelectCase{
+		{Channel: ch, IsSend: true, Value: values.NewString("hello")},
 	}
 
-	idx, _, ok := ChannelSelect(cases)
+	idx, _, ok := values.ChannelSelect(cases)
 	c.Assert(idx, qt.Equals, 0)
 	c.Assert(ok, qt.IsTrue)
 
 	// Verify the value was sent
 	v, recvOK := ch.Receive()
 	c.Assert(recvOK, qt.IsTrue)
-	c.Assert(v, SchemeEquals, NewString("hello"))
+	c.Assert(v, valuestest.SchemeEquals, values.NewString("hello"))
 }
 
 func TestChannelSelectDefault(t *testing.T) {
 	c := qt.New(t)
 
-	ch := NewChannel(0) // unbuffered, nothing ready
-	cases := []SelectCase{
+	ch := values.NewChannel(0) // unbuffered, nothing ready
+	cases := []values.SelectCase{
 		{Channel: ch, IsSend: false},
 		{IsDefault: true},
 	}
 
-	idx, _, ok := ChannelSelect(cases)
+	idx, _, ok := values.ChannelSelect(cases)
 	c.Assert(idx, qt.Equals, 1)
 	c.Assert(ok, qt.IsTrue)
 }
@@ -248,23 +251,23 @@ func TestChannelSelectDefault(t *testing.T) {
 func TestChannelSelectBlocking(t *testing.T) {
 	c := qt.New(t)
 
-	ch := NewChannel(0) // unbuffered
-	cases := []SelectCase{
+	ch := values.NewChannel(0) // unbuffered
+	cases := []values.SelectCase{
 		{Channel: ch, IsSend: false},
 	}
 
 	// Send from another goroutine after a short delay
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		_ = ch.Send(NewInteger(99))
+		_ = ch.Send(values.NewInteger(99))
 	}()
 
 	done := make(chan struct{})
 	go func() {
-		idx, val, ok := ChannelSelect(cases)
+		idx, val, ok := values.ChannelSelect(cases)
 		c.Assert(idx, qt.Equals, 0)
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(val, SchemeEquals, NewInteger(99))
+		c.Assert(val, valuestest.SchemeEquals, values.NewInteger(99))
 		close(done)
 	}()
 
@@ -279,14 +282,14 @@ func TestChannelSelectBlocking(t *testing.T) {
 func TestChannelSelectClosedChannel(t *testing.T) {
 	c := qt.New(t)
 
-	ch := NewChannel(0)
+	ch := values.NewChannel(0)
 	_ = ch.Close()
 
-	cases := []SelectCase{
+	cases := []values.SelectCase{
 		{Channel: ch, IsSend: false},
 	}
 
-	idx, _, ok := ChannelSelect(cases)
+	idx, _, ok := values.ChannelSelect(cases)
 	c.Assert(idx, qt.Equals, 0)
 	c.Assert(ok, qt.IsFalse)
 }
@@ -294,18 +297,18 @@ func TestChannelSelectClosedChannel(t *testing.T) {
 func TestChannelSelectSendToClosedChannel(t *testing.T) {
 	c := qt.New(t)
 
-	ch := NewChannel(1)
+	ch := values.NewChannel(1)
 	// Fill the buffer so TrySend fails (non-blocking pass won't catch it)
-	_ = ch.Send(NewInteger(1))
+	_ = ch.Send(values.NewInteger(1))
 	// Close the channel — reflect.Select would panic without the recover guard
 	_ = ch.Close()
 
-	cases := []SelectCase{
-		{Channel: ch, IsSend: true, Value: NewInteger(2)},
+	cases := []values.SelectCase{
+		{Channel: ch, IsSend: true, Value: values.NewInteger(2)},
 	}
 
 	// Must not panic
-	idx, _, ok := ChannelSelect(cases)
+	idx, _, ok := values.ChannelSelect(cases)
 	c.Assert(idx, qt.Equals, 0)
 	c.Assert(ok, qt.IsFalse)
 }

--- a/values/character_port_test.go
+++ b/values/character_port_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"bufio"
@@ -22,48 +22,50 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestCharacterInputPort_NewCharacterInputPort(t *testing.T) {
 	reader := strings.NewReader("test")
-	port := NewCharacterInputPort(bufio.NewReader(reader))
+	port := values.NewCharacterInputPort(bufio.NewReader(reader))
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestCharacterInputPort_NewCharacterInputPortFromReader(t *testing.T) {
 	reader := strings.NewReader("test")
-	port := NewCharacterInputPortFromReader(reader)
+	port := values.NewCharacterInputPortFromReader(reader)
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestCharacterInputPort_IsVoid(t *testing.T) {
 	reader := strings.NewReader("test")
-	port := NewCharacterInputPortFromReader(reader)
+	port := values.NewCharacterInputPortFromReader(reader)
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *CharacterInputPort
+	var nilPort *values.CharacterInputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestCharacterInputPort_Datum(t *testing.T) {
 	reader := strings.NewReader("test")
-	port := NewCharacterInputPortFromReader(reader)
+	port := values.NewCharacterInputPortFromReader(reader)
 	datum := port.Datum()
 	qt.Assert(t, datum, qt.Not(qt.IsNil))
 }
 
 func TestCharacterInputPort_EqualTo(t *testing.T) {
 	reader1 := strings.NewReader("test")
-	port1 := NewCharacterInputPortFromReader(reader1)
+	port1 := values.NewCharacterInputPortFromReader(reader1)
 	reader2 := strings.NewReader("test")
-	port2 := NewCharacterInputPortFromReader(reader2)
+	port2 := values.NewCharacterInputPortFromReader(reader2)
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
 }
 func TestCharacterInputPort_ReadRune(t *testing.T) {
 	reader := strings.NewReader("te")
-	port := NewCharacterInputPortFromReader(reader)
+	port := values.NewCharacterInputPortFromReader(reader)
 	c, n, err := port.ReadRune()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, n, qt.Equals, 1)
@@ -81,38 +83,38 @@ func TestCharacterInputPort_ReadRune(t *testing.T) {
 
 func TestCharacterInputPort_SchemeString(t *testing.T) {
 	reader := strings.NewReader("test")
-	port := NewCharacterInputPortFromReader(reader)
+	port := values.NewCharacterInputPortFromReader(reader)
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "character-input-port"), qt.IsTrue)
 }
 
 func TestCharacterOutputPort_NewCharacterOutputPort(t *testing.T) {
 	var buf bytes.Buffer
-	port := NewCharacterOutputPortFromWriter(&buf)
+	port := values.NewCharacterOutputPortFromWriter(&buf)
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestCharacterOutputPort_IsVoid(t *testing.T) {
 	var buf bytes.Buffer
-	port := NewCharacterOutputPortFromWriter(&buf)
+	port := values.NewCharacterOutputPortFromWriter(&buf)
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *CharacterOutputPort
+	var nilPort *values.CharacterOutputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestCharacterOutputPort_Datum(t *testing.T) {
 	var buf bytes.Buffer
-	port := NewCharacterOutputPortFromWriter(&buf)
+	port := values.NewCharacterOutputPortFromWriter(&buf)
 	datum := port.Datum()
 	qt.Assert(t, datum, qt.Not(qt.IsNil))
 }
 
 func TestCharacterOutputPort_EqualTo(t *testing.T) {
 	var buf1 bytes.Buffer
-	port1 := NewCharacterOutputPortFromWriter(&buf1)
+	port1 := values.NewCharacterOutputPortFromWriter(&buf1)
 	var buf2 bytes.Buffer
-	port2 := NewCharacterOutputPortFromWriter(&buf2)
+	port2 := values.NewCharacterOutputPortFromWriter(&buf2)
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
@@ -120,7 +122,7 @@ func TestCharacterOutputPort_EqualTo(t *testing.T) {
 
 func TestCharacterOutputPort_SchemeString(t *testing.T) {
 	var buf bytes.Buffer
-	port := NewCharacterOutputPortFromWriter(&buf)
+	port := values.NewCharacterOutputPortFromWriter(&buf)
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "character-output-port"), qt.IsTrue)
 }

--- a/values/character_test.go
+++ b/values/character_test.go
@@ -12,25 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestCharacter_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewCharacter('='),
+			in:  values.NewCharacter('='),
 			out: `#\=`,
 		},
 		{
-			in:  NewCharacter('>'),
+			in:  values.NewCharacter('>'),
 			out: `#\>`,
 		},
 	}
@@ -43,18 +45,18 @@ func TestCharacter_SchemeString(t *testing.T) {
 
 func TestCharacter_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewCharacter('='),
-			in1: NewCharacter('='),
+			in0: values.NewCharacter('='),
+			in1: values.NewCharacter('='),
 			out: true,
 		},
 		{
-			in0: NewCharacter('='),
-			in1: NewCharacter('>'),
+			in0: values.NewCharacter('='),
+			in1: values.NewCharacter('>'),
 			out: false,
 		},
 	}
@@ -66,20 +68,20 @@ func TestCharacter_EqualTo(t *testing.T) {
 }
 
 func TestCharacter_Datum(t *testing.T) {
-	c := NewCharacter('a')
+	c := values.NewCharacter('a')
 	qt.Assert(t, c.Datum(), qt.Equals, 'a')
 }
 
 func TestCharacter_IsVoid(t *testing.T) {
-	c := NewCharacter('x')
+	c := values.NewCharacter('x')
 	qt.Assert(t, c.IsVoid(), qt.IsFalse)
 
-	var nilChar *Character
+	var nilChar *values.Character
 	qt.Assert(t, nilChar.IsVoid(), qt.IsTrue)
 }
 
 func TestCharacter_String(t *testing.T) {
-	c := NewCharacter('z')
+	c := values.NewCharacter('z')
 	qt.Assert(t, c.String(), qt.Equals, "z")
 }
 
@@ -98,8 +100,8 @@ func TestCharacter_CacheIdentity(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			a := NewCharacter(tc.r)
-			b := NewCharacter(tc.r)
+			a := values.NewCharacter(tc.r)
+			b := values.NewCharacter(tc.r)
 			if tc.samePtr {
 				qt.Assert(t, a, qt.Equals, b)
 			} else {

--- a/values/compile_time_value_test.go
+++ b/values/compile_time_value_test.go
@@ -12,75 +12,78 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestCompileTimeValue_NewCompileTimeValue(t *testing.T) {
-	inner := NewInteger(42)
-	ctv := NewCompileTimeValue(inner)
-	qt.Assert(t, ctv.Value, SchemeEquals, inner)
+	inner := values.NewInteger(42)
+	ctv := values.NewCompileTimeValue(inner)
+	qt.Assert(t, ctv.Value, valuestest.SchemeEquals, inner)
 }
 
 func TestCompileTimeValue_Unwrap(t *testing.T) {
-	inner := NewString("hello")
-	ctv := NewCompileTimeValue(inner)
-	qt.Assert(t, ctv.Unwrap(), SchemeEquals, inner)
+	inner := values.NewString("hello")
+	ctv := values.NewCompileTimeValue(inner)
+	qt.Assert(t, ctv.Unwrap(), valuestest.SchemeEquals, inner)
 }
 
 func TestCompileTimeValue_IsVoid(t *testing.T) {
-	ctv := NewCompileTimeValue(NewInteger(1))
+	ctv := values.NewCompileTimeValue(values.NewInteger(1))
 	qt.Assert(t, ctv.IsVoid(), qt.IsFalse)
 
-	var nilCTV *CompileTimeValue
+	var nilCTV *values.CompileTimeValue
 	qt.Assert(t, nilCTV.IsVoid(), qt.IsTrue)
 }
 
 func TestCompileTimeValue_EqualTo(t *testing.T) {
 	tcs := []struct {
 		name string
-		a    Value
-		b    Value
+		a    values.Value
+		b    values.Value
 		out  bool
 	}{
 		{
 			name: "same object",
-			a:    NewCompileTimeValue(NewInteger(1)),
+			a:    values.NewCompileTimeValue(values.NewInteger(1)),
 			b:    nil, // will be set to a
 			out:  true,
 		},
 		{
 			name: "equal wrapped values",
-			a:    NewCompileTimeValue(NewInteger(42)),
-			b:    NewCompileTimeValue(NewInteger(42)),
+			a:    values.NewCompileTimeValue(values.NewInteger(42)),
+			b:    values.NewCompileTimeValue(values.NewInteger(42)),
 			out:  true,
 		},
 		{
 			name: "different wrapped values",
-			a:    NewCompileTimeValue(NewInteger(1)),
-			b:    NewCompileTimeValue(NewInteger(2)),
+			a:    values.NewCompileTimeValue(values.NewInteger(1)),
+			b:    values.NewCompileTimeValue(values.NewInteger(2)),
 			out:  false,
 		},
 		{
 			name: "type mismatch",
-			a:    NewCompileTimeValue(NewInteger(1)),
-			b:    NewInteger(1),
+			a:    values.NewCompileTimeValue(values.NewInteger(1)),
+			b:    values.NewInteger(1),
 			out:  false,
 		},
 		{
 			name: "both nil wrapped",
-			a:    NewCompileTimeValue(nil),
-			b:    NewCompileTimeValue(nil),
+			a:    values.NewCompileTimeValue(nil),
+			b:    values.NewCompileTimeValue(nil),
 			out:  true,
 		},
 		{
 			name: "one nil wrapped",
-			a:    NewCompileTimeValue(nil),
-			b:    NewCompileTimeValue(NewInteger(1)),
+			a:    values.NewCompileTimeValue(nil),
+			b:    values.NewCompileTimeValue(values.NewInteger(1)),
 			out:  false,
 		},
 	}
@@ -96,9 +99,9 @@ func TestCompileTimeValue_EqualTo(t *testing.T) {
 }
 
 func TestCompileTimeValue_SchemeString(t *testing.T) {
-	ctv := NewCompileTimeValue(NewInteger(42))
+	ctv := values.NewCompileTimeValue(values.NewInteger(42))
 	qt.Assert(t, ctv.SchemeString(), qt.Equals, "#<compile-time-value 42>")
 
-	ctv2 := NewCompileTimeValue(NewString("hello"))
+	ctv2 := values.NewCompileTimeValue(values.NewString("hello"))
 	qt.Assert(t, ctv2.SchemeString(), qt.Equals, "#<compile-time-value \"hello\">")
 }

--- a/values/complex_test.go
+++ b/values/complex_test.go
@@ -12,193 +12,196 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestComplex_NewComplex(t *testing.T) {
-	c := NewComplex(complex(3, 4))
+	c := values.NewComplex(complex(3, 4))
 	qt.Assert(t, c.Real(), qt.Equals, 3.0)
 	qt.Assert(t, c.Imag(), qt.Equals, 4.0)
 }
 
 func TestComplex_NewComplexFromParts(t *testing.T) {
-	c := NewComplexFromParts(3, 4)
+	c := values.NewComplexFromParts(3, 4)
 	qt.Assert(t, c.Real(), qt.Equals, 3.0)
 	qt.Assert(t, c.Imag(), qt.Equals, 4.0)
 }
 
 func TestComplex_Datum(t *testing.T) {
-	c := NewComplex(complex(3, 4))
+	c := values.NewComplex(complex(3, 4))
 	qt.Assert(t, c.Datum(), qt.Equals, complex(3, 4))
 }
 
 func TestComplex_Real(t *testing.T) {
-	c := NewComplex(complex(3, 4))
+	c := values.NewComplex(complex(3, 4))
 	qt.Assert(t, c.Real(), qt.Equals, 3.0)
 }
 
 func TestComplex_Imag(t *testing.T) {
-	c := NewComplex(complex(3, 4))
+	c := values.NewComplex(complex(3, 4))
 	qt.Assert(t, c.Imag(), qt.Equals, 4.0)
 }
 
 func TestComplex_Add(t *testing.T) {
-	c1 := NewComplex(complex(1, 2))
-	c2 := NewComplex(complex(3, 4))
+	c1 := values.NewComplex(complex(1, 2))
+	c2 := values.NewComplex(complex(3, 4))
 	result := c1.Add(c2)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(4, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(4, 6)))
 
-	c3 := NewComplex(complex(0, 0))
+	c3 := values.NewComplex(complex(0, 0))
 	result = c1.Add(c3)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(1, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(1, 2)))
 
-	i1 := NewInteger(5)
+	i1 := values.NewInteger(5)
 	result = c1.Add(i1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(6, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(6, 2)))
 
-	f1 := NewFloat(2.5)
+	f1 := values.NewFloat(2.5)
 	result = c1.Add(f1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(3.5, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(3.5, 2)))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = c1.Add(r1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(1.5, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(1.5, 2)))
 }
 
 func TestComplex_Subtract(t *testing.T) {
-	c1 := NewComplex(complex(5, 6))
-	c2 := NewComplex(complex(2, 3))
+	c1 := values.NewComplex(complex(5, 6))
+	c2 := values.NewComplex(complex(2, 3))
 	result := c1.Subtract(c2)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(3, 3)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(3, 3)))
 
-	c3 := NewComplex(complex(0, 0))
+	c3 := values.NewComplex(complex(0, 0))
 	result = c1.Subtract(c3)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(5, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(5, 6)))
 
-	i1 := NewInteger(2)
+	i1 := values.NewInteger(2)
 	result = c1.Subtract(i1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(3, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(3, 6)))
 
-	f1 := NewFloat(1.0)
+	f1 := values.NewFloat(1.0)
 	result = c1.Subtract(f1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(4, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(4, 6)))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = c1.Subtract(r1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(4.5, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(4.5, 6)))
 }
 
 func TestComplex_Multiply(t *testing.T) {
-	c1 := NewComplex(complex(2, 3))
-	c2 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(2, 3))
+	c2 := values.NewComplex(complex(1, 2))
 	result := c1.Multiply(c2)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(-4, 7)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(-4, 7)))
 
-	c3 := NewComplex(complex(0, 0))
+	c3 := values.NewComplex(complex(0, 0))
 	result = c1.Multiply(c3)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(0, 0)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(0, 0)))
 
-	i1 := NewInteger(3)
+	i1 := values.NewInteger(3)
 	result = c1.Multiply(i1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(6, 9)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(6, 9)))
 
-	f1 := NewFloat(2.0)
+	f1 := values.NewFloat(2.0)
 	result = c1.Multiply(f1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(4, 6)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(4, 6)))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = c1.Multiply(r1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(1, 1.5)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(1, 1.5)))
 }
 
 func TestComplex_Divide(t *testing.T) {
-	c1 := NewComplex(complex(4, 2))
-	c2 := NewComplex(complex(2, 0))
+	c1 := values.NewComplex(complex(4, 2))
+	c2 := values.NewComplex(complex(2, 0))
 	result := c1.Divide(c2)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(2, 1)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(2, 1)))
 
-	i1 := NewInteger(2)
+	i1 := values.NewInteger(2)
 	result = c1.Divide(i1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(2, 1)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(2, 1)))
 
-	f1 := NewFloat(2.0)
+	f1 := values.NewFloat(2.0)
 	result = c1.Divide(f1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(2, 1)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(2, 1)))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = c1.Divide(r1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(8, 4)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(8, 4)))
 }
 
 func TestComplex_IsZero(t *testing.T) {
-	c1 := NewComplex(complex(0, 0))
+	c1 := values.NewComplex(complex(0, 0))
 	qt.Assert(t, c1.IsZero(), qt.IsTrue)
 
-	c2 := NewComplex(complex(1, 2))
+	c2 := values.NewComplex(complex(1, 2))
 	qt.Assert(t, c2.IsZero(), qt.IsFalse)
 
-	c3 := NewComplex(complex(0, 1))
+	c3 := values.NewComplex(complex(0, 1))
 	qt.Assert(t, c3.IsZero(), qt.IsFalse)
 }
 
 func TestComplex_LessThan(t *testing.T) {
-	c1 := NewComplex(complex(3, 4))
-	c2 := NewComplex(complex(5, 6))
+	c1 := values.NewComplex(complex(3, 4))
+	c2 := values.NewComplex(complex(5, 6))
 	qt.Assert(t, c1.LessThan(c2), qt.IsTrue)
 	qt.Assert(t, c2.LessThan(c1), qt.IsFalse)
 
-	i1 := NewInteger(5)
+	i1 := values.NewInteger(5)
 	qt.Assert(t, c1.LessThan(i1), qt.IsTrue)
 
-	f1 := NewFloat(4.0)
+	f1 := values.NewFloat(4.0)
 	qt.Assert(t, c1.LessThan(f1), qt.IsTrue)
 
-	r1 := NewRational(7, 2)
+	r1 := values.NewRational(7, 2)
 	qt.Assert(t, c1.LessThan(r1), qt.IsTrue)
 }
 
 func TestComplex_IsReal(t *testing.T) {
-	c1 := NewComplex(complex(5, 0))
+	c1 := values.NewComplex(complex(5, 0))
 	qt.Assert(t, c1.IsReal(), qt.IsTrue)
 
-	c2 := NewComplex(complex(5, 1))
+	c2 := values.NewComplex(complex(5, 1))
 	qt.Assert(t, c2.IsReal(), qt.IsFalse)
 }
 
 func TestComplex_Magnitude(t *testing.T) {
-	c := NewComplex(complex(3, 4))
+	c := values.NewComplex(complex(3, 4))
 	qt.Assert(t, c.Magnitude(), qt.Equals, 5.0)
 }
 
 func TestComplex_Phase(t *testing.T) {
-	c := NewComplex(complex(1, 1))
+	c := values.NewComplex(complex(1, 1))
 	expected := math.Pi / 4
 	qt.Assert(t, math.Abs(c.Phase()-expected) < 0.0001, qt.IsTrue)
 }
 
 func TestComplex_IsVoid(t *testing.T) {
-	c := NewComplex(complex(1, 2))
+	c := values.NewComplex(complex(1, 2))
 	qt.Assert(t, c.IsVoid(), qt.IsFalse)
 
-	var nilComplex *Complex
+	var nilComplex *values.Complex
 	qt.Assert(t, nilComplex.IsVoid(), qt.IsTrue)
 }
 
 func TestComplex_EqualTo(t *testing.T) {
-	c1 := NewComplex(complex(1, 2))
-	c2 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
+	c2 := values.NewComplex(complex(1, 2))
 	qt.Assert(t, c1.EqualTo(c2), qt.IsTrue)
 
-	c3 := NewComplex(complex(1, 3))
+	c3 := values.NewComplex(complex(1, 3))
 	qt.Assert(t, c1.EqualTo(c3), qt.IsFalse)
 
-	i1 := NewInteger(5)
+	i1 := values.NewInteger(5)
 	qt.Assert(t, c1.EqualTo(i1), qt.IsFalse)
 }
 
@@ -221,7 +224,7 @@ func TestComplex_SchemeString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewComplex(tt.value)
+			c := values.NewComplex(tt.value)
 			qt.Assert(t, c.SchemeString(), qt.Equals, tt.expect)
 		})
 	}

--- a/values/concurrency_wrappers_test.go
+++ b/values/concurrency_wrappers_test.go
@@ -12,38 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // --- RWMutex ---
 
 func TestRWMutex_NewRWMutex(t *testing.T) {
-	m := NewRWMutex("test-rw")
+	m := values.NewRWMutex("test-rw")
 	qt.Assert(t, m, qt.Not(qt.IsNil))
 	qt.Assert(t, m.Name(), qt.Equals, "test-rw")
 	qt.Assert(t, m.ID() > 0, qt.IsTrue)
 }
 
 func TestRWMutex_DefaultName(t *testing.T) {
-	m := NewRWMutex("")
+	m := values.NewRWMutex("")
 	qt.Assert(t, strings.HasPrefix(m.Name(), "rwmutex-"), qt.IsTrue)
 }
 
 func TestRWMutex_LockUnlock(t *testing.T) {
-	m := NewRWMutex("test")
+	m := values.NewRWMutex("test")
 	m.Lock()
 	qt.Assert(t, m, qt.Not(qt.IsNil)) // verify lock held
 	m.Unlock()
 }
 
 func TestRWMutex_RLockRUnlock(t *testing.T) {
-	m := NewRWMutex("test")
+	m := values.NewRWMutex("test")
 	m.RLock()
 	qt.Assert(t, m, qt.Not(qt.IsNil)) // verify rlock held
 	m.RLock()
@@ -53,14 +55,14 @@ func TestRWMutex_RLockRUnlock(t *testing.T) {
 }
 
 func TestRWMutex_TryLock(t *testing.T) {
-	m := NewRWMutex("test")
+	m := values.NewRWMutex("test")
 	qt.Assert(t, m.TryLock(), qt.IsTrue)
 	qt.Assert(t, m.TryLock(), qt.IsFalse) // already locked
 	m.Unlock()
 }
 
 func TestRWMutex_TryRLock(t *testing.T) {
-	m := NewRWMutex("test")
+	m := values.NewRWMutex("test")
 	qt.Assert(t, m.TryRLock(), qt.IsTrue)
 	qt.Assert(t, m.TryRLock(), qt.IsTrue) // multiple readers
 	m.RUnlock()
@@ -68,41 +70,41 @@ func TestRWMutex_TryRLock(t *testing.T) {
 }
 
 func TestRWMutex_IsVoid(t *testing.T) {
-	m := NewRWMutex("test")
+	m := values.NewRWMutex("test")
 	qt.Assert(t, m.IsVoid(), qt.IsFalse)
 
-	var nilM *RWMutex
+	var nilM *values.RWMutex
 	qt.Assert(t, nilM.IsVoid(), qt.IsTrue)
 }
 
 func TestRWMutex_EqualTo(t *testing.T) {
-	m1 := NewRWMutex("test")
-	m2 := NewRWMutex("test")
+	m1 := values.NewRWMutex("test")
+	m2 := values.NewRWMutex("test")
 	qt.Assert(t, m1.EqualTo(m1), qt.IsTrue)
 	qt.Assert(t, m1.EqualTo(m2), qt.IsFalse)
-	qt.Assert(t, m1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, m1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestRWMutex_SchemeString(t *testing.T) {
-	m := NewRWMutex("test-rw")
+	m := values.NewRWMutex("test-rw")
 	s := m.SchemeString()
 	qt.Assert(t, strings.Contains(s, "rw-mutex"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "test-rw"), qt.IsTrue)
 
-	var nilM *RWMutex
+	var nilM *values.RWMutex
 	qt.Assert(t, nilM.SchemeString(), qt.Equals, "#<rw-mutex:void>")
 }
 
 // --- Once ---
 
 func TestOnce_NewOnce(t *testing.T) {
-	o := NewOnce()
+	o := values.NewOnce()
 	qt.Assert(t, o, qt.Not(qt.IsNil))
 	qt.Assert(t, o.ID() > 0, qt.IsTrue)
 }
 
 func TestOnce_Do(t *testing.T) {
-	o := NewOnce()
+	o := values.NewOnce()
 	qt.Assert(t, o.Done(), qt.IsFalse)
 
 	count := 0
@@ -118,23 +120,23 @@ func TestOnce_Do(t *testing.T) {
 }
 
 func TestOnce_IsVoid(t *testing.T) {
-	o := NewOnce()
+	o := values.NewOnce()
 	qt.Assert(t, o.IsVoid(), qt.IsFalse)
 
-	var nilO *Once
+	var nilO *values.Once
 	qt.Assert(t, nilO.IsVoid(), qt.IsTrue)
 }
 
 func TestOnce_EqualTo(t *testing.T) {
-	o1 := NewOnce()
-	o2 := NewOnce()
+	o1 := values.NewOnce()
+	o2 := values.NewOnce()
 	qt.Assert(t, o1.EqualTo(o1), qt.IsTrue)
 	qt.Assert(t, o1.EqualTo(o2), qt.IsFalse)
-	qt.Assert(t, o1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, o1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestOnce_SchemeString(t *testing.T) {
-	o := NewOnce()
+	o := values.NewOnce()
 	s := o.SchemeString()
 	qt.Assert(t, strings.Contains(s, "once"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "pending"), qt.IsTrue)
@@ -143,20 +145,20 @@ func TestOnce_SchemeString(t *testing.T) {
 	s2 := o.SchemeString()
 	qt.Assert(t, strings.Contains(s2, "done"), qt.IsTrue)
 
-	var nilO *Once
+	var nilO *values.Once
 	qt.Assert(t, nilO.SchemeString(), qt.Equals, "#<once:void>")
 }
 
 // --- WaitGroup ---
 
 func TestWaitGroup_NewWaitGroup(t *testing.T) {
-	wg := NewWaitGroup()
+	wg := values.NewWaitGroup()
 	qt.Assert(t, wg, qt.Not(qt.IsNil))
 	qt.Assert(t, wg.ID() > 0, qt.IsTrue)
 }
 
 func TestWaitGroup_AddDoneWait(t *testing.T) {
-	wg := NewWaitGroup()
+	wg := values.NewWaitGroup()
 	wg.Add(1)
 
 	done := make(chan struct{})
@@ -170,26 +172,26 @@ func TestWaitGroup_AddDoneWait(t *testing.T) {
 }
 
 func TestWaitGroup_IsVoid(t *testing.T) {
-	wg := NewWaitGroup()
+	wg := values.NewWaitGroup()
 	qt.Assert(t, wg.IsVoid(), qt.IsFalse)
 
-	var nilWG *WaitGroup
+	var nilWG *values.WaitGroup
 	qt.Assert(t, nilWG.IsVoid(), qt.IsTrue)
 }
 
 func TestWaitGroup_EqualTo(t *testing.T) {
-	wg1 := NewWaitGroup()
-	wg2 := NewWaitGroup()
+	wg1 := values.NewWaitGroup()
+	wg2 := values.NewWaitGroup()
 	qt.Assert(t, wg1.EqualTo(wg1), qt.IsTrue)
 	qt.Assert(t, wg1.EqualTo(wg2), qt.IsFalse)
-	qt.Assert(t, wg1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, wg1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestWaitGroup_SchemeString(t *testing.T) {
-	wg := NewWaitGroup()
+	wg := values.NewWaitGroup()
 	s := wg.SchemeString()
 	qt.Assert(t, strings.Contains(s, "wait-group"), qt.IsTrue)
 
-	var nilWG *WaitGroup
+	var nilWG *values.WaitGroup
 	qt.Assert(t, nilWG.SchemeString(), qt.Equals, "#<wait-group:void>")
 }

--- a/values/condition_variable_test.go
+++ b/values/condition_variable_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"runtime"
@@ -21,30 +21,33 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestConditionVariable_NewConditionVariable(t *testing.T) {
-	cv := NewConditionVariable("test-cv")
+	cv := values.NewConditionVariable("test-cv")
 	qt.Assert(t, cv, qt.Not(qt.IsNil))
 	qt.Assert(t, cv.Name(), qt.Equals, "test-cv")
 	qt.Assert(t, cv.ID() > 0, qt.IsTrue)
 }
 
 func TestConditionVariable_DefaultName(t *testing.T) {
-	cv := NewConditionVariable("")
+	cv := values.NewConditionVariable("")
 	qt.Assert(t, strings.HasPrefix(cv.Name(), "condvar-"), qt.IsTrue)
 }
 
 func TestConditionVariable_Specific(t *testing.T) {
-	cv := NewConditionVariable("test")
+	cv := values.NewConditionVariable("test")
 	qt.Assert(t, cv.Specific() == nil, qt.IsTrue)
 
-	cv.SetSpecific(NewInteger(42))
-	qt.Assert(t, cv.Specific(), SchemeEquals, NewInteger(42))
+	cv.SetSpecific(values.NewInteger(42))
+	qt.Assert(t, cv.Specific(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestConditionVariable_SignalBroadcast_NoWaiters(t *testing.T) {
-	cv := NewConditionVariable("test")
+	cv := values.NewConditionVariable("test")
 	qt.Assert(t, cv.WaiterCount(), qt.Equals, 0)
 
 	// Signal and Broadcast with no waiters should not panic
@@ -53,33 +56,33 @@ func TestConditionVariable_SignalBroadcast_NoWaiters(t *testing.T) {
 }
 
 func TestConditionVariable_WaiterCount(t *testing.T) {
-	cv := NewConditionVariable("test")
+	cv := values.NewConditionVariable("test")
 	qt.Assert(t, cv.WaiterCount(), qt.Equals, 0)
 }
 
 func TestConditionVariable_IsVoid(t *testing.T) {
-	cv := NewConditionVariable("test")
+	cv := values.NewConditionVariable("test")
 	qt.Assert(t, cv.IsVoid(), qt.IsFalse)
 
-	var nilCV *ConditionVariable
+	var nilCV *values.ConditionVariable
 	qt.Assert(t, nilCV.IsVoid(), qt.IsTrue)
 }
 
 func TestConditionVariable_EqualTo(t *testing.T) {
-	cv1 := NewConditionVariable("a")
-	cv2 := NewConditionVariable("b")
+	cv1 := values.NewConditionVariable("a")
+	cv2 := values.NewConditionVariable("b")
 	qt.Assert(t, cv1.EqualTo(cv1), qt.IsTrue)
 	qt.Assert(t, cv1.EqualTo(cv2), qt.IsFalse)
-	qt.Assert(t, cv1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, cv1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestConditionVariable_SchemeString(t *testing.T) {
-	cv := NewConditionVariable("my-cv")
+	cv := values.NewConditionVariable("my-cv")
 	s := cv.SchemeString()
 	qt.Assert(t, strings.Contains(s, "condition-variable"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "my-cv"), qt.IsTrue)
 
-	var nilCV *ConditionVariable
+	var nilCV *values.ConditionVariable
 	qt.Assert(t, nilCV.SchemeString(), qt.Equals, "#<condition-variable:void>")
 }
 
@@ -91,7 +94,7 @@ func TestConditionVariable_Wait_NoGoroutineLeak(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	baseline := runtime.NumGoroutine()
 
-	cv := NewConditionVariable("leak-test")
+	cv := values.NewConditionVariable("leak-test")
 	timeout := 10 * time.Millisecond
 
 	// Run 100 timeouts (old code would leak 100 goroutines)
@@ -112,7 +115,7 @@ func TestConditionVariable_Wait_NoGoroutineLeak(t *testing.T) {
 
 func TestConditionVariable_Wait_SignalBeforeTimeout(t *testing.T) {
 	c := qt.New(t)
-	cv := NewConditionVariable("signal-test")
+	cv := values.NewConditionVariable("signal-test")
 	timeout := 1 * time.Second
 
 	// Signal after 50ms
@@ -132,7 +135,7 @@ func TestConditionVariable_Wait_SignalBeforeTimeout(t *testing.T) {
 
 func TestConditionVariable_Wait_Timeout(t *testing.T) {
 	c := qt.New(t)
-	cv := NewConditionVariable("timeout-test")
+	cv := values.NewConditionVariable("timeout-test")
 	timeout := 50 * time.Millisecond
 
 	start := time.Now()
@@ -147,7 +150,7 @@ func TestConditionVariable_Wait_Timeout(t *testing.T) {
 
 func TestConditionVariable_Wait_BroadcastBeforeTimeout(t *testing.T) {
 	c := qt.New(t)
-	cv := NewConditionVariable("broadcast-test")
+	cv := values.NewConditionVariable("broadcast-test")
 	timeout := 1 * time.Second
 
 	go func() {
@@ -165,7 +168,7 @@ func TestConditionVariable_Wait_BroadcastBeforeTimeout(t *testing.T) {
 
 func TestConditionVariable_Wait_NilTimeout(t *testing.T) {
 	c := qt.New(t)
-	cv := NewConditionVariable("nil-timeout-test")
+	cv := values.NewConditionVariable("nil-timeout-test")
 
 	go func() {
 		time.Sleep(50 * time.Millisecond)
@@ -177,7 +180,7 @@ func TestConditionVariable_Wait_NilTimeout(t *testing.T) {
 }
 
 func TestConditionVariable_Wait_RaceCondition(t *testing.T) {
-	cv := NewConditionVariable("race-test")
+	cv := values.NewConditionVariable("race-test")
 	timeout := 50 * time.Millisecond
 
 	// Signal at ~timeout boundary (creates race)
@@ -194,7 +197,7 @@ func TestConditionVariable_Wait_RaceCondition(t *testing.T) {
 
 func TestConditionVariable_Wait_ConcurrentWaiters(t *testing.T) {
 	c := qt.New(t)
-	cv := NewConditionVariable("concurrent-test")
+	cv := values.NewConditionVariable("concurrent-test")
 	timeout := 100 * time.Millisecond
 
 	const numWaiters = 50

--- a/values/exactness_contagion_test.go
+++ b/values/exactness_contagion_test.go
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // TestExactnessContagionAddition validates R7RS §6.2.2 exactness contagion
@@ -45,49 +47,49 @@ func TestExactnessContagionAddition(t *testing.T) {
 	// This is the critical case that detects improper zero short-circuits.
 	tcs := []struct {
 		name     string
-		a        Number
-		b        Number
+		a        values.Number
+		b        values.Number
 		wantType string
 		isExact  bool
 	}{
 		// Integer (exact) + Float (inexact) → Float (inexact)
-		{"Integer 0 + Float 0.0", NewInteger(0), NewFloat(0.0), "Float", false},
-		{"Float 0.0 + Integer 0", NewFloat(0.0), NewInteger(0), "Float", false},
+		{"Integer 0 + Float 0.0", values.NewInteger(0), values.NewFloat(0.0), "Float", false},
+		{"Float 0.0 + Integer 0", values.NewFloat(0.0), values.NewInteger(0), "Float", false},
 
 		// Integer (exact) + Integer (exact) → Integer (exact)
-		{"Integer 0 + Integer 0", NewInteger(0), NewInteger(0), "Integer", true},
+		{"Integer 0 + Integer 0", values.NewInteger(0), values.NewInteger(0), "Integer", true},
 
 		// BigInteger (exact) + Float (inexact) → BigFloat (inexact)
 		// Changed: precision preservation via BigFloat instead of Float
-		{"BigInteger 0 + Float 0.0", NewBigIntegerFromInt64(0), NewFloat(0.0), "BigFloat", false},
-		{"Float 0.0 + BigInteger 0", NewFloat(0.0), NewBigIntegerFromInt64(0), "BigFloat", false},
+		{"BigInteger 0 + Float 0.0", values.NewBigIntegerFromInt64(0), values.NewFloat(0.0), "BigFloat", false},
+		{"Float 0.0 + BigInteger 0", values.NewFloat(0.0), values.NewBigIntegerFromInt64(0), "BigFloat", false},
 
 		// BigInteger (exact) + BigFloat (inexact) → BigFloat (inexact)
-		{"BigInteger 0 + BigFloat 0.0", NewBigIntegerFromInt64(0), NewBigFloatFromFloat64(0.0), "BigFloat", false},
-		{"BigFloat 0.0 + BigInteger 0", NewBigFloatFromFloat64(0.0), NewBigIntegerFromInt64(0), "BigFloat", false},
+		{"BigInteger 0 + BigFloat 0.0", values.NewBigIntegerFromInt64(0), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 + BigInteger 0", values.NewBigFloatFromFloat64(0.0), values.NewBigIntegerFromInt64(0), "BigFloat", false},
 
 		// Rational (exact) + Float (inexact) → Float (inexact)
-		{"Rational 0/1 + Float 0.0", NewRational(0, 1), NewFloat(0.0), "Float", false},
-		{"Float 0.0 + Rational 0/1", NewFloat(0.0), NewRational(0, 1), "Float", false},
+		{"Rational 0/1 + Float 0.0", values.NewRational(0, 1), values.NewFloat(0.0), "Float", false},
+		{"Float 0.0 + Rational 0/1", values.NewFloat(0.0), values.NewRational(0, 1), "Float", false},
 
 		// Rational (exact) + BigFloat (inexact) → BigFloat (inexact)
-		{"Rational 0/1 + BigFloat 0.0", NewRational(0, 1), NewBigFloatFromFloat64(0.0), "BigFloat", false},
-		{"BigFloat 0.0 + Rational 0/1", NewBigFloatFromFloat64(0.0), NewRational(0, 1), "BigFloat", false},
+		{"Rational 0/1 + BigFloat 0.0", values.NewRational(0, 1), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 + Rational 0/1", values.NewBigFloatFromFloat64(0.0), values.NewRational(0, 1), "BigFloat", false},
 
 		// Integer (exact) + Complex (inexact) → Complex (inexact)
-		{"Integer 0 + Complex 0+0i", NewInteger(0), NewComplex(0), "Complex", false},
-		{"Complex 0+0i + Integer 0", NewComplex(0), NewInteger(0), "Complex", false},
+		{"Integer 0 + Complex 0+0i", values.NewInteger(0), values.NewComplex(0), "Complex", false},
+		{"Complex 0+0i + Integer 0", values.NewComplex(0), values.NewInteger(0), "Complex", false},
 
 		// BigInteger (exact) + BigComplex (can be exact or inexact depending on parts)
-		{"BigInteger 0 + BigComplex(inexact)", NewBigIntegerFromInt64(0),
-			NewBigComplexFromBigFloats(NewBigFloatFromFloat64(0), NewBigFloatFromFloat64(0)),
+		{"BigInteger 0 + BigComplex(inexact)", values.NewBigIntegerFromInt64(0),
+			values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(0), values.NewBigFloatFromFloat64(0)),
 			"BigComplex", false},
 
 		// Float (inexact) + Float (inexact) → Float (inexact)
-		{"Float 0.0 + Float 0.0", NewFloat(0.0), NewFloat(0.0), "Float", false},
+		{"Float 0.0 + Float 0.0", values.NewFloat(0.0), values.NewFloat(0.0), "Float", false},
 
 		// BigFloat (inexact) + BigFloat (inexact) → BigFloat (inexact)
-		{"BigFloat 0.0 + BigFloat 0.0", NewBigFloatFromFloat64(0.0), NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 + BigFloat 0.0", values.NewBigFloatFromFloat64(0.0), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
 	}
 
 	for _, tc := range tcs {
@@ -116,44 +118,44 @@ func TestExactnessContagionSubtraction(t *testing.T) {
 
 	tcs := []struct {
 		name     string
-		a        Number
-		b        Number
+		a        values.Number
+		b        values.Number
 		wantType string
 		isExact  bool
 	}{
 		// Integer (exact) - Float (inexact) → Float (inexact)
-		{"Integer 0 - Float 0.0", NewInteger(0), NewFloat(0.0), "Float", false},
-		{"Float 0.0 - Integer 0", NewFloat(0.0), NewInteger(0), "Float", false},
+		{"Integer 0 - Float 0.0", values.NewInteger(0), values.NewFloat(0.0), "Float", false},
+		{"Float 0.0 - Integer 0", values.NewFloat(0.0), values.NewInteger(0), "Float", false},
 
 		// Integer (exact) - Integer (exact) → Integer (exact)
-		{"Integer 0 - Integer 0", NewInteger(0), NewInteger(0), "Integer", true},
+		{"Integer 0 - Integer 0", values.NewInteger(0), values.NewInteger(0), "Integer", true},
 
 		// BigInteger (exact) - Float (inexact) → BigFloat (inexact)
 		// Changed: precision preservation via BigFloat instead of Float
-		{"BigInteger 0 - Float 0.0", NewBigIntegerFromInt64(0), NewFloat(0.0), "BigFloat", false},
-		{"Float 0.0 - BigInteger 0", NewFloat(0.0), NewBigIntegerFromInt64(0), "BigFloat", false},
+		{"BigInteger 0 - Float 0.0", values.NewBigIntegerFromInt64(0), values.NewFloat(0.0), "BigFloat", false},
+		{"Float 0.0 - BigInteger 0", values.NewFloat(0.0), values.NewBigIntegerFromInt64(0), "BigFloat", false},
 
 		// BigInteger (exact) - BigFloat (inexact) → BigFloat (inexact)
-		{"BigInteger 0 - BigFloat 0.0", NewBigIntegerFromInt64(0), NewBigFloatFromFloat64(0.0), "BigFloat", false},
-		{"BigFloat 0.0 - BigInteger 0", NewBigFloatFromFloat64(0.0), NewBigIntegerFromInt64(0), "BigFloat", false},
+		{"BigInteger 0 - BigFloat 0.0", values.NewBigIntegerFromInt64(0), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 - BigInteger 0", values.NewBigFloatFromFloat64(0.0), values.NewBigIntegerFromInt64(0), "BigFloat", false},
 
 		// Rational (exact) - Float (inexact) → Float (inexact)
-		{"Rational 0/1 - Float 0.0", NewRational(0, 1), NewFloat(0.0), "Float", false},
-		{"Float 0.0 - Rational 0/1", NewFloat(0.0), NewRational(0, 1), "Float", false},
+		{"Rational 0/1 - Float 0.0", values.NewRational(0, 1), values.NewFloat(0.0), "Float", false},
+		{"Float 0.0 - Rational 0/1", values.NewFloat(0.0), values.NewRational(0, 1), "Float", false},
 
 		// Rational (exact) - BigFloat (inexact) → BigFloat (inexact)
-		{"Rational 0/1 - BigFloat 0.0", NewRational(0, 1), NewBigFloatFromFloat64(0.0), "BigFloat", false},
-		{"BigFloat 0.0 - Rational 0/1", NewBigFloatFromFloat64(0.0), NewRational(0, 1), "BigFloat", false},
+		{"Rational 0/1 - BigFloat 0.0", values.NewRational(0, 1), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 - Rational 0/1", values.NewBigFloatFromFloat64(0.0), values.NewRational(0, 1), "BigFloat", false},
 
 		// Integer (exact) - Complex (inexact) → Complex (inexact)
-		{"Integer 0 - Complex 0+0i", NewInteger(0), NewComplex(0), "Complex", false},
-		{"Complex 0+0i - Integer 0", NewComplex(0), NewInteger(0), "Complex", false},
+		{"Integer 0 - Complex 0+0i", values.NewInteger(0), values.NewComplex(0), "Complex", false},
+		{"Complex 0+0i - Integer 0", values.NewComplex(0), values.NewInteger(0), "Complex", false},
 
 		// Float (inexact) - Float (inexact) → Float (inexact)
-		{"Float 0.0 - Float 0.0", NewFloat(0.0), NewFloat(0.0), "Float", false},
+		{"Float 0.0 - Float 0.0", values.NewFloat(0.0), values.NewFloat(0.0), "Float", false},
 
 		// BigFloat (inexact) - BigFloat (inexact) → BigFloat (inexact)
-		{"BigFloat 0.0 - BigFloat 0.0", NewBigFloatFromFloat64(0.0), NewBigFloatFromFloat64(0.0), "BigFloat", false},
+		{"BigFloat 0.0 - BigFloat 0.0", values.NewBigFloatFromFloat64(0.0), values.NewBigFloatFromFloat64(0.0), "BigFloat", false},
 	}
 
 	for _, tc := range tcs {
@@ -185,20 +187,20 @@ func TestExactnessContagionSubtraction(t *testing.T) {
 func TestIEEE754SignedZeroPreservation(t *testing.T) {
 	c := qt.New(t)
 
-	posZero := NewFloat(+0.0)
-	negZero := NewFloat(math.Copysign(0.0, -1.0)) // -0.0
+	posZero := values.NewFloat(+0.0)
+	negZero := values.NewFloat(math.Copysign(0.0, -1.0)) // -0.0
 
 	// Helper to check sign via math.Signbit
-	isNegativeZero := func(n Number) bool {
-		f, ok := n.(*Float)
+	isNegativeZero := func(n values.Number) bool {
+		f, ok := n.(*values.Float)
 		if !ok {
 			return false
 		}
 		return f.Value == 0.0 && math.Signbit(f.Value)
 	}
 
-	isPositiveZero := func(n Number) bool {
-		f, ok := n.(*Float)
+	isPositiveZero := func(n values.Number) bool {
+		f, ok := n.(*values.Float)
 		if !ok {
 			return false
 		}
@@ -207,36 +209,36 @@ func TestIEEE754SignedZeroPreservation(t *testing.T) {
 
 	tcs := []struct {
 		name    string
-		a       Number
-		b       Number
-		op      func(Number, Number) Number
+		a       values.Number
+		b       values.Number
+		op      func(values.Number, values.Number) values.Number
 		wantPos bool // true = +0.0, false = -0.0
 	}{
 		// Addition
-		{"(+0.0) + (+0.0)", posZero, posZero, func(a, b Number) Number {
+		{"(+0.0) + (+0.0)", posZero, posZero, func(a, b values.Number) values.Number {
 			return a.Add(b)
 		}, true},
-		{"(+0.0) + (-0.0)", posZero, negZero, func(a, b Number) Number {
+		{"(+0.0) + (-0.0)", posZero, negZero, func(a, b values.Number) values.Number {
 			return a.Add(b)
 		}, true},
-		{"(-0.0) + (-0.0)", negZero, negZero, func(a, b Number) Number {
+		{"(-0.0) + (-0.0)", negZero, negZero, func(a, b values.Number) values.Number {
 			return a.Add(b)
 		}, false},
-		{"(-0.0) + (+0.0)", negZero, posZero, func(a, b Number) Number {
+		{"(-0.0) + (+0.0)", negZero, posZero, func(a, b values.Number) values.Number {
 			return a.Add(b)
 		}, true},
 
 		// Subtraction
-		{"(+0.0) - (+0.0)", posZero, posZero, func(a, b Number) Number {
+		{"(+0.0) - (+0.0)", posZero, posZero, func(a, b values.Number) values.Number {
 			return a.Subtract(b)
 		}, true},
-		{"(+0.0) - (-0.0)", posZero, negZero, func(a, b Number) Number {
+		{"(+0.0) - (-0.0)", posZero, negZero, func(a, b values.Number) values.Number {
 			return a.Subtract(b)
 		}, true},
-		{"(-0.0) - (+0.0)", negZero, posZero, func(a, b Number) Number {
+		{"(-0.0) - (+0.0)", negZero, posZero, func(a, b values.Number) values.Number {
 			return a.Subtract(b)
 		}, false},
-		{"(-0.0) - (-0.0)", negZero, negZero, func(a, b Number) Number {
+		{"(-0.0) - (-0.0)", negZero, negZero, func(a, b values.Number) values.Number {
 			return a.Subtract(b)
 		}, true},
 	}
@@ -251,7 +253,7 @@ func TestIEEE754SignedZeroPreservation(t *testing.T) {
 			} else {
 				c.Assert(isNegativeZero(result), qt.IsTrue,
 					qt.Commentf("Expected -0.0, got %v (signbit=%v)",
-						result.SchemeString(), math.Signbit(result.(*Float).Value)))
+						result.SchemeString(), math.Signbit(result.(*values.Float).Value)))
 			}
 		})
 	}
@@ -290,26 +292,26 @@ func TestMultiplicationExactZeroOptimization(t *testing.T) {
 
 	// Case 1: Exact zero * finite inexact → exact zero
 	// This is the optimization: mathematically unambiguous result
-	result := NewInteger(0).Multiply(NewFloat(42.5))
+	result := values.NewInteger(0).Multiply(values.NewFloat(42.5))
 	c.Assert(result.IsZero(), qt.IsTrue)
 	c.Assert(result.IsExact(), qt.IsTrue, qt.Commentf("(* 0 42.5) should be exact 0"))
 
 	// Case 2: Inexact zero * finite exact → depends on implementation
 	// Some implementations return exact 0, others return inexact 0
-	result = NewFloat(0.0).Multiply(NewInteger(42))
+	result = values.NewFloat(0.0).Multiply(values.NewInteger(42))
 	c.Assert(result.IsZero(), qt.IsTrue)
 	// No exactness assertion here — both behaviors are acceptable per R7RS
 
 	// Case 3: Exact zero * infinity → NaN (NOT zero)
-	result = NewInteger(0).Multiply(NewFloat(math.Inf(1)))
+	result = values.NewInteger(0).Multiply(values.NewFloat(math.Inf(1)))
 	c.Assert(result.IsNaN(), qt.IsTrue, qt.Commentf("(* 0 +inf.0) should be +nan.0"))
 
 	// Case 4: Exact zero * -infinity → NaN (NOT zero)
-	result = NewInteger(0).Multiply(NewFloat(math.Inf(-1)))
+	result = values.NewInteger(0).Multiply(values.NewFloat(math.Inf(-1)))
 	c.Assert(result.IsNaN(), qt.IsTrue, qt.Commentf("(* 0 -inf.0) should be +nan.0"))
 
 	// Case 5: Exact zero * NaN → NaN (NOT zero)
-	result = NewInteger(0).Multiply(NewFloat(math.NaN()))
+	result = values.NewInteger(0).Multiply(values.NewFloat(math.NaN()))
 	c.Assert(result.IsNaN(), qt.IsTrue, qt.Commentf("(* 0 +nan.0) should be +nan.0"))
 }
 
@@ -334,17 +336,17 @@ func TestExactnessContagionWhyMultiplicationIsDifferent(t *testing.T) {
 	c := qt.New(t)
 
 	// Demonstrate: addition preserves exactness of non-zero operand
-	addResult := NewInteger(0).Add(NewFloat(0.0))
+	addResult := values.NewInteger(0).Add(values.NewFloat(0.0))
 	c.Assert(addResult.IsExact(), qt.IsFalse,
 		qt.Commentf("(+ 0 0.0) must be inexact because 0.0 is inexact"))
 
 	// Demonstrate: subtraction preserves exactness of minuend
-	subResult := NewFloat(0.0).Subtract(NewInteger(0))
+	subResult := values.NewFloat(0.0).Subtract(values.NewInteger(0))
 	c.Assert(subResult.IsExact(), qt.IsFalse,
 		qt.Commentf("(- 0.0 0) must be inexact because 0.0 is inexact"))
 
 	// Demonstrate: multiplication can return exact zero
-	mulResult := NewInteger(0).Multiply(NewFloat(42.5))
+	mulResult := values.NewInteger(0).Multiply(values.NewFloat(42.5))
 	c.Assert(mulResult.IsExact(), qt.IsTrue,
 		qt.Commentf("(* 0 42.5) can be exact because result is mathematically 0"))
 }

--- a/values/export_test.go
+++ b/values/export_test.go
@@ -1,0 +1,6 @@
+package values
+
+// Export unexported constructors for use in external test files (package values_test).
+
+var ExportNewForeignError = newForeignError
+var ExportNewForeignReadErrorf = newForeignReadErrorf

--- a/values/float_test.go
+++ b/values/float_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"errors"
@@ -20,19 +20,22 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestFloat_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  Value
+		in  values.Value
 		out string
 	}{
 		{
-			in:  NewFloat(1.1),
+			in:  values.NewFloat(1.1),
 			out: "1.1",
 		},
 		{
-			in:  NewFloat(1.2),
+			in:  values.NewFloat(1.2),
 			out: "1.2",
 		},
 	}
@@ -45,18 +48,18 @@ func TestFloat_SchemeString(t *testing.T) {
 
 func TestFloat_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewFloat(1.1),
-			in1: NewFloat(1.1),
+			in0: values.NewFloat(1.1),
+			in1: values.NewFloat(1.1),
 			out: true,
 		},
 		{
-			in0: NewFloat(1.0),
-			in1: NewFloat(1.1),
+			in0: values.NewFloat(1.0),
+			in1: values.NewFloat(1.1),
 			out: false,
 		},
 	}
@@ -68,124 +71,124 @@ func TestFloat_EqualTo(t *testing.T) {
 }
 
 func TestFloat_Datum(t *testing.T) {
-	f := NewFloat(3.14)
+	f := values.NewFloat(3.14)
 	qt.Assert(t, f.Datum(), qt.Equals, 3.14)
 }
 
 func TestFloat_String(t *testing.T) {
-	f := NewFloat(3.14)
+	f := values.NewFloat(3.14)
 	qt.Assert(t, f.String(), qt.Equals, "3.14")
 }
 
 func TestFloat_Add(t *testing.T) {
-	f1 := NewFloat(5.5)
-	f2 := NewFloat(2.5)
+	f1 := values.NewFloat(5.5)
+	f2 := values.NewFloat(2.5)
 	result := f1.Add(f2)
-	qt.Assert(t, result, SchemeEquals, NewFloat(8.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(8.0))
 
-	f3 := NewFloat(0.0)
+	f3 := values.NewFloat(0.0)
 	result = f1.Add(f3)
-	qt.Assert(t, result, SchemeEquals, NewFloat(5.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(5.5))
 
-	i1 := NewInteger(3)
+	i1 := values.NewInteger(3)
 	result = f1.Add(i1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(8.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(8.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = f1.Add(r1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(6.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(6.0))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = f1.Add(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(6.5, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(6.5, 2)))
 }
 
 func TestFloat_Subtract(t *testing.T) {
-	f1 := NewFloat(10.5)
-	f2 := NewFloat(2.5)
+	f1 := values.NewFloat(10.5)
+	f2 := values.NewFloat(2.5)
 	result := f1.Subtract(f2)
-	qt.Assert(t, result, SchemeEquals, NewFloat(8.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(8.0))
 
-	f3 := NewFloat(0.0)
+	f3 := values.NewFloat(0.0)
 	result = f1.Subtract(f3)
-	qt.Assert(t, result, SchemeEquals, NewFloat(10.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(10.5))
 
-	i1 := NewInteger(3)
+	i1 := values.NewInteger(3)
 	result = f1.Subtract(i1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(7.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(7.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = f1.Subtract(r1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(10.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(10.0))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = f1.Subtract(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(9.5, -2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(9.5, -2)))
 }
 
 func TestFloat_Multiply(t *testing.T) {
-	f1 := NewFloat(5.0)
-	f2 := NewFloat(2.5)
+	f1 := values.NewFloat(5.0)
+	f2 := values.NewFloat(2.5)
 	result := f1.Multiply(f2)
-	qt.Assert(t, result, SchemeEquals, NewFloat(12.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(12.5))
 
-	f3 := NewFloat(0.0)
+	f3 := values.NewFloat(0.0)
 	result = f1.Multiply(f3)
-	qt.Assert(t, result, SchemeEquals, NewFloat(0.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(0.0))
 
-	i1 := NewInteger(3)
+	i1 := values.NewInteger(3)
 	result = f1.Multiply(i1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(15.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(15.0))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = f1.Multiply(r1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(2.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(2.5))
 
-	c1 := NewComplex(complex(2, 3))
+	c1 := values.NewComplex(complex(2, 3))
 	result = f1.Multiply(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(10, 15)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(10, 15)))
 }
 
 func TestFloat_Divide(t *testing.T) {
-	f1 := NewFloat(10.0)
-	f2 := NewFloat(2.0)
+	f1 := values.NewFloat(10.0)
+	f2 := values.NewFloat(2.0)
 	result := f1.Divide(f2)
-	qt.Assert(t, result, SchemeEquals, NewFloat(5.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(5.0))
 
-	i1 := NewInteger(4)
+	i1 := values.NewInteger(4)
 	result = f1.Divide(i1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(2.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(2.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = f1.Divide(r1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(20.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(20.0))
 
-	c1 := NewComplex(complex(2, 0))
+	c1 := values.NewComplex(complex(2, 0))
 	result = f1.Divide(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(5, 0)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(5, 0)))
 }
 
 func TestFloat_IsZero(t *testing.T) {
-	f1 := NewFloat(0.0)
+	f1 := values.NewFloat(0.0)
 	qt.Assert(t, f1.IsZero(), qt.IsTrue)
 
-	f2 := NewFloat(5.5)
+	f2 := values.NewFloat(5.5)
 	qt.Assert(t, f2.IsZero(), qt.IsFalse)
 }
 
 func TestFloat_LessThan(t *testing.T) {
-	f1 := NewFloat(5.5)
-	f2 := NewFloat(10.5)
+	f1 := values.NewFloat(5.5)
+	f2 := values.NewFloat(10.5)
 	qt.Assert(t, f1.LessThan(f2), qt.IsTrue)
 	qt.Assert(t, f2.LessThan(f1), qt.IsFalse)
 
-	i1 := NewInteger(7)
+	i1 := values.NewInteger(7)
 	qt.Assert(t, f1.LessThan(i1), qt.IsTrue)
 
-	r1 := NewRational(11, 2)
+	r1 := values.NewRational(11, 2)
 	qt.Assert(t, f1.LessThan(r1), qt.IsFalse)
 
-	c1 := NewComplex(complex(7, 0))
+	c1 := values.NewComplex(complex(7, 0))
 	qt.Assert(t, f1.LessThan(c1), qt.IsTrue)
 }
 
@@ -195,30 +198,30 @@ func TestFloat_ToExact(t *testing.T) {
 	tcs := []struct {
 		name  string
 		input float64
-		want  Value
+		want  values.Value
 	}{
 		{
 			name:  "integer value",
 			input: 5.0,
-			want:  NewInteger(5),
+			want:  values.NewInteger(5),
 		},
 		{
 			name:  "rational value",
 			input: 2.5,
-			want:  NewRational(5, 2),
+			want:  values.NewRational(5, 2),
 		},
 		{
 			name:  "negative integer",
 			input: -3.0,
-			want:  NewInteger(-3),
+			want:  values.NewInteger(-3),
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			f := NewFloat(tc.input)
+			f := values.NewFloat(tc.input)
 			result := f.ToExact()
-			c.Assert(result, SchemeEquals, tc.want)
+			c.Assert(result, valuestest.SchemeEquals, tc.want)
 		})
 	}
 }
@@ -255,16 +258,16 @@ func TestFloat_ToExact_NonFinite(t *testing.T) {
 					t.Fatal("expected panic for non-finite float")
 				}
 				// Verify it's a ForeignError wrapping ErrExactnessConversion
-				fe, ok := r.(*ForeignError)
+				fe, ok := r.(*values.ForeignError)
 				if !ok {
 					t.Fatalf("expected ForeignError, got %T: %v", r, r)
 				}
-				if !errors.Is(fe, ErrExactnessConversion) {
+				if !errors.Is(fe, values.ErrExactnessConversion) {
 					t.Fatalf("expected error wrapping ErrExactnessConversion, got: %v", fe)
 				}
 			}()
 
-			f := NewFloat(tc.input)
+			f := values.NewFloat(tc.input)
 			// This should panic with a ForeignError
 			_ = f.ToExact()
 		})

--- a/values/foreign_error_test.go
+++ b/values/foreign_error_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"errors"
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestForeignError_EqualTo(t *testing.T) {
@@ -27,8 +29,8 @@ func TestForeignError_EqualTo(t *testing.T) {
 
 func TestForeignFileError_ErrorsAs(t *testing.T) {
 	c := qt.New(t)
-	err := WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
-	var fileErr *ForeignFileError
+	err := values.WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
+	var fileErr *values.ForeignFileError
 	c.Assert(errors.As(err, &fileErr), qt.IsTrue)
 	c.Assert(fileErr.Filename, qt.Equals, "/tmp/missing")
 	c.Assert(fileErr.Op, qt.Equals, "open-input-file")
@@ -36,46 +38,46 @@ func TestForeignFileError_ErrorsAs(t *testing.T) {
 
 func TestForeignFileError_ErrorsAs_Wrapped(t *testing.T) {
 	c := qt.New(t)
-	inner := WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
+	inner := values.WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
 	outer := fmt.Errorf("wrapped: %w", inner)
-	var fileErr *ForeignFileError
+	var fileErr *values.ForeignFileError
 	c.Assert(errors.As(outer, &fileErr), qt.IsTrue)
 	c.Assert(fileErr.Filename, qt.Equals, "/tmp/missing")
 }
 
 func TestForeignFileError_NotDetectedAsReadError(t *testing.T) {
 	c := qt.New(t)
-	err := WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
-	var readErr *ForeignReadError
+	err := values.WrapForeignFileError(fmt.Errorf("no such file"), "open-input-file", "/tmp/missing")
+	var readErr *values.ForeignReadError
 	c.Assert(errors.As(err, &readErr), qt.IsFalse)
 }
 
 func TestForeignReadError_ErrorsAs(t *testing.T) {
 	c := qt.New(t)
-	err := WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
-	var readErr *ForeignReadError
+	err := values.WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
+	var readErr *values.ForeignReadError
 	c.Assert(errors.As(err, &readErr), qt.IsTrue)
 }
 
 func TestForeignReadError_ErrorsAs_Wrapped(t *testing.T) {
 	c := qt.New(t)
-	inner := WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
+	inner := values.WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
 	outer := fmt.Errorf("wrapped: %w", inner)
-	var readErr *ForeignReadError
+	var readErr *values.ForeignReadError
 	c.Assert(errors.As(outer, &readErr), qt.IsTrue)
 }
 
 func TestForeignReadError_NotDetectedAsFileError(t *testing.T) {
 	c := qt.New(t)
-	err := WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
-	var fileErr *ForeignFileError
+	err := values.WrapForeignReadErrorf(fmt.Errorf("unexpected token"), "read error")
+	var fileErr *values.ForeignFileError
 	c.Assert(errors.As(err, &fileErr), qt.IsFalse)
 }
 
 func TestNewForeignReadErrorf(t *testing.T) {
 	c := qt.New(t)
-	err := newForeignReadErrorf("parse error at %d", 42)
-	var readErr *ForeignReadError
+	err := values.ExportNewForeignReadErrorf("parse error at %d", 42)
+	var readErr *values.ForeignReadError
 	c.Assert(errors.As(err, &readErr), qt.IsTrue)
 	c.Assert(err.Error(), qt.Matches, ".*parse error at 42.*")
 }
@@ -83,33 +85,33 @@ func TestNewForeignReadErrorf(t *testing.T) {
 func TestForeignFileError_ErrorsIs_Cause(t *testing.T) {
 	c := qt.New(t)
 	cause := fmt.Errorf("permission denied")
-	err := WrapForeignFileError(cause, "open-input-file", "/etc/shadow")
+	err := values.WrapForeignFileError(cause, "open-input-file", "/etc/shadow")
 	c.Assert(errors.Is(err, cause), qt.IsTrue)
 }
 
 func TestForeignReadError_ErrorsIs_Cause(t *testing.T) {
 	c := qt.New(t)
 	cause := fmt.Errorf("unexpected )")
-	err := WrapForeignReadErrorf(cause, "read error")
+	err := values.WrapForeignReadErrorf(cause, "read error")
 	c.Assert(errors.Is(err, cause), qt.IsTrue)
 }
 
 func TestForeignError_Is(t *testing.T) {
 	c := qt.New(t)
-	sentinel := NewStaticError("test sentinel")
+	sentinel := values.NewStaticError("test sentinel")
 	cause := fmt.Errorf("root cause")
 
 	tcs := []struct {
 		name   string
-		err    *ForeignError
+		err    *values.ForeignError
 		target error
 		want   bool
 	}{
-		{"sentinel match", WrapForeignErrorf(sentinel, "msg"), sentinel, true},
-		{"cause match", WrapForeignErrorWithCause(sentinel, cause, "msg"), cause, true},
-		{"sentinel via cause constructor", WrapForeignErrorWithCause(sentinel, cause, "msg"), sentinel, true},
-		{"no match", WrapForeignErrorf(sentinel, "msg"), fmt.Errorf("other"), false},
-		{"nil sentinel and cause", newForeignError("msg"), sentinel, false},
+		{"sentinel match", values.WrapForeignErrorf(sentinel, "msg"), sentinel, true},
+		{"cause match", values.WrapForeignErrorWithCause(sentinel, cause, "msg"), cause, true},
+		{"sentinel via cause constructor", values.WrapForeignErrorWithCause(sentinel, cause, "msg"), sentinel, true},
+		{"no match", values.WrapForeignErrorf(sentinel, "msg"), fmt.Errorf("other"), false},
+		{"nil sentinel and cause", values.ExportNewForeignError("msg"), sentinel, false},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -122,14 +124,14 @@ func TestForeignError_As(t *testing.T) {
 	c := qt.New(t)
 
 	// ForeignFileError detected through embedded ForeignError
-	fileErr := WrapForeignFileError(fmt.Errorf("no such file"), "open", "/tmp/x")
+	fileErr := values.WrapForeignFileError(fmt.Errorf("no such file"), "open", "/tmp/x")
 	wrapped := fmt.Errorf("outer: %w", fileErr)
-	var target *ForeignFileError
+	var target *values.ForeignFileError
 	c.Assert(errors.As(wrapped, &target), qt.IsTrue)
 	c.Assert(target.Filename, qt.Equals, "/tmp/x")
 
 	// ForeignReadError not detected through ForeignFileError
-	var readTarget *ForeignReadError
+	var readTarget *values.ForeignReadError
 	c.Assert(errors.As(wrapped, &readTarget), qt.IsFalse)
 }
 
@@ -138,11 +140,11 @@ func TestForeignError_Cause(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		err  *ForeignError
+		err  *values.ForeignError
 		want error
 	}{
-		{"with cause", WrapForeignErrorWithCause(ErrNotANumber, fmt.Errorf("root"), "msg"), fmt.Errorf("root")},
-		{"without cause", WrapForeignErrorf(ErrNotANumber, "msg"), nil},
+		{"with cause", values.WrapForeignErrorWithCause(values.ErrNotANumber, fmt.Errorf("root"), "msg"), fmt.Errorf("root")},
+		{"without cause", values.WrapForeignErrorf(values.ErrNotANumber, "msg"), nil},
 		{"nil receiver", nil, nil},
 	}
 	for _, tc := range tcs {
@@ -159,10 +161,10 @@ func TestForeignError_Cause(t *testing.T) {
 
 func TestWrapForeignErrorWithCause(t *testing.T) {
 	c := qt.New(t)
-	sentinel := NewStaticError("test sentinel")
+	sentinel := values.NewStaticError("test sentinel")
 	cause := fmt.Errorf("disk full")
 
-	err := WrapForeignErrorWithCause(sentinel, cause, "write failed: %s", "/tmp/out")
+	err := values.WrapForeignErrorWithCause(sentinel, cause, "write failed: %s", "/tmp/out")
 	c.Assert(errors.Is(err, sentinel), qt.IsTrue)
 	c.Assert(errors.Is(err, cause), qt.IsTrue)
 	c.Assert(err.Cause(), qt.Equals, cause)

--- a/values/hash_consistency_test.go
+++ b/values/hash_consistency_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestHashConsistencyExactFamily verifies that Integer, BigInteger, and
@@ -30,14 +33,14 @@ func TestHashConsistencyExactFamily(t *testing.T) {
 
 	cases := []struct {
 		name string
-		int_ *Integer
-		big_ *BigInteger
-		rat_ *Rational
+		int_ *values.Integer
+		big_ *values.BigInteger
+		rat_ *values.Rational
 	}{
-		{"positive", NewInteger(5), NewBigIntegerFromInt64(5), NewRational(5, 1)},
-		{"zero", NewInteger(0), NewBigIntegerFromInt64(0), NewRational(0, 1)},
-		{"negative", NewInteger(-42), NewBigIntegerFromInt64(-42), NewRational(-42, 1)},
-		{"large", NewInteger(1000000), NewBigIntegerFromInt64(1000000), NewRational(1000000, 1)},
+		{"positive", values.NewInteger(5), values.NewBigIntegerFromInt64(5), values.NewRational(5, 1)},
+		{"zero", values.NewInteger(0), values.NewBigIntegerFromInt64(0), values.NewRational(0, 1)},
+		{"negative", values.NewInteger(-42), values.NewBigIntegerFromInt64(-42), values.NewRational(-42, 1)},
+		{"large", values.NewInteger(1000000), values.NewBigIntegerFromInt64(1000000), values.NewRational(1000000, 1)},
 	}
 
 	for _, tc := range cases {
@@ -69,8 +72,8 @@ func TestHashConsistencyExactLargeValues(t *testing.T) {
 
 	// A value that doesn't fit in int64.
 	large := new(big.Int).Exp(big.NewInt(2), big.NewInt(100), nil)
-	bi := NewBigInteger(large)
-	rat := NewRationalFromBigInt(large, big.NewInt(1))
+	bi := values.NewBigInteger(large)
+	rat := values.NewRationalFromBigInt(large, big.NewInt(1))
 
 	c.Assert(bi.EqualTo(rat), qt.IsTrue)
 	c.Assert(bi.HashCode(), qt.Equals, rat.HashCode())
@@ -83,14 +86,14 @@ func TestHashConsistencyInexactFamily(t *testing.T) {
 
 	cases := []struct {
 		name string
-		f    *Float
-		bf   *BigFloat
+		f    *values.Float
+		bf   *values.BigFloat
 	}{
-		{"pi-ish", NewFloat(3.14), NewBigFloatFromFloat64(3.14)},
-		{"zero", NewFloat(0.0), NewBigFloatFromFloat64(0.0)},
-		{"negative", NewFloat(-2.5), NewBigFloatFromFloat64(-2.5)},
-		{"one", NewFloat(1.0), NewBigFloatFromFloat64(1.0)},
-		{"small", NewFloat(0.001), NewBigFloatFromFloat64(0.001)},
+		{"pi-ish", values.NewFloat(3.14), values.NewBigFloatFromFloat64(3.14)},
+		{"zero", values.NewFloat(0.0), values.NewBigFloatFromFloat64(0.0)},
+		{"negative", values.NewFloat(-2.5), values.NewBigFloatFromFloat64(-2.5)},
+		{"one", values.NewFloat(1.0), values.NewBigFloatFromFloat64(1.0)},
+		{"small", values.NewFloat(0.001), values.NewBigFloatFromFloat64(0.001)},
 	}
 
 	for _, tc := range cases {
@@ -122,11 +125,11 @@ func TestHashConsistencyFloatSpecialValues(t *testing.T) {
 
 	for _, tc := range specials {
 		c.Run(tc.name, func(c *qt.C) {
-			f := NewFloat(tc.val)
+			f := values.NewFloat(tc.val)
 			// Must not panic.
 			h := f.HashCode()
 			// Same value must produce same hash (stability).
-			c.Assert(h, qt.Equals, NewFloat(tc.val).HashCode())
+			c.Assert(h, qt.Equals, values.NewFloat(tc.val).HashCode())
 		})
 	}
 }
@@ -136,23 +139,23 @@ func TestHashConsistencyFloatSpecialValues(t *testing.T) {
 func TestHashConsistencyHashtableExact(t *testing.T) {
 	c := qt.New(t)
 
-	ht := NewEmptyHashtable()
-	key := NewInteger(42)
-	val := NewInteger(100)
+	ht := values.NewEmptyHashtable()
+	key := values.NewInteger(42)
+	val := values.NewInteger(100)
 	err := ht.Set(key, val)
 	c.Assert(err, qt.IsNil)
 
 	// Look up with BigInteger.
-	got, ok, err := ht.Get(NewBigIntegerFromInt64(42))
+	got, ok, err := ht.Get(values.NewBigIntegerFromInt64(42))
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(got, SchemeEquals, val)
+	c.Assert(got, valuestest.SchemeEquals, val)
 
 	// Look up with Rational.
-	got, ok, err = ht.Get(NewRational(42, 1))
+	got, ok, err = ht.Get(values.NewRational(42, 1))
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(got, SchemeEquals, val)
+	c.Assert(got, valuestest.SchemeEquals, val)
 }
 
 // TestHashConsistencyHashtableInexact verifies the end-to-end hashtable
@@ -160,17 +163,17 @@ func TestHashConsistencyHashtableExact(t *testing.T) {
 func TestHashConsistencyHashtableInexact(t *testing.T) {
 	c := qt.New(t)
 
-	ht := NewEmptyHashtable()
-	key := NewFloat(3.14)
-	val := NewInteger(999)
+	ht := values.NewEmptyHashtable()
+	key := values.NewFloat(3.14)
+	val := values.NewInteger(999)
 	err := ht.Set(key, val)
 	c.Assert(err, qt.IsNil)
 
 	// Look up with BigFloat.
-	got, ok, err := ht.Get(NewBigFloatFromFloat64(3.14))
+	got, ok, err := ht.Get(values.NewBigFloatFromFloat64(3.14))
 	c.Assert(err, qt.IsNil)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(got, SchemeEquals, val)
+	c.Assert(got, valuestest.SchemeEquals, val)
 }
 
 // TestHashConsistencyExactInexactBoundary is a regression guard ensuring
@@ -180,8 +183,8 @@ func TestHashConsistencyHashtableInexact(t *testing.T) {
 func TestHashConsistencyExactInexactBoundary(t *testing.T) {
 	c := qt.New(t)
 
-	i := NewInteger(5)
-	f := NewFloat(5.0)
+	i := values.NewInteger(5)
+	f := values.NewFloat(5.0)
 	c.Assert(i.EqualTo(f), qt.IsFalse,
 		qt.Commentf("exact Integer must not equal inexact Float"))
 }
@@ -191,23 +194,23 @@ func TestHashConsistencyExactInexactBoundary(t *testing.T) {
 func TestHashConsistencySameValueStability(t *testing.T) {
 	c := qt.New(t)
 
-	i1 := NewInteger(7)
-	i2 := NewInteger(7)
+	i1 := values.NewInteger(7)
+	i2 := values.NewInteger(7)
 	c.Assert(i1.HashCode(), qt.Equals, i2.HashCode())
 
-	f1 := NewFloat(2.718)
-	f2 := NewFloat(2.718)
+	f1 := values.NewFloat(2.718)
+	f2 := values.NewFloat(2.718)
 	c.Assert(f1.HashCode(), qt.Equals, f2.HashCode())
 
-	r1 := NewRational(3, 7)
-	r2 := NewRational(3, 7)
+	r1 := values.NewRational(3, 7)
+	r2 := values.NewRational(3, 7)
 	c.Assert(r1.HashCode(), qt.Equals, r2.HashCode())
 
-	bi1 := NewBigIntegerFromInt64(99)
-	bi2 := NewBigIntegerFromInt64(99)
+	bi1 := values.NewBigIntegerFromInt64(99)
+	bi2 := values.NewBigIntegerFromInt64(99)
 	c.Assert(bi1.HashCode(), qt.Equals, bi2.HashCode())
 
-	bf1 := NewBigFloatFromFloat64(1.23)
-	bf2 := NewBigFloatFromFloat64(1.23)
+	bf1 := values.NewBigFloatFromFloat64(1.23)
+	bf2 := values.NewBigFloatFromFloat64(1.23)
 	c.Assert(bf1.HashCode(), qt.Equals, bf2.HashCode())
 }

--- a/values/hashtable_test.go
+++ b/values/hashtable_test.go
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // helper to build a hashtable from key-value pairs for tests.
-func makeHT(kvs ...any) *Hashtable {
-	ht := NewEmptyHashtable()
+func makeHT(kvs ...any) *values.Hashtable {
+	ht := values.NewEmptyHashtable()
 	for i := 0; i < len(kvs); i += 2 {
-		_ = ht.Set(kvs[i].(Value), kvs[i+1].(Value))
+		_ = ht.Set(kvs[i].(values.Value), kvs[i+1].(values.Value))
 	}
 	return ht
 }
@@ -32,50 +35,50 @@ func makeHT(kvs ...any) *Hashtable {
 func TestHashtable_EqualTo(t *testing.T) {
 	tcs := []struct {
 		name string
-		in0  Value
-		in1  Value
+		in0  values.Value
+		in1  values.Value
 		out  bool
 	}{
 		{
 			name: "different keys",
-			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
-			in1:  makeHT(NewSymbol("key2"), NewInteger(1)),
+			in0:  makeHT(values.NewSymbol("key1"), values.NewInteger(1)),
+			in1:  makeHT(values.NewSymbol("key2"), values.NewInteger(1)),
 			out:  false,
 		},
 		{
 			name: "equal contents",
-			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
-			in1:  makeHT(NewSymbol("key1"), NewInteger(1)),
+			in0:  makeHT(values.NewSymbol("key1"), values.NewInteger(1)),
+			in1:  makeHT(values.NewSymbol("key1"), values.NewInteger(1)),
 			out:  true,
 		},
 		{
 			name: "different values",
-			in0:  makeHT(NewSymbol("key1"), NewInteger(1)),
-			in1:  makeHT(NewSymbol("key1"), NewInteger(2)),
+			in0:  makeHT(values.NewSymbol("key1"), values.NewInteger(1)),
+			in1:  makeHT(values.NewSymbol("key1"), values.NewInteger(2)),
 			out:  false,
 		},
 		{
 			name: "different sizes",
-			in0:  makeHT(NewSymbol("a"), NewInteger(1), NewSymbol("b"), NewInteger(2)),
-			in1:  makeHT(NewSymbol("a"), NewInteger(1)),
+			in0:  makeHT(values.NewSymbol("a"), values.NewInteger(1), values.NewSymbol("b"), values.NewInteger(2)),
+			in1:  makeHT(values.NewSymbol("a"), values.NewInteger(1)),
 			out:  false,
 		},
 		{
 			name: "not a hashtable",
-			in0:  NewEmptyHashtable(),
-			in1:  NewInteger(1),
+			in0:  values.NewEmptyHashtable(),
+			in1:  values.NewInteger(1),
 			out:  false,
 		},
 		{
 			name: "empty hashtables equal",
-			in0:  NewEmptyHashtable(),
-			in1:  NewEmptyHashtable(),
+			in0:  values.NewEmptyHashtable(),
+			in1:  values.NewEmptyHashtable(),
 			out:  true,
 		},
 		{
 			name: "integer keys",
-			in0:  makeHT(NewInteger(1), NewString("one")),
-			in1:  makeHT(NewInteger(1), NewString("one")),
+			in0:  makeHT(values.NewInteger(1), values.NewString("one")),
+			in1:  makeHT(values.NewInteger(1), values.NewString("one")),
 			out:  true,
 		},
 	}
@@ -88,49 +91,49 @@ func TestHashtable_EqualTo(t *testing.T) {
 
 func TestHashtable_SchemeString(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
+	ht := values.NewEmptyHashtable()
 	c.Assert(ht.SchemeString(), qt.Equals, "#hash()")
 
-	ht2 := makeHT(NewSymbol("a"), NewInteger(1))
+	ht2 := makeHT(values.NewSymbol("a"), values.NewInteger(1))
 	c.Assert(ht2.SchemeString(), qt.Equals, "#hash((a . 1))")
 }
 
 func TestHashtable_NewEmptyHashtable(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
+	ht := values.NewEmptyHashtable()
 	c.Assert(ht.Size(), qt.Equals, 0)
 	c.Assert(ht.IsVoid(), qt.IsFalse)
 }
 
 func TestHashtable_GetSetDelete(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
+	ht := values.NewEmptyHashtable()
 
 	// Set and Get — uses structural equality, not pointer identity
-	err := ht.Set(NewSymbol("key"), NewInteger(42))
+	err := ht.Set(values.NewSymbol("key"), values.NewInteger(42))
 	c.Assert(err, qt.IsNil)
 
-	val, found, err := ht.Get(NewSymbol("key"))
+	val, found, err := ht.Get(values.NewSymbol("key"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsTrue)
-	c.Assert(val, SchemeEquals, NewInteger(42))
+	c.Assert(val, valuestest.SchemeEquals, values.NewInteger(42))
 
 	// HasKey
-	found, err = ht.HasKey(NewSymbol("key"))
+	found, err = ht.HasKey(values.NewSymbol("key"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsTrue)
 
-	found, err = ht.HasKey(NewSymbol("missing"))
+	found, err = ht.HasKey(values.NewSymbol("missing"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsFalse)
 
 	// Get missing
-	_, found, err = ht.Get(NewSymbol("missing"))
+	_, found, err = ht.Get(values.NewSymbol("missing"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsFalse)
 
 	// Delete
-	err = ht.Delete(NewSymbol("key"))
+	err = ht.Delete(values.NewSymbol("key"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(ht.Size(), qt.Equals, 0)
 }
@@ -138,34 +141,34 @@ func TestHashtable_GetSetDelete(t *testing.T) {
 func TestHashtable_KeysValues(t *testing.T) {
 	c := qt.New(t)
 
-	ht := NewEmptyHashtable()
-	c.Assert(ht.Keys(), qt.Equals, EmptyList)
-	c.Assert(ht.Values(), qt.Equals, EmptyList)
+	ht := values.NewEmptyHashtable()
+	c.Assert(ht.Keys(), qt.Equals, values.EmptyList)
+	c.Assert(ht.Values(), qt.Equals, values.EmptyList)
 
-	err := ht.Set(NewSymbol("a"), NewInteger(1))
+	err := ht.Set(values.NewSymbol("a"), values.NewInteger(1))
 	c.Assert(err, qt.IsNil)
 
 	keys := ht.Keys()
 	c.Assert(keys.Length(), qt.Equals, 1)
-	c.Assert(keys.Car(), SchemeEquals, NewSymbol("a"))
+	c.Assert(keys.Car(), valuestest.SchemeEquals, values.NewSymbol("a"))
 
 	vals := ht.Values()
 	c.Assert(vals.Length(), qt.Equals, 1)
-	c.Assert(vals.Car(), SchemeEquals, NewInteger(1))
+	c.Assert(vals.Car(), valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestHashtable_CopyClear(t *testing.T) {
 	c := qt.New(t)
 
-	ht := NewEmptyHashtable()
-	err := ht.Set(NewSymbol("a"), NewInteger(1))
+	ht := values.NewEmptyHashtable()
+	err := ht.Set(values.NewSymbol("a"), values.NewInteger(1))
 	c.Assert(err, qt.IsNil)
 
 	// Copy is independent
 	cp := ht.Copy()
 	c.Assert(cp.Size(), qt.Equals, 1)
 
-	err = ht.Set(NewSymbol("b"), NewInteger(2))
+	err = ht.Set(values.NewSymbol("b"), values.NewInteger(2))
 	c.Assert(err, qt.IsNil)
 	c.Assert(ht.Size(), qt.Equals, 2)
 	c.Assert(cp.Size(), qt.Equals, 1)
@@ -178,10 +181,10 @@ func TestHashtable_CopyClear(t *testing.T) {
 
 func TestHashtable_NonHashableKey(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
-	key := NewCons(NewInteger(1), NewInteger(2))
+	ht := values.NewEmptyHashtable()
+	key := values.NewCons(values.NewInteger(1), values.NewInteger(2))
 
-	err := ht.Set(key, NewInteger(1))
+	err := ht.Set(key, values.NewInteger(1))
 	c.Assert(err, qt.IsNotNil)
 
 	_, _, err = ht.Get(key)
@@ -196,54 +199,54 @@ func TestHashtable_NonHashableKey(t *testing.T) {
 
 func TestHashtable_VariousKeyTypes(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
+	ht := values.NewEmptyHashtable()
 
 	// Symbol key
-	err := ht.Set(NewSymbol("sym"), NewInteger(1))
+	err := ht.Set(values.NewSymbol("sym"), values.NewInteger(1))
 	c.Assert(err, qt.IsNil)
 
 	// Integer key
-	err = ht.Set(NewInteger(42), NewInteger(2))
+	err = ht.Set(values.NewInteger(42), values.NewInteger(2))
 	c.Assert(err, qt.IsNil)
 
 	// String key
-	err = ht.Set(NewString("str"), NewInteger(3))
+	err = ht.Set(values.NewString("str"), values.NewInteger(3))
 	c.Assert(err, qt.IsNil)
 
 	// Boolean key
-	err = ht.Set(TrueValue, NewInteger(4))
+	err = ht.Set(values.TrueValue, values.NewInteger(4))
 	c.Assert(err, qt.IsNil)
 
 	// Character key
-	err = ht.Set(NewCharacter('x'), NewInteger(5))
+	err = ht.Set(values.NewCharacter('x'), values.NewInteger(5))
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(ht.Size(), qt.Equals, 5)
 
 	// Look up with new pointers — structural equality
-	val, found, err := ht.Get(NewInteger(42))
+	val, found, err := ht.Get(values.NewInteger(42))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsTrue)
-	c.Assert(val, SchemeEquals, NewInteger(2))
+	c.Assert(val, valuestest.SchemeEquals, values.NewInteger(2))
 
-	val, found, err = ht.Get(NewSymbol("sym"))
+	val, found, err = ht.Get(values.NewSymbol("sym"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsTrue)
-	c.Assert(val, SchemeEquals, NewInteger(1))
+	c.Assert(val, valuestest.SchemeEquals, values.NewInteger(1))
 }
 
 func TestHashtable_OverwriteKey(t *testing.T) {
 	c := qt.New(t)
-	ht := NewEmptyHashtable()
+	ht := values.NewEmptyHashtable()
 
-	err := ht.Set(NewSymbol("k"), NewInteger(1))
+	err := ht.Set(values.NewSymbol("k"), values.NewInteger(1))
 	c.Assert(err, qt.IsNil)
-	err = ht.Set(NewSymbol("k"), NewInteger(2))
+	err = ht.Set(values.NewSymbol("k"), values.NewInteger(2))
 	c.Assert(err, qt.IsNil)
 
 	c.Assert(ht.Size(), qt.Equals, 1)
-	val, found, err := ht.Get(NewSymbol("k"))
+	val, found, err := ht.Get(values.NewSymbol("k"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(found, qt.IsTrue)
-	c.Assert(val, SchemeEquals, NewInteger(2))
+	c.Assert(val, valuestest.SchemeEquals, values.NewInteger(2))
 }

--- a/values/integer_bench_test.go
+++ b/values/integer_bench_test.go
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
 	"testing"
+
+	"github.com/aalpar/wile/values"
 )
 
 func BenchmarkIntegerAdd(b *testing.B) {
-	x := NewInteger(42)
-	y := NewInteger(17)
+	x := values.NewInteger(42)
+	y := values.NewInteger(17)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = x.Add(y)
@@ -29,8 +31,8 @@ func BenchmarkIntegerAdd(b *testing.B) {
 }
 
 func BenchmarkIntegerMultiply(b *testing.B) {
-	x := NewInteger(42)
-	y := NewInteger(17)
+	x := values.NewInteger(42)
+	y := values.NewInteger(17)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = x.Multiply(y)
@@ -38,8 +40,8 @@ func BenchmarkIntegerMultiply(b *testing.B) {
 }
 
 func BenchmarkIntegerOverflow(b *testing.B) {
-	x := NewInteger(math.MaxInt64)
-	one := NewInteger(1)
+	x := values.NewInteger(math.MaxInt64)
+	one := values.NewInteger(1)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = x.Add(one)
@@ -49,13 +51,13 @@ func BenchmarkIntegerOverflow(b *testing.B) {
 func BenchmarkIntegerCache(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = NewInteger(42)
+		_ = values.NewInteger(42)
 	}
 }
 
 func BenchmarkBigIntegerAdd(b *testing.B) {
-	x := NewBigIntegerFromInt64(1000000)
-	y := NewBigIntegerFromInt64(2000000)
+	x := values.NewBigIntegerFromInt64(1000000)
+	y := values.NewBigIntegerFromInt64(2000000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = x.Add(y)
@@ -63,8 +65,8 @@ func BenchmarkBigIntegerAdd(b *testing.B) {
 }
 
 func BenchmarkBigIntegerMultiply(b *testing.B) {
-	x := NewBigIntegerFromInt64(1000000)
-	y := NewBigIntegerFromInt64(2000000)
+	x := values.NewBigIntegerFromInt64(1000000)
+	y := values.NewBigIntegerFromInt64(2000000)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = x.Multiply(y)

--- a/values/integer_test.go
+++ b/values/integer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
@@ -20,22 +20,25 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestInteger_EqualTo(t *testing.T) {
 	tcs := []struct {
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		{
-			in0: NewInteger(10),
-			in1: NewInteger(10),
+			in0: values.NewInteger(10),
+			in1: values.NewInteger(10),
 			out: true,
 		},
 		{
-			in0: NewInteger(10),
-			in1: NewInteger(11),
+			in0: values.NewInteger(10),
+			in1: values.NewInteger(11),
 			out: false,
 		},
 	}
@@ -47,168 +50,168 @@ func TestInteger_EqualTo(t *testing.T) {
 }
 
 func TestInteger_Datum(t *testing.T) {
-	i := NewInteger(42)
+	i := values.NewInteger(42)
 	qt.Assert(t, i.Datum(), qt.Equals, int64(42))
 }
 
 func TestInteger_Add(t *testing.T) {
-	i1 := NewInteger(5)
-	i2 := NewInteger(3)
+	i1 := values.NewInteger(5)
+	i2 := values.NewInteger(3)
 	result := i1.Add(i2)
-	qt.Assert(t, result, SchemeEquals, NewInteger(8))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(8))
 
-	i3 := NewInteger(0)
+	i3 := values.NewInteger(0)
 	result = i1.Add(i3)
-	qt.Assert(t, result, SchemeEquals, NewInteger(5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(5))
 
-	f1 := NewFloat(2.5)
+	f1 := values.NewFloat(2.5)
 	result = i1.Add(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(7.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(7.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = i1.Add(r1)
-	qt.Assert(t, result, SchemeEquals, NewRational(11, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(11, 2))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = i1.Add(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(6, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(6, 2)))
 }
 
 func TestInteger_Subtract(t *testing.T) {
-	i1 := NewInteger(10)
-	i2 := NewInteger(3)
+	i1 := values.NewInteger(10)
+	i2 := values.NewInteger(3)
 	result := i1.Subtract(i2)
-	qt.Assert(t, result, SchemeEquals, NewInteger(7))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(7))
 
-	i3 := NewInteger(0)
+	i3 := values.NewInteger(0)
 	result = i1.Subtract(i3)
-	qt.Assert(t, result, SchemeEquals, NewInteger(10))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(10))
 
-	f1 := NewFloat(2.5)
+	f1 := values.NewFloat(2.5)
 	result = i1.Subtract(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(7.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(7.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = i1.Subtract(r1)
-	qt.Assert(t, result, SchemeEquals, NewRational(19, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(19, 2))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = i1.Subtract(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(9, -2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(9, -2)))
 }
 
 func TestInteger_Multiply(t *testing.T) {
-	i1 := NewInteger(5)
-	i2 := NewInteger(3)
+	i1 := values.NewInteger(5)
+	i2 := values.NewInteger(3)
 	result := i1.Multiply(i2)
-	qt.Assert(t, result, SchemeEquals, NewInteger(15))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(15))
 
-	i3 := NewInteger(0)
+	i3 := values.NewInteger(0)
 	result = i1.Multiply(i3)
-	qt.Assert(t, result, SchemeEquals, NewInteger(0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(0))
 
-	f1 := NewFloat(2.5)
+	f1 := values.NewFloat(2.5)
 	result = i1.Multiply(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(12.5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(12.5))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = i1.Multiply(r1)
-	qt.Assert(t, result, SchemeEquals, NewRational(5, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(5, 2))
 
-	c1 := NewComplex(complex(2, 3))
+	c1 := values.NewComplex(complex(2, 3))
 	result = i1.Multiply(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(10, 15)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(10, 15)))
 }
 
 func TestInteger_Divide(t *testing.T) {
-	i1 := NewInteger(10)
-	i2 := NewInteger(2)
+	i1 := values.NewInteger(10)
+	i2 := values.NewInteger(2)
 	result := i1.Divide(i2)
-	qt.Assert(t, result, SchemeEquals, NewInteger(5))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewInteger(5))
 
-	i3 := NewInteger(3)
+	i3 := values.NewInteger(3)
 	result = i1.Divide(i3)
-	qt.Assert(t, result, SchemeEquals, NewRational(10, 3))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(10, 3))
 
-	f1 := NewFloat(2.0)
+	f1 := values.NewFloat(2.0)
 	result = i1.Divide(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(5.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(5.0))
 
-	r1 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
 	result = i1.Divide(r1)
-	qt.Assert(t, result, SchemeEquals, NewRational(20, 1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(20, 1))
 
-	c1 := NewComplex(complex(2, 0))
+	c1 := values.NewComplex(complex(2, 0))
 	result = i1.Divide(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(5, 0)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(5, 0)))
 }
 
 func TestInteger_IsZero(t *testing.T) {
-	i1 := NewInteger(0)
+	i1 := values.NewInteger(0)
 	qt.Assert(t, i1.IsZero(), qt.IsTrue)
 
-	i2 := NewInteger(5)
+	i2 := values.NewInteger(5)
 	qt.Assert(t, i2.IsZero(), qt.IsFalse)
 }
 
 func TestInteger_LessThan(t *testing.T) {
-	i1 := NewInteger(5)
-	i2 := NewInteger(10)
+	i1 := values.NewInteger(5)
+	i2 := values.NewInteger(10)
 	qt.Assert(t, i1.LessThan(i2), qt.IsTrue)
 	qt.Assert(t, i2.LessThan(i1), qt.IsFalse)
 
-	f1 := NewFloat(7.5)
+	f1 := values.NewFloat(7.5)
 	qt.Assert(t, i1.LessThan(f1), qt.IsTrue)
 
-	r1 := NewRational(11, 2)
+	r1 := values.NewRational(11, 2)
 	qt.Assert(t, i1.LessThan(r1), qt.IsTrue)
 
-	c1 := NewComplex(complex(7, 0))
+	c1 := values.NewComplex(complex(7, 0))
 	qt.Assert(t, i1.LessThan(c1), qt.IsTrue)
 }
 
 func TestInteger_Caching(t *testing.T) {
 	// Small integers should be cached (same pointer)
-	i1 := NewInteger(42)
-	i2 := NewInteger(42)
+	i1 := values.NewInteger(42)
+	i2 := values.NewInteger(42)
 	qt.Assert(t, i1 == i2, qt.IsTrue, qt.Commentf("small integers should return same pointer"))
 
 	// Test cache boundaries (-32768 to 32767, 16-bit range)
-	iMin := NewInteger(-32768)
-	iMin2 := NewInteger(-32768)
+	iMin := values.NewInteger(-32768)
+	iMin2 := values.NewInteger(-32768)
 	qt.Assert(t, iMin == iMin2, qt.IsTrue, qt.Commentf("cache min boundary should be cached"))
 
-	iMax := NewInteger(32767)
-	iMax2 := NewInteger(32767)
+	iMax := values.NewInteger(32767)
+	iMax2 := values.NewInteger(32767)
 	qt.Assert(t, iMax == iMax2, qt.IsTrue, qt.Commentf("cache max boundary should be cached"))
 
 	// Zero should be cached
-	i0a := NewInteger(0)
-	i0b := NewInteger(0)
+	i0a := values.NewInteger(0)
+	i0b := values.NewInteger(0)
 	qt.Assert(t, i0a == i0b, qt.IsTrue, qt.Commentf("zero should be cached"))
 
 	// Negative numbers in range should be cached
-	iNeg := NewInteger(-100)
-	iNeg2 := NewInteger(-100)
+	iNeg := values.NewInteger(-100)
+	iNeg2 := values.NewInteger(-100)
 	qt.Assert(t, iNeg == iNeg2, qt.IsTrue, qt.Commentf("negative integers in range should be cached"))
 
 	// Values within 16-bit range should be cached
-	i1000a := NewInteger(1000)
-	i1000b := NewInteger(1000)
+	i1000a := values.NewInteger(1000)
+	i1000b := values.NewInteger(1000)
 	qt.Assert(t, i1000a == i1000b, qt.IsTrue, qt.Commentf("integers within 16-bit range should be cached"))
 
 	// Values outside cache range should NOT be cached (different pointers)
-	iOutMin := NewInteger(-32769)
-	iOutMin2 := NewInteger(-32769)
+	iOutMin := values.NewInteger(-32769)
+	iOutMin2 := values.NewInteger(-32769)
 	qt.Assert(t, iOutMin != iOutMin2, qt.IsTrue, qt.Commentf("integers below cache min should not be cached"))
 
-	iOutMax := NewInteger(32768)
-	iOutMax2 := NewInteger(32768)
+	iOutMax := values.NewInteger(32768)
+	iOutMax2 := values.NewInteger(32768)
 	qt.Assert(t, iOutMax != iOutMax2, qt.IsTrue, qt.Commentf("integers above cache max should not be cached"))
 
 	// Large integers should NOT be cached
-	iBig1 := NewInteger(100000)
-	iBig2 := NewInteger(100000)
+	iBig1 := values.NewInteger(100000)
+	iBig2 := values.NewInteger(100000)
 	qt.Assert(t, iBig1 != iBig2, qt.IsTrue, qt.Commentf("large integers should not be cached"))
 
 	// Cached integers should still have correct values
@@ -219,56 +222,56 @@ func TestInteger_Caching(t *testing.T) {
 func TestInteger_OverflowPromotion(t *testing.T) {
 	c := qt.New(t)
 
-	maxInt := NewInteger(math.MaxInt64)
-	minInt := NewInteger(math.MinInt64)
+	maxInt := values.NewInteger(math.MaxInt64)
+	minInt := values.NewInteger(math.MinInt64)
 
 	// MaxInt64 + 1 -> BigInteger
-	result := maxInt.Add(NewInteger(1))
-	bi, ok := result.(*BigInteger)
+	result := maxInt.Add(values.NewInteger(1))
+	bi, ok := result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("MaxInt64 + 1 should produce BigInteger, got %T", result))
 	expected := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// MinInt64 - 1 -> BigInteger
-	result = minInt.Subtract(NewInteger(1))
-	bi, ok = result.(*BigInteger)
+	result = minInt.Subtract(values.NewInteger(1))
+	bi, ok = result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("MinInt64 - 1 should produce BigInteger, got %T", result))
 	expected = new(big.Int).Sub(big.NewInt(math.MinInt64), big.NewInt(1))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// MaxInt64 * 2 -> BigInteger
-	result = maxInt.Multiply(NewInteger(2))
-	bi, ok = result.(*BigInteger)
+	result = maxInt.Multiply(values.NewInteger(2))
+	bi, ok = result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("MaxInt64 * 2 should produce BigInteger, got %T", result))
 	expected = new(big.Int).Mul(big.NewInt(math.MaxInt64), big.NewInt(2))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// MinInt64 * 2 -> BigInteger
-	result = minInt.Multiply(NewInteger(2))
-	bi, ok = result.(*BigInteger)
+	result = minInt.Multiply(values.NewInteger(2))
+	bi, ok = result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("MinInt64 * 2 should produce BigInteger, got %T", result))
 	expected = new(big.Int).Mul(big.NewInt(math.MinInt64), big.NewInt(2))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// Negate MinInt64 -> BigInteger equal to 2^63
 	result = minInt.Negate()
-	bi, ok = result.(*BigInteger)
+	bi, ok = result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("Negate MinInt64 should produce BigInteger, got %T", result))
 	expected = new(big.Int).Neg(big.NewInt(math.MinInt64))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// Abs MinInt64 -> BigInteger equal to 2^63
 	result = minInt.Abs()
-	bi, ok = result.(*BigInteger)
+	bi, ok = result.(*values.BigInteger)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("Abs MinInt64 should produce BigInteger, got %T", result))
 	c.Assert(bi.BigInt().Cmp(expected), qt.Equals, 0)
 
 	// Small values still produce *Integer
-	result = NewInteger(5).Add(NewInteger(3))
-	_, ok = result.(*Integer)
+	result = values.NewInteger(5).Add(values.NewInteger(3))
+	_, ok = result.(*values.Integer)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("5 + 3 should produce Integer, got %T", result))
 
-	result = NewInteger(5).Multiply(NewInteger(3))
-	_, ok = result.(*Integer)
+	result = values.NewInteger(5).Multiply(values.NewInteger(3))
+	_, ok = result.(*values.Integer)
 	c.Assert(ok, qt.IsTrue, qt.Commentf("5 * 3 should produce Integer, got %T", result))
 }

--- a/values/mutex_test.go
+++ b/values/mutex_test.go
@@ -12,46 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestMutex_NewMutex(t *testing.T) {
-	m := NewMutex("test-mutex")
+	m := values.NewMutex("test-mutex")
 	qt.Assert(t, m, qt.Not(qt.IsNil))
 	qt.Assert(t, m.Name(), qt.Equals, "test-mutex")
 	qt.Assert(t, m.ID() > 0, qt.IsTrue)
-	qt.Assert(t, m.State(), qt.Equals, MutexUnlocked)
+	qt.Assert(t, m.State(), qt.Equals, values.MutexUnlocked)
 }
 
 func TestMutex_DefaultName(t *testing.T) {
-	m := NewMutex("")
+	m := values.NewMutex("")
 	qt.Assert(t, strings.HasPrefix(m.Name(), "mutex-"), qt.IsTrue)
 }
 
 func TestMutex_Specific(t *testing.T) {
-	m := NewMutex("test")
+	m := values.NewMutex("test")
 	qt.Assert(t, m.Specific() == nil, qt.IsTrue)
 
-	m.SetSpecific(NewInteger(42))
-	qt.Assert(t, m.Specific(), SchemeEquals, NewInteger(42))
+	m.SetSpecific(values.NewInteger(42))
+	qt.Assert(t, m.Specific(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestMutexState_String(t *testing.T) {
 	tcs := []struct {
-		state MutexState
+		state values.MutexState
 		str   string
 	}{
-		{MutexUnlocked, "not-owned"},
-		{MutexLockedOwned, "owned"},
-		{MutexLockedNotOwned, "not-owned"},
-		{MutexAbandoned, "abandoned"},
-		{MutexState(99), "unknown"},
+		{values.MutexUnlocked, "not-owned"},
+		{values.MutexLockedOwned, "owned"},
+		{values.MutexLockedNotOwned, "not-owned"},
+		{values.MutexAbandoned, "abandoned"},
+		{values.MutexState(99), "unknown"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.str, func(t *testing.T) {
@@ -61,27 +64,27 @@ func TestMutexState_String(t *testing.T) {
 }
 
 func TestMutex_LockUnlock_NoOwner(t *testing.T) {
-	m := NewMutex("test")
+	m := values.NewMutex("test")
 
 	ok, err := m.Lock(nil, nil)
 	qt.Assert(t, ok, qt.IsTrue)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, m.State(), qt.Equals, MutexLockedNotOwned)
+	qt.Assert(t, m.State(), qt.Equals, values.MutexLockedNotOwned)
 	qt.Assert(t, m.Owner() == nil, qt.IsTrue)
 
 	ok = m.Unlock(nil, nil)
 	qt.Assert(t, ok, qt.IsTrue)
-	qt.Assert(t, m.State(), qt.Equals, MutexUnlocked)
+	qt.Assert(t, m.State(), qt.Equals, values.MutexUnlocked)
 }
 
 func TestMutex_LockUnlock_WithOwner(t *testing.T) {
-	m := NewMutex("test")
-	th := NewThread(NewSymbol("thunk"), "owner")
+	m := values.NewMutex("test")
+	th := values.NewThread(values.NewSymbol("thunk"), "owner")
 
 	ok, err := m.Lock(nil, th)
 	qt.Assert(t, ok, qt.IsTrue)
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, m.State(), qt.Equals, MutexLockedOwned)
+	qt.Assert(t, m.State(), qt.Equals, values.MutexLockedOwned)
 	qt.Assert(t, m.Owner(), qt.Equals, th)
 
 	m.Unlock(nil, nil)
@@ -89,14 +92,14 @@ func TestMutex_LockUnlock_WithOwner(t *testing.T) {
 }
 
 func TestMutex_StateValue(t *testing.T) {
-	m := NewMutex("test")
+	m := values.NewMutex("test")
 
 	// Unlocked
 	sv := m.StateValue()
-	qt.Assert(t, sv, SchemeEquals, NewSymbol("not-owned"))
+	qt.Assert(t, sv, valuestest.SchemeEquals, values.NewSymbol("not-owned"))
 
 	// Locked with owner
-	th := NewThread(NewSymbol("thunk"), "owner")
+	th := values.NewThread(values.NewSymbol("thunk"), "owner")
 	m.Lock(nil, th)
 	sv = m.StateValue()
 	qt.Assert(t, sv.EqualTo(th), qt.IsTrue)
@@ -106,21 +109,21 @@ func TestMutex_StateValue(t *testing.T) {
 	m.Lock(nil, th)
 	m.MarkAbandoned()
 	sv = m.StateValue()
-	qt.Assert(t, sv, SchemeEquals, NewSymbol("abandoned"))
+	qt.Assert(t, sv, valuestest.SchemeEquals, values.NewSymbol("abandoned"))
 }
 
 func TestMutex_MarkAbandoned(t *testing.T) {
-	m := NewMutex("test")
-	th := NewThread(NewSymbol("thunk"), "owner")
+	m := values.NewMutex("test")
+	th := values.NewThread(values.NewSymbol("thunk"), "owner")
 	m.Lock(nil, th)
 
 	m.MarkAbandoned()
-	qt.Assert(t, m.State(), qt.Equals, MutexAbandoned)
+	qt.Assert(t, m.State(), qt.Equals, values.MutexAbandoned)
 }
 
 func TestMutex_LockAbandoned(t *testing.T) {
-	m := NewMutex("test")
-	th := NewThread(NewSymbol("thunk"), "owner")
+	m := values.NewMutex("test")
+	th := values.NewThread(values.NewSymbol("thunk"), "owner")
 	m.Lock(nil, th)
 	m.MarkAbandoned()
 
@@ -129,32 +132,32 @@ func TestMutex_LockAbandoned(t *testing.T) {
 	qt.Assert(t, ok, qt.IsTrue)
 	qt.Assert(t, err, qt.Not(qt.IsNil))
 
-	_, isAbandoned := err.(*AbandonedMutexException)
+	_, isAbandoned := err.(*values.AbandonedMutexException)
 	qt.Assert(t, isAbandoned, qt.IsTrue)
 }
 
 func TestMutex_IsVoid(t *testing.T) {
-	m := NewMutex("test")
+	m := values.NewMutex("test")
 	qt.Assert(t, m.IsVoid(), qt.IsFalse)
 
-	var nilM *Mutex
+	var nilM *values.Mutex
 	qt.Assert(t, nilM.IsVoid(), qt.IsTrue)
 }
 
 func TestMutex_EqualTo(t *testing.T) {
-	m1 := NewMutex("a")
-	m2 := NewMutex("b")
+	m1 := values.NewMutex("a")
+	m2 := values.NewMutex("b")
 	qt.Assert(t, m1.EqualTo(m1), qt.IsTrue)
 	qt.Assert(t, m1.EqualTo(m2), qt.IsFalse)
-	qt.Assert(t, m1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, m1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestMutex_SchemeString(t *testing.T) {
-	m := NewMutex("my-mutex")
+	m := values.NewMutex("my-mutex")
 	s := m.SchemeString()
 	qt.Assert(t, strings.Contains(s, "mutex"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "my-mutex"), qt.IsTrue)
 
-	var nilM *Mutex
+	var nilM *values.Mutex
 	qt.Assert(t, nilM.SchemeString(), qt.Equals, "#<mutex:void>")
 }

--- a/values/native_error_test.go
+++ b/values/native_error_test.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestNativeError_EqualTo(t *testing.T) {
@@ -25,16 +27,16 @@ func TestNativeError_EqualTo(t *testing.T) {
 
 func TestNewFileError_SetsKindFile(t *testing.T) {
 	c := qt.New(t)
-	err := NewFileError("file not found", NewString("/tmp/foo"))
-	c.Assert(err.Kind(), qt.Equals, NativeErrorKindFile)
+	err := values.NewFileError("file not found", values.NewString("/tmp/foo"))
+	c.Assert(err.Kind(), qt.Equals, values.NativeErrorKindFile)
 	c.Assert(err.IsFileError(), qt.IsTrue)
 	c.Assert(err.IsReadError(), qt.IsFalse)
 }
 
 func TestNewReadError_SetsKindRead(t *testing.T) {
 	c := qt.New(t)
-	err := NewReadError("unexpected token")
-	c.Assert(err.Kind(), qt.Equals, NativeErrorKindRead)
+	err := values.NewReadError("unexpected token")
+	c.Assert(err.Kind(), qt.Equals, values.NativeErrorKindRead)
 	c.Assert(err.IsReadError(), qt.IsTrue)
 	c.Assert(err.IsFileError(), qt.IsFalse)
 }
@@ -43,18 +45,18 @@ func TestNewErrorObjectWithCauseAndKind(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name string
-		kind NativeErrorKind
+		kind values.NativeErrorKind
 		file bool
 		read bool
 	}{
-		{"generic", NativeErrorKindGeneric, false, false},
-		{"file", NativeErrorKindFile, true, false},
-		{"read", NativeErrorKindRead, false, true},
+		{"generic", values.NativeErrorKindGeneric, false, false},
+		{"file", values.NativeErrorKindFile, true, false},
+		{"read", values.NativeErrorKindRead, false, true},
 	}
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			cause := newForeignError("underlying error")
-			err := NewErrorObjectWithCauseAndKind("msg", cause, tt.kind)
+			cause := values.ExportNewForeignError("underlying error")
+			err := values.NewErrorObjectWithCauseAndKind("msg", cause, tt.kind)
 			c.Assert(err.Kind(), qt.Equals, tt.kind)
 			c.Assert(err.IsFileError(), qt.Equals, tt.file)
 			c.Assert(err.IsReadError(), qt.Equals, tt.read)

--- a/values/numeric_exactness_regression_test.go
+++ b/values/numeric_exactness_regression_test.go
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestMultiply_ExactZeroDominates verifies R7RS §6.2.2 exact zero behavior.
@@ -27,145 +30,145 @@ import (
 // If either operand is an exact zero, the result is exact zero.
 // If both operands are inexact, the result is inexact zero.
 func TestMultiply_ExactZeroDominates(t *testing.T) {
-	exactZero := NewInteger(0)
+	exactZero := values.NewInteger(0)
 
 	tcs := []struct {
 		nm  string
-		in0 Number
-		in1 Number
-		out Number
+		in0 values.Number
+		in1 values.Number
+		out values.Number
 	}{
 		// Exact zero (Integer) × inexact → exact zero
 		{
 			nm:  "Integer(0) * Float(5.0)",
-			in0: NewInteger(0),
-			in1: NewFloat(5.0),
+			in0: values.NewInteger(0),
+			in1: values.NewFloat(5.0),
 			out: exactZero,
 		},
 		{
 			nm:  "Float(5.0) * Integer(0)",
-			in0: NewFloat(5.0),
-			in1: NewInteger(0),
+			in0: values.NewFloat(5.0),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 		{
 			nm:  "Integer(0) * BigFloat(5.0)",
-			in0: NewInteger(0),
-			in1: NewBigFloatFromFloat64(5.0),
+			in0: values.NewInteger(0),
+			in1: values.NewBigFloatFromFloat64(5.0),
 			out: exactZero,
 		},
 		{
 			nm:  "BigFloat(5.0) * Integer(0)",
-			in0: NewBigFloatFromFloat64(5.0),
-			in1: NewInteger(0),
+			in0: values.NewBigFloatFromFloat64(5.0),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 		{
 			nm:  "Integer(0) * Complex(1+2i)",
-			in0: NewInteger(0),
-			in1: NewComplex(complex(1, 2)),
+			in0: values.NewInteger(0),
+			in1: values.NewComplex(complex(1, 2)),
 			out: exactZero,
 		},
 		{
 			nm:  "Complex(1+2i) * Integer(0)",
-			in0: NewComplex(complex(1, 2)),
-			in1: NewInteger(0),
+			in0: values.NewComplex(complex(1, 2)),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 		// Exact zero (BigInteger) × inexact → exact zero
 		{
 			nm:  "BigInteger(0) * Float(5.0)",
-			in0: NewBigIntegerFromInt64(0),
-			in1: NewFloat(5.0),
+			in0: values.NewBigIntegerFromInt64(0),
+			in1: values.NewFloat(5.0),
 			out: exactZero,
 		},
 		{
 			nm:  "Float(5.0) * BigInteger(0)",
-			in0: NewFloat(5.0),
-			in1: NewBigIntegerFromInt64(0),
+			in0: values.NewFloat(5.0),
+			in1: values.NewBigIntegerFromInt64(0),
 			out: exactZero,
 		},
 		// Exact zero (Rational) × inexact → exact zero
 		{
 			nm:  "Rational(0) * Float(5.0)",
-			in0: NewRational(0, 1),
-			in1: NewFloat(5.0),
+			in0: values.NewRational(0, 1),
+			in1: values.NewFloat(5.0),
 			out: exactZero,
 		},
 		{
 			nm:  "Float(5.0) * Rational(0)",
-			in0: NewFloat(5.0),
-			in1: NewRational(0, 1),
+			in0: values.NewFloat(5.0),
+			in1: values.NewRational(0, 1),
 			out: exactZero,
 		},
 		// Exact × exact → exact zero
 		{
 			nm:  "Integer(0) * Integer(5)",
-			in0: NewInteger(0),
-			in1: NewInteger(5),
+			in0: values.NewInteger(0),
+			in1: values.NewInteger(5),
 			out: exactZero,
 		},
 		{
 			nm:  "Integer(5) * Integer(0)",
-			in0: NewInteger(5),
-			in1: NewInteger(0),
+			in0: values.NewInteger(5),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 		{
 			nm:  "BigInteger(0) * Rational(1/3)",
-			in0: NewBigIntegerFromInt64(0),
-			in1: NewRational(1, 3),
+			in0: values.NewBigIntegerFromInt64(0),
+			in1: values.NewRational(1, 3),
 			out: exactZero,
 		},
 		{
 			nm:  "Rational(1/3) * Integer(0)",
-			in0: NewRational(1, 3),
-			in1: NewInteger(0),
+			in0: values.NewRational(1, 3),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 		// Inexact × inexact → inexact zero (contagion preserved)
 		{
 			nm:  "Float(0.0) * Float(5.0)",
-			in0: NewFloat(0.0),
-			in1: NewFloat(5.0),
-			out: NewFloat(0.0),
+			in0: values.NewFloat(0.0),
+			in1: values.NewFloat(5.0),
+			out: values.NewFloat(0.0),
 		},
 		{
 			nm:  "Float(5.0) * Float(0.0)",
-			in0: NewFloat(5.0),
-			in1: NewFloat(0.0),
-			out: NewFloat(0.0),
+			in0: values.NewFloat(5.0),
+			in1: values.NewFloat(0.0),
+			out: values.NewFloat(0.0),
 		},
 		{
 			nm:  "Complex(0+0i) * Complex(1+2i)",
-			in0: NewComplex(complex(0, 0)),
-			in1: NewComplex(complex(1, 2)),
-			out: NewComplex(complex(0, 0)),
+			in0: values.NewComplex(complex(0, 0)),
+			in1: values.NewComplex(complex(1, 2)),
+			out: values.NewComplex(complex(0, 0)),
 		},
 		{
 			nm:  "BigFloat(0.0) * BigFloat(5.0)",
-			in0: NewBigFloatFromFloat64(0.0),
-			in1: NewBigFloatFromFloat64(5.0),
-			out: NewBigFloatFromFloat64(0.0),
+			in0: values.NewBigFloatFromFloat64(0.0),
+			in1: values.NewBigFloatFromFloat64(5.0),
+			out: values.NewBigFloatFromFloat64(0.0),
 		},
 		// Cross-type: exact zero × BigComplex → exact zero
 		{
 			nm:  "Integer(0) * BigComplex(1+2i)",
-			in0: NewInteger(0),
-			in1: NewBigComplexFromBigFloats(NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0)),
+			in0: values.NewInteger(0),
+			in1: values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(1.0), values.NewBigFloatFromFloat64(2.0)),
 			out: exactZero,
 		},
 		{
 			nm:  "BigComplex(1+2i) * Integer(0)",
-			in0: NewBigComplexFromBigFloats(NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0)),
-			in1: NewInteger(0),
+			in0: values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(1.0), values.NewBigFloatFromFloat64(2.0)),
+			in1: values.NewInteger(0),
 			out: exactZero,
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.nm, func(t *testing.T) {
 			result := tc.in0.Multiply(tc.in1)
-			qt.Assert(t, result, SchemeEquals, tc.out)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.out)
 			// Verify exactness is correct
 			qt.Assert(t, result.IsExact(), qt.Equals, tc.out.IsExact(),
 				qt.Commentf("exactness mismatch: got %T (exact=%v), want %T (exact=%v)",
@@ -179,21 +182,21 @@ func TestMultiply_ExactZeroDominates(t *testing.T) {
 func TestMultiply_ExactZeroCommutativity(t *testing.T) {
 	tcs := []struct {
 		nm string
-		a  Number
-		b  Number
+		a  values.Number
+		b  values.Number
 	}{
-		{"Integer(0) * Float(5.0)", NewInteger(0), NewFloat(5.0)},
-		{"Integer(0) * BigFloat(5.0)", NewInteger(0), NewBigFloatFromFloat64(5.0)},
-		{"Integer(0) * Complex(1+2i)", NewInteger(0), NewComplex(complex(1, 2))},
-		{"BigInteger(0) * Float(5.0)", NewBigIntegerFromInt64(0), NewFloat(5.0)},
-		{"Rational(0) * Float(5.0)", NewRational(0, 1), NewFloat(5.0)},
-		{"Float(0.0) * Float(5.0)", NewFloat(0.0), NewFloat(5.0)},
+		{"Integer(0) * Float(5.0)", values.NewInteger(0), values.NewFloat(5.0)},
+		{"Integer(0) * BigFloat(5.0)", values.NewInteger(0), values.NewBigFloatFromFloat64(5.0)},
+		{"Integer(0) * Complex(1+2i)", values.NewInteger(0), values.NewComplex(complex(1, 2))},
+		{"BigInteger(0) * Float(5.0)", values.NewBigIntegerFromInt64(0), values.NewFloat(5.0)},
+		{"Rational(0) * Float(5.0)", values.NewRational(0, 1), values.NewFloat(5.0)},
+		{"Float(0.0) * Float(5.0)", values.NewFloat(0.0), values.NewFloat(5.0)},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.nm, func(t *testing.T) {
 			ab := tc.a.Multiply(tc.b)
 			ba := tc.b.Multiply(tc.a)
-			qt.Assert(t, ab, SchemeEquals, ba,
+			qt.Assert(t, ab, valuestest.SchemeEquals, ba,
 				qt.Commentf("a*b=%v (%T), b*a=%v (%T)", ab, ab, ba, ba))
 			qt.Assert(t, ab.IsExact(), qt.Equals, ba.IsExact(),
 				qt.Commentf("exactness differs: a*b exact=%v, b*a exact=%v",
@@ -207,78 +210,78 @@ func TestMultiply_ExactZeroCommutativity(t *testing.T) {
 func TestEqualTo_NumericSymmetry(t *testing.T) {
 	tcs := []struct {
 		nm  string
-		in0 Value
-		in1 Value
+		in0 values.Value
+		in1 values.Value
 		out bool
 	}{
 		// Float ↔ BigFloat
 		{
 			nm:  "Float(3.0) == BigFloat(3.0)",
-			in0: NewFloat(3.0),
-			in1: NewBigFloatFromFloat64(3.0),
+			in0: values.NewFloat(3.0),
+			in1: values.NewBigFloatFromFloat64(3.0),
 			out: true,
 		},
 		{
 			nm:  "BigFloat(3.0) == Float(3.0)",
-			in0: NewBigFloatFromFloat64(3.0),
-			in1: NewFloat(3.0),
+			in0: values.NewBigFloatFromFloat64(3.0),
+			in1: values.NewFloat(3.0),
 			out: true,
 		},
 		{
 			nm:  "Float(3.0) == BigFloat(4.0)",
-			in0: NewFloat(3.0),
-			in1: NewBigFloatFromFloat64(4.0),
+			in0: values.NewFloat(3.0),
+			in1: values.NewBigFloatFromFloat64(4.0),
 			out: false,
 		},
 		{
 			nm:  "BigFloat(4.0) == Float(3.0)",
-			in0: NewBigFloatFromFloat64(4.0),
-			in1: NewFloat(3.0),
+			in0: values.NewBigFloatFromFloat64(4.0),
+			in1: values.NewFloat(3.0),
 			out: false,
 		},
 		// Rational ↔ Integer
 		{
 			nm:  "Rational(10/2) == Integer(5)",
-			in0: NewRational(10, 2),
-			in1: NewInteger(5),
+			in0: values.NewRational(10, 2),
+			in1: values.NewInteger(5),
 			out: true,
 		},
 		{
 			nm:  "Integer(5) == Rational(10/2)",
-			in0: NewInteger(5),
-			in1: NewRational(10, 2),
+			in0: values.NewInteger(5),
+			in1: values.NewRational(10, 2),
 			out: true,
 		},
 		{
 			nm:  "Rational(1/3) == Integer(0)",
-			in0: NewRational(1, 3),
-			in1: NewInteger(0),
+			in0: values.NewRational(1, 3),
+			in1: values.NewInteger(0),
 			out: false,
 		},
 		// Rational ↔ BigInteger
 		{
 			nm:  "Rational(14/2) == BigInteger(7)",
-			in0: NewRational(14, 2),
-			in1: NewBigIntegerFromInt64(7),
+			in0: values.NewRational(14, 2),
+			in1: values.NewBigIntegerFromInt64(7),
 			out: true,
 		},
 		{
 			nm:  "BigInteger(7) == Rational(14/2)",
-			in0: NewBigIntegerFromInt64(7),
-			in1: NewRational(14, 2),
+			in0: values.NewBigIntegerFromInt64(7),
+			in1: values.NewRational(14, 2),
 			out: true,
 		},
 		// Integer ↔ BigInteger (pre-existing, verify still works)
 		{
 			nm:  "Integer(42) == BigInteger(42)",
-			in0: NewInteger(42),
-			in1: NewBigIntegerFromInt64(42),
+			in0: values.NewInteger(42),
+			in1: values.NewBigIntegerFromInt64(42),
 			out: true,
 		},
 		{
 			nm:  "BigInteger(42) == Integer(42)",
-			in0: NewBigIntegerFromInt64(42),
-			in1: NewInteger(42),
+			in0: values.NewBigIntegerFromInt64(42),
+			in1: values.NewInteger(42),
 			out: true,
 		},
 	}
@@ -299,48 +302,48 @@ func TestEqualTo_NumericSymmetry(t *testing.T) {
 func TestPair_EqualTo_CircularList(t *testing.T) {
 	t.Run("identical circular lists are equal", func(t *testing.T) {
 		// Build circular list: (1 2 3 1 2 3 ...)
-		a := NewCons(NewInteger(1),
-			NewCons(NewInteger(2),
-				NewCons(NewInteger(3), EmptyList)))
+		a := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(2),
+				values.NewCons(values.NewInteger(3), values.EmptyList)))
 		// Make it circular: last cdr points back to head
-		a[1].(*Pair)[1].(*Pair)[1] = a
+		a[1].(*values.Pair)[1].(*values.Pair)[1] = a
 
-		b := NewCons(NewInteger(1),
-			NewCons(NewInteger(2),
-				NewCons(NewInteger(3), EmptyList)))
-		b[1].(*Pair)[1].(*Pair)[1] = b
+		b := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(2),
+				values.NewCons(values.NewInteger(3), values.EmptyList)))
+		b[1].(*values.Pair)[1].(*values.Pair)[1] = b
 
 		qt.Assert(t, a.EqualTo(b), qt.IsTrue)
 	})
 
 	t.Run("different circular lists are not equal", func(t *testing.T) {
-		a := NewCons(NewInteger(1),
-			NewCons(NewInteger(2), EmptyList))
-		a[1].(*Pair)[1] = a
+		a := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(2), values.EmptyList))
+		a[1].(*values.Pair)[1] = a
 
-		b := NewCons(NewInteger(1),
-			NewCons(NewInteger(99), EmptyList))
-		b[1].(*Pair)[1] = b
+		b := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(99), values.EmptyList))
+		b[1].(*values.Pair)[1] = b
 
 		qt.Assert(t, a.EqualTo(b), qt.IsFalse)
 	})
 
 	t.Run("self-referential pair is equal to itself", func(t *testing.T) {
-		a := NewCons(NewInteger(1), EmptyList)
+		a := values.NewCons(values.NewInteger(1), values.EmptyList)
 		a[1] = a
 
 		qt.Assert(t, a.EqualTo(a), qt.IsTrue)
 	})
 
 	t.Run("top-level EqualTo also handles circular lists", func(t *testing.T) {
-		a := NewCons(NewInteger(1),
-			NewCons(NewInteger(2), EmptyList))
-		a[1].(*Pair)[1] = a
+		a := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(2), values.EmptyList))
+		a[1].(*values.Pair)[1] = a
 
-		b := NewCons(NewInteger(1),
-			NewCons(NewInteger(2), EmptyList))
-		b[1].(*Pair)[1] = b
+		b := values.NewCons(values.NewInteger(1),
+			values.NewCons(values.NewInteger(2), values.EmptyList))
+		b[1].(*values.Pair)[1] = b
 
-		qt.Assert(t, EqualTo(a, b), qt.IsTrue)
+		qt.Assert(t, values.EqualTo(a, b), qt.IsTrue)
 	})
 }

--- a/values/numeric_lattice_test.go
+++ b/values/numeric_lattice_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"fmt"
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // =============================================================================
@@ -83,29 +85,29 @@ func (tc TypeClass) String() string {
 }
 
 // Classify returns the lattice position of a number.
-func Classify(n Number) TypeClass {
+func Classify(n values.Number) TypeClass {
 	switch v := n.(type) {
-	case *Integer:
+	case *values.Integer:
 		return TypeClass{PrecisionInteger, ComplexityReal}
-	case *BigInteger:
+	case *values.BigInteger:
 		return TypeClass{PrecisionBigInteger, ComplexityReal}
-	case *Rational:
+	case *values.Rational:
 		return TypeClass{PrecisionRational, ComplexityReal}
-	case *Float:
+	case *values.Float:
 		return TypeClass{PrecisionFloat, ComplexityReal}
-	case *BigFloat:
+	case *values.BigFloat:
 		return TypeClass{PrecisionBigFloat, ComplexityReal}
-	case *Complex:
+	case *values.Complex:
 		// complex128 uses float64 internally
 		return TypeClass{PrecisionFloat, ComplexityComplex}
-	case *BigComplex:
+	case *values.BigComplex:
 		// BigComplex precision depends on its components
 		return TypeClass{classifyBigComplexPrecision(v), ComplexityComplex}
 	}
 	panic(fmt.Sprintf("unknown type: %T", n))
 }
 
-func classifyBigComplexPrecision(bc *BigComplex) PrecisionRank {
+func classifyBigComplexPrecision(bc *values.BigComplex) PrecisionRank {
 	// BigComplex precision is the max of its real and imaginary parts
 	realPrec := Classify(bc.Real())
 	imagPrec := Classify(bc.Imag())
@@ -189,25 +191,25 @@ func TestLattice_Classify(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		value    Number
+		value    values.Number
 		expected TypeClass
 	}{
 		// Real types
-		{"Integer", NewInteger(42), TypeClass{PrecisionInteger, ComplexityReal}},
-		{"BigInteger", NewBigIntegerFromInt64(42), TypeClass{PrecisionBigInteger, ComplexityReal}},
-		{"Rational", NewRational(3, 4), TypeClass{PrecisionRational, ComplexityReal}},
-		{"Float", NewFloat(3.14), TypeClass{PrecisionFloat, ComplexityReal}},
-		{"BigFloat", NewBigFloatFromFloat64(3.14), TypeClass{PrecisionBigFloat, ComplexityReal}},
+		{"Integer", values.NewInteger(42), TypeClass{PrecisionInteger, ComplexityReal}},
+		{"BigInteger", values.NewBigIntegerFromInt64(42), TypeClass{PrecisionBigInteger, ComplexityReal}},
+		{"Rational", values.NewRational(3, 4), TypeClass{PrecisionRational, ComplexityReal}},
+		{"Float", values.NewFloat(3.14), TypeClass{PrecisionFloat, ComplexityReal}},
+		{"BigFloat", values.NewBigFloatFromFloat64(3.14), TypeClass{PrecisionBigFloat, ComplexityReal}},
 
 		// Complex types
-		{"Complex", NewComplex(complex(1, 2)), TypeClass{PrecisionFloat, ComplexityComplex}},
+		{"Complex", values.NewComplex(complex(1, 2)), TypeClass{PrecisionFloat, ComplexityComplex}},
 
 		// BigComplex with various component types
-		{"BigComplex(BigInteger)", NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2)),
+		{"BigComplex(BigInteger)", values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2)),
 			TypeClass{PrecisionBigInteger, ComplexityComplex}},
-		{"BigComplex(Rational)", NewBigComplex(NewRational(1, 2), NewRational(3, 4)),
+		{"BigComplex(Rational)", values.NewBigComplex(values.NewRational(1, 2), values.NewRational(3, 4)),
 			TypeClass{PrecisionRational, ComplexityComplex}},
-		{"BigComplex(BigFloat)", NewBigComplex(NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0)),
+		{"BigComplex(BigFloat)", values.NewBigComplex(values.NewBigFloatFromFloat64(1.0), values.NewBigFloatFromFloat64(2.0)),
 			TypeClass{PrecisionBigFloat, ComplexityComplex}},
 	}
 
@@ -278,25 +280,25 @@ func TestLattice_PredictionsVsActual(t *testing.T) {
 	c := qt.New(t)
 
 	// Test values - use different values for receiver vs operand to avoid simplification
-	testValues := map[string]Number{
-		"Integer":    NewInteger(5),
-		"BigInteger": NewBigIntegerFromInt64(7),
-		"Rational":   NewRational(3, 4),
-		"Float":      NewFloat(2.5),
-		"BigFloat":   NewBigFloatFromFloat64(3.5),
-		"Complex":    NewComplex(complex(1, 2)),
-		"BigComplex": NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2)),
+	testValues := map[string]values.Number{
+		"Integer":    values.NewInteger(5),
+		"BigInteger": values.NewBigIntegerFromInt64(7),
+		"Rational":   values.NewRational(3, 4),
+		"Float":      values.NewFloat(2.5),
+		"BigFloat":   values.NewBigFloatFromFloat64(3.5),
+		"Complex":    values.NewComplex(complex(1, 2)),
+		"BigComplex": values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2)),
 	}
 
 	// Different operand values to avoid simplification
-	operandValues := map[string]Number{
-		"Integer":    NewInteger(3),
-		"BigInteger": NewBigIntegerFromInt64(11),
-		"Rational":   NewRational(1, 3),
-		"Float":      NewFloat(1.5),
-		"BigFloat":   NewBigFloatFromFloat64(2.5),
-		"Complex":    NewComplex(complex(3, 4)),
-		"BigComplex": NewBigComplex(NewBigIntegerFromInt64(5), NewBigIntegerFromInt64(6)),
+	operandValues := map[string]values.Number{
+		"Integer":    values.NewInteger(3),
+		"BigInteger": values.NewBigIntegerFromInt64(11),
+		"Rational":   values.NewRational(1, 3),
+		"Float":      values.NewFloat(1.5),
+		"BigFloat":   values.NewBigFloatFromFloat64(2.5),
+		"Complex":    values.NewComplex(complex(3, 4)),
+		"BigComplex": values.NewBigComplex(values.NewBigIntegerFromInt64(5), values.NewBigIntegerFromInt64(6)),
 	}
 
 	typeNames := []string{"Integer", "BigInteger", "Rational", "Float", "BigFloat", "Complex", "BigComplex"}
@@ -469,24 +471,24 @@ func TestLattice_ResultTypeMatrix(t *testing.T) {
 	}
 
 	// Test values
-	testValues := map[string]Number{
-		"Integer":    NewInteger(5),
-		"BigInteger": NewBigIntegerFromInt64(7),
-		"Rational":   NewRational(3, 4),
-		"Float":      NewFloat(2.5),
-		"BigFloat":   NewBigFloatFromFloat64(3.5),
-		"Complex":    NewComplex(complex(1, 2)),
-		"BigComplex": NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2)),
+	testValues := map[string]values.Number{
+		"Integer":    values.NewInteger(5),
+		"BigInteger": values.NewBigIntegerFromInt64(7),
+		"Rational":   values.NewRational(3, 4),
+		"Float":      values.NewFloat(2.5),
+		"BigFloat":   values.NewBigFloatFromFloat64(3.5),
+		"Complex":    values.NewComplex(complex(1, 2)),
+		"BigComplex": values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2)),
 	}
 
-	operandValues := map[string]Number{
-		"Integer":    NewInteger(3),
-		"BigInteger": NewBigIntegerFromInt64(11),
-		"Rational":   NewRational(1, 3),
-		"Float":      NewFloat(1.5),
-		"BigFloat":   NewBigFloatFromFloat64(2.5),
-		"Complex":    NewComplex(complex(3, 4)),
-		"BigComplex": NewBigComplex(NewBigIntegerFromInt64(5), NewBigIntegerFromInt64(6)),
+	operandValues := map[string]values.Number{
+		"Integer":    values.NewInteger(3),
+		"BigInteger": values.NewBigIntegerFromInt64(11),
+		"Rational":   values.NewRational(1, 3),
+		"Float":      values.NewFloat(1.5),
+		"BigFloat":   values.NewBigFloatFromFloat64(2.5),
+		"Complex":    values.NewComplex(complex(3, 4)),
+		"BigComplex": values.NewBigComplex(values.NewBigIntegerFromInt64(5), values.NewBigIntegerFromInt64(6)),
 	}
 
 	typeNames := []string{"Integer", "BigInteger", "Rational", "Float", "BigFloat", "Complex", "BigComplex"}
@@ -518,33 +520,33 @@ func TestLattice_ExactnessPreservation(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		a, b        Number
+		a, b        values.Number
 		expectExact bool
 		description string
 	}{
 		// Exact + Exact = Exact
-		{"Int+Int", NewInteger(1), NewInteger(2), true, "exact integer + exact integer"},
-		{"Int+BigInt", NewInteger(1), NewBigIntegerFromInt64(2), true, "exact integer + exact big integer"},
-		{"Int+Rational", NewInteger(1), NewRational(1, 2), true, "exact integer + exact rational"},
-		{"BigInt+Rational", NewBigIntegerFromInt64(1), NewRational(1, 2), true, "exact big integer + exact rational"},
-		{"Rational+Rational", NewRational(1, 2), NewRational(1, 3), true, "exact rational + exact rational"},
+		{"Int+Int", values.NewInteger(1), values.NewInteger(2), true, "exact integer + exact integer"},
+		{"Int+BigInt", values.NewInteger(1), values.NewBigIntegerFromInt64(2), true, "exact integer + exact big integer"},
+		{"Int+Rational", values.NewInteger(1), values.NewRational(1, 2), true, "exact integer + exact rational"},
+		{"BigInt+Rational", values.NewBigIntegerFromInt64(1), values.NewRational(1, 2), true, "exact big integer + exact rational"},
+		{"Rational+Rational", values.NewRational(1, 2), values.NewRational(1, 3), true, "exact rational + exact rational"},
 
 		// Exact + Inexact = Inexact
-		{"Int+Float", NewInteger(1), NewFloat(2.0), false, "exact + inexact float"},
-		{"Int+BigFloat", NewInteger(1), NewBigFloatFromFloat64(2.0), false, "exact + inexact big float"},
-		{"Rational+Float", NewRational(1, 2), NewFloat(2.0), false, "exact rational + inexact float"},
+		{"Int+Float", values.NewInteger(1), values.NewFloat(2.0), false, "exact + inexact float"},
+		{"Int+BigFloat", values.NewInteger(1), values.NewBigFloatFromFloat64(2.0), false, "exact + inexact big float"},
+		{"Rational+Float", values.NewRational(1, 2), values.NewFloat(2.0), false, "exact rational + inexact float"},
 
 		// Inexact + Inexact = Inexact
-		{"Float+Float", NewFloat(1.0), NewFloat(2.0), false, "inexact + inexact"},
-		{"Float+BigFloat", NewFloat(1.0), NewBigFloatFromFloat64(2.0), false, "float + big float"},
-		{"BigFloat+BigFloat", NewBigFloatFromFloat64(1.0), NewBigFloatFromFloat64(2.0), false, "big float + big float"},
+		{"Float+Float", values.NewFloat(1.0), values.NewFloat(2.0), false, "inexact + inexact"},
+		{"Float+BigFloat", values.NewFloat(1.0), values.NewBigFloatFromFloat64(2.0), false, "float + big float"},
+		{"BigFloat+BigFloat", values.NewBigFloatFromFloat64(1.0), values.NewBigFloatFromFloat64(2.0), false, "big float + big float"},
 
 		// Complex exactness
-		{"Int+ExactComplex", NewInteger(1),
-			NewBigComplex(NewBigIntegerFromInt64(2), NewBigIntegerFromInt64(3)), true, "exact + exact complex"},
-		{"Int+InexactComplex", NewInteger(1), NewComplex(complex(2, 3)), false, "exact + inexact complex"},
-		{"Float+ExactComplex", NewFloat(1.0),
-			NewBigComplex(NewBigIntegerFromInt64(2), NewBigIntegerFromInt64(3)), false, "inexact + exact complex = inexact"},
+		{"Int+ExactComplex", values.NewInteger(1),
+			values.NewBigComplex(values.NewBigIntegerFromInt64(2), values.NewBigIntegerFromInt64(3)), true, "exact + exact complex"},
+		{"Int+InexactComplex", values.NewInteger(1), values.NewComplex(complex(2, 3)), false, "exact + inexact complex"},
+		{"Float+ExactComplex", values.NewFloat(1.0),
+			values.NewBigComplex(values.NewBigIntegerFromInt64(2), values.NewBigIntegerFromInt64(3)), false, "inexact + exact complex = inexact"},
 	}
 
 	for _, tt := range tests {
@@ -569,8 +571,8 @@ func TestLattice_VsLinearTower(t *testing.T) {
 	// The linear tower forces: Integer -> BigInteger -> Rational -> Float -> BigFloat -> Complex -> BigComplex
 	// This loses exactness when promoting exact reals to complex
 
-	exactInt := NewInteger(3)
-	exactComplex := NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2))
+	exactInt := values.NewInteger(3)
+	exactComplex := values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2))
 
 	// Direct dispatch (correct): preserves exactness
 	directResult := exactInt.Add(exactComplex)
@@ -607,11 +609,11 @@ func TestLattice_PrecisionLoss(t *testing.T) {
 	// BigFloat + Complex now preserves BigFloat precision (fixed asymmetry bug)
 	c.Run("BigFloat+Complex_preserves_precision", func(c *qt.C) {
 		// A BigFloat with more precision than float64 can represent
-		bf := NewBigFloatFromFloat64(1.0)
-		bf.value.SetPrec(256)
-		bf.value.SetString("1.123456789012345678901234567890")
+		bf := values.NewBigFloatFromFloat64(1.0)
+		bf.BigFloatValue().SetPrec(256)
+		bf.BigFloatValue().SetString("1.123456789012345678901234567890")
 
-		cx := NewComplex(complex(2, 3))
+		cx := values.NewComplex(complex(2, 3))
 
 		result := bf.Add(cx)
 
@@ -632,9 +634,9 @@ func TestLattice_PrecisionLoss(t *testing.T) {
 		// An integer larger than float64 can exactly represent
 		largeInt := new(big.Int)
 		largeInt.SetString("9999999999999999999999999999", 10)
-		bi := &BigInteger{value: largeInt}
+		bi := values.NewBigInteger(largeInt)
 
-		fl := NewFloat(1.0)
+		fl := values.NewFloat(1.0)
 
 		result := bi.Add(fl)
 

--- a/values/numeric_methods_coverage_test.go
+++ b/values/numeric_methods_coverage_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math"
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 // TestIntegerPredicates covers IsInteger, IsRational, IsFinite, IsNaN, IsPositive,
@@ -29,14 +32,14 @@ func TestIntegerPredicates(t *testing.T) {
 
 	tcs := []struct {
 		name       string
-		val        *Integer
+		val        *values.Integer
 		isPositive bool
 		isNegative bool
 		sign       int
 	}{
-		{"positive", NewInteger(42), true, false, 1},
-		{"negative", NewInteger(-7), false, true, -1},
-		{"zero", NewInteger(0), false, false, 0},
+		{"positive", values.NewInteger(42), true, false, 1},
+		{"negative", values.NewInteger(-7), false, true, -1},
+		{"zero", values.NewInteger(0), false, false, 0},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,13 +56,13 @@ func TestIntegerPredicates(t *testing.T) {
 
 func TestIntegerExactness(t *testing.T) {
 	c := qt.New(t)
-	i := NewInteger(5)
+	i := values.NewInteger(5)
 
 	exact := i.ToExact()
-	c.Assert(exact, SchemeEquals, i)
+	c.Assert(exact, valuestest.SchemeEquals, i)
 
 	inexact := i.ToInexact()
-	f, ok := inexact.(*Float)
+	f, ok := inexact.(*values.Float)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(f.Value, qt.Equals, 5.0)
 }
@@ -69,22 +72,22 @@ func TestIntegerCompare(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		a    *Integer
-		b    Number
+		a    *values.Integer
+		b    values.Number
 		want int
 	}{
-		{"int<int", NewInteger(1), NewInteger(2), -1},
-		{"int=int", NewInteger(5), NewInteger(5), 0},
-		{"int>int", NewInteger(9), NewInteger(3), 1},
-		{"int<float", NewInteger(1), NewFloat(1.5), -1},
-		{"int=float", NewInteger(2), NewFloat(2.0), 0},
-		{"int>float", NewInteger(3), NewFloat(2.5), 1},
-		{"int<rational", NewInteger(1), NewRational(3, 2), -1},
-		{"int<bigint", NewInteger(1), NewBigIntegerFromInt64(2), -1},
-		{"int<bigfloat", NewInteger(1), NewBigFloatFromFloat64(1.5), -1},
-		{"int<complex", NewInteger(1), NewComplexFromParts(2.0, 0.0), -1},
-		{"int=complex", NewInteger(2), NewComplexFromParts(2.0, 0.0), 0},
-		{"int<bigcomplex", NewInteger(1), NewBigComplex(NewBigIntegerFromInt64(2), NewBigIntegerFromInt64(0)), -1},
+		{"int<int", values.NewInteger(1), values.NewInteger(2), -1},
+		{"int=int", values.NewInteger(5), values.NewInteger(5), 0},
+		{"int>int", values.NewInteger(9), values.NewInteger(3), 1},
+		{"int<float", values.NewInteger(1), values.NewFloat(1.5), -1},
+		{"int=float", values.NewInteger(2), values.NewFloat(2.0), 0},
+		{"int>float", values.NewInteger(3), values.NewFloat(2.5), 1},
+		{"int<rational", values.NewInteger(1), values.NewRational(3, 2), -1},
+		{"int<bigint", values.NewInteger(1), values.NewBigIntegerFromInt64(2), -1},
+		{"int<bigfloat", values.NewInteger(1), values.NewBigFloatFromFloat64(1.5), -1},
+		{"int<complex", values.NewInteger(1), values.NewComplexFromParts(2.0, 0.0), -1},
+		{"int=complex", values.NewInteger(2), values.NewComplexFromParts(2.0, 0.0), 0},
+		{"int<bigcomplex", values.NewInteger(1), values.NewBigComplex(values.NewBigIntegerFromInt64(2), values.NewBigIntegerFromInt64(0)), -1},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -100,7 +103,7 @@ func TestFloatPredicates(t *testing.T) {
 
 	tcs := []struct {
 		name       string
-		val        *Float
+		val        *values.Float
 		isInteger  bool
 		isRational bool
 		isFinite   bool
@@ -109,13 +112,13 @@ func TestFloatPredicates(t *testing.T) {
 		isNegative bool
 		sign       int
 	}{
-		{"positive", NewFloat(3.14), false, true, true, false, true, false, 1},
-		{"negative", NewFloat(-2.5), false, true, true, false, false, true, -1},
-		{"zero", NewFloat(0.0), true, true, true, false, false, false, 0},
-		{"integer value", NewFloat(7.0), true, true, true, false, true, false, 1},
-		{"+inf", NewFloat(math.Inf(1)), false, false, false, false, true, false, 1},
-		{"-inf", NewFloat(math.Inf(-1)), false, false, false, false, false, true, -1},
-		{"NaN", NewFloat(math.NaN()), false, false, false, true, false, false, 0},
+		{"positive", values.NewFloat(3.14), false, true, true, false, true, false, 1},
+		{"negative", values.NewFloat(-2.5), false, true, true, false, false, true, -1},
+		{"zero", values.NewFloat(0.0), true, true, true, false, false, false, 0},
+		{"integer value", values.NewFloat(7.0), true, true, true, false, true, false, 1},
+		{"+inf", values.NewFloat(math.Inf(1)), false, false, false, false, true, false, 1},
+		{"-inf", values.NewFloat(math.Inf(-1)), false, false, false, false, false, true, -1},
+		{"NaN", values.NewFloat(math.NaN()), false, false, false, true, false, false, 0},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -133,29 +136,29 @@ func TestFloatPredicates(t *testing.T) {
 func TestFloatAbsNegate(t *testing.T) {
 	c := qt.New(t)
 
-	f := NewFloat(-3.5)
+	f := values.NewFloat(-3.5)
 	abs := f.Abs()
-	c.Assert(abs, SchemeEquals, NewFloat(3.5))
+	c.Assert(abs, valuestest.SchemeEquals, values.NewFloat(3.5))
 
 	neg := f.Negate()
-	c.Assert(neg, SchemeEquals, NewFloat(3.5))
+	c.Assert(neg, valuestest.SchemeEquals, values.NewFloat(3.5))
 }
 
 func TestFloatExactness(t *testing.T) {
 	c := qt.New(t)
 
-	f := NewFloat(2.5)
+	f := values.NewFloat(2.5)
 	exact := f.ToExact()
 	c.Assert(exact.IsExact(), qt.IsTrue)
 
 	inexact := f.ToInexact()
-	c.Assert(inexact, SchemeEquals, f)
+	c.Assert(inexact, valuestest.SchemeEquals, f)
 }
 
 func TestFloatHashCode(t *testing.T) {
 	c := qt.New(t)
-	f1 := NewFloat(3.14)
-	f2 := NewFloat(3.14)
+	f1 := values.NewFloat(3.14)
+	f2 := values.NewFloat(3.14)
 	c.Assert(f1.HashCode(), qt.Equals, f2.HashCode())
 }
 
@@ -164,20 +167,20 @@ func TestFloatCompare(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		a    *Float
-		b    Number
+		a    *values.Float
+		b    values.Number
 		want int
 	}{
-		{"float<float", NewFloat(1.0), NewFloat(2.0), -1},
-		{"float=float", NewFloat(5.0), NewFloat(5.0), 0},
-		{"float>float", NewFloat(9.0), NewFloat(3.0), 1},
-		{"float<int", NewFloat(1.0), NewInteger(2), -1},
-		{"float<bigint", NewFloat(1.0), NewBigIntegerFromInt64(2), -1},
-		{"float<bigfloat", NewFloat(1.0), NewBigFloatFromFloat64(2.0), -1},
-		{"float<rational", NewFloat(1.0), NewRational(3, 2), -1},
-		{"float<complex", NewFloat(1.0), NewComplexFromParts(2.0, 0.0), -1},
-		{"float=complex", NewFloat(2.0), NewComplexFromParts(2.0, 3.0), 0},
-		{"float<bigcomplex", NewFloat(1.0), NewBigComplex(NewBigIntegerFromInt64(2), NewBigIntegerFromInt64(0)), -1},
+		{"float<float", values.NewFloat(1.0), values.NewFloat(2.0), -1},
+		{"float=float", values.NewFloat(5.0), values.NewFloat(5.0), 0},
+		{"float>float", values.NewFloat(9.0), values.NewFloat(3.0), 1},
+		{"float<int", values.NewFloat(1.0), values.NewInteger(2), -1},
+		{"float<bigint", values.NewFloat(1.0), values.NewBigIntegerFromInt64(2), -1},
+		{"float<bigfloat", values.NewFloat(1.0), values.NewBigFloatFromFloat64(2.0), -1},
+		{"float<rational", values.NewFloat(1.0), values.NewRational(3, 2), -1},
+		{"float<complex", values.NewFloat(1.0), values.NewComplexFromParts(2.0, 0.0), -1},
+		{"float=complex", values.NewFloat(2.0), values.NewComplexFromParts(2.0, 3.0), 0},
+		{"float<bigcomplex", values.NewFloat(1.0), values.NewBigComplex(values.NewBigIntegerFromInt64(2), values.NewBigIntegerFromInt64(0)), -1},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -193,17 +196,17 @@ func TestComplexPredicates(t *testing.T) {
 
 	tcs := []struct {
 		name       string
-		val        *Complex
+		val        *values.Complex
 		isInteger  bool
 		isRational bool
 		isFinite   bool
 		isNaN      bool
 	}{
-		{"standard", NewComplexFromParts(1.0, 2.0), false, false, true, false},
-		{"real integer", NewComplexFromParts(5.0, 0.0), true, true, true, false},
-		{"with inf", NewComplexFromParts(math.Inf(1), 0.0), false, false, false, false},
-		{"with NaN real", NewComplexFromParts(math.NaN(), 0.0), false, false, false, true},
-		{"with NaN imag", NewComplexFromParts(0.0, math.NaN()), false, false, false, true},
+		{"standard", values.NewComplexFromParts(1.0, 2.0), false, false, true, false},
+		{"real integer", values.NewComplexFromParts(5.0, 0.0), true, true, true, false},
+		{"with inf", values.NewComplexFromParts(math.Inf(1), 0.0), false, false, false, false},
+		{"with NaN real", values.NewComplexFromParts(math.NaN(), 0.0), false, false, false, true},
+		{"with NaN imag", values.NewComplexFromParts(0.0, math.NaN()), false, false, false, true},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -218,34 +221,34 @@ func TestComplexPredicates(t *testing.T) {
 func TestComplexMethods(t *testing.T) {
 	c := qt.New(t)
 
-	z := NewComplexFromParts(3.0, 4.0)
+	z := values.NewComplexFromParts(3.0, 4.0)
 
 	neg := z.Negate()
-	negC := neg.(*Complex)
+	negC := neg.(*values.Complex)
 	c.Assert(real(negC.Value), qt.Equals, -3.0)
 	c.Assert(imag(negC.Value), qt.Equals, -4.0)
 
 	abs := z.Abs()
-	absF := abs.(*Float)
+	absF := abs.(*values.Float)
 	c.Assert(absF.Value, qt.Equals, 5.0)
 
 	realPart := z.RealPart()
-	c.Assert(realPart, SchemeEquals, NewFloat(3.0))
+	c.Assert(realPart, valuestest.SchemeEquals, values.NewFloat(3.0))
 
 	imagPart := z.ImagPart()
-	c.Assert(imagPart, SchemeEquals, NewFloat(4.0))
+	c.Assert(imagPart, valuestest.SchemeEquals, values.NewFloat(4.0))
 }
 
 func TestComplexExactness(t *testing.T) {
 	c := qt.New(t)
 
-	z := NewComplexFromParts(2.0, 3.0)
+	z := values.NewComplexFromParts(2.0, 3.0)
 
 	exact := z.ToExact()
 	c.Assert(exact.IsExact(), qt.IsTrue)
 
 	inexact := z.ToInexact()
-	c.Assert(inexact, SchemeEquals, z)
+	c.Assert(inexact, valuestest.SchemeEquals, z)
 }
 
 func TestComplexCompare(t *testing.T) {
@@ -253,18 +256,18 @@ func TestComplexCompare(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		a    *Complex
-		b    Number
+		a    *values.Complex
+		b    values.Number
 		want int
 	}{
-		{"complex<complex", NewComplexFromParts(1.0, 0.0), NewComplexFromParts(2.0, 0.0), -1},
-		{"complex=complex", NewComplexFromParts(5.0, 1.0), NewComplexFromParts(5.0, 2.0), 0},
-		{"complex<float", NewComplexFromParts(1.0, 0.0), NewFloat(2.0), -1},
-		{"complex<int", NewComplexFromParts(1.0, 0.0), NewInteger(2), -1},
-		{"complex<bigint", NewComplexFromParts(1.0, 0.0), NewBigIntegerFromInt64(2), -1},
-		{"complex<bigfloat", NewComplexFromParts(1.0, 0.0), NewBigFloatFromFloat64(2.0), -1},
-		{"complex<rational", NewComplexFromParts(1.0, 0.0), NewRational(3, 1), -1},
-		{"complex<bigcomplex", NewComplexFromParts(1.0, 0.0), NewBigComplex(NewBigIntegerFromInt64(2), NewBigIntegerFromInt64(0)), -1},
+		{"complex<complex", values.NewComplexFromParts(1.0, 0.0), values.NewComplexFromParts(2.0, 0.0), -1},
+		{"complex=complex", values.NewComplexFromParts(5.0, 1.0), values.NewComplexFromParts(5.0, 2.0), 0},
+		{"complex<float", values.NewComplexFromParts(1.0, 0.0), values.NewFloat(2.0), -1},
+		{"complex<int", values.NewComplexFromParts(1.0, 0.0), values.NewInteger(2), -1},
+		{"complex<bigint", values.NewComplexFromParts(1.0, 0.0), values.NewBigIntegerFromInt64(2), -1},
+		{"complex<bigfloat", values.NewComplexFromParts(1.0, 0.0), values.NewBigFloatFromFloat64(2.0), -1},
+		{"complex<rational", values.NewComplexFromParts(1.0, 0.0), values.NewRational(3, 1), -1},
+		{"complex<bigcomplex", values.NewComplexFromParts(1.0, 0.0), values.NewBigComplex(values.NewBigIntegerFromInt64(2), values.NewBigIntegerFromInt64(0)), -1},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -280,14 +283,14 @@ func TestRationalPredicates(t *testing.T) {
 
 	tcs := []struct {
 		name       string
-		val        *Rational
+		val        *values.Rational
 		isPositive bool
 		isNegative bool
 		sign       int
 	}{
-		{"positive", NewRational(3, 4), true, false, 1},
-		{"negative", NewRational(-1, 3), false, true, -1},
-		{"zero", NewRational(0, 1), false, false, 0},
+		{"positive", values.NewRational(3, 4), true, false, 1},
+		{"negative", values.NewRational(-1, 3), false, true, -1},
+		{"zero", values.NewRational(0, 1), false, false, 0},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -304,32 +307,32 @@ func TestRationalPredicates(t *testing.T) {
 func TestRationalAbsNegate(t *testing.T) {
 	c := qt.New(t)
 
-	r := NewRational(-3, 4)
+	r := values.NewRational(-3, 4)
 	abs := r.Abs()
-	c.Assert(abs.(*Rational).value.Sign(), qt.Equals, 1)
+	c.Assert(abs.(*values.Rational).Rat().Sign(), qt.Equals, 1)
 
 	neg := r.Negate()
-	c.Assert(neg.(*Rational).value.Sign(), qt.Equals, 1)
+	c.Assert(neg.(*values.Rational).Rat().Sign(), qt.Equals, 1)
 }
 
 func TestRationalExactness(t *testing.T) {
 	c := qt.New(t)
 
-	r := NewRational(1, 3)
+	r := values.NewRational(1, 3)
 	exact := r.ToExact()
-	c.Assert(exact, SchemeEquals, r)
+	c.Assert(exact, valuestest.SchemeEquals, r)
 
 	inexact := r.ToInexact()
 	// L18: ToInexact now returns BigFloat for precision
-	bf, ok := inexact.(*BigFloat)
+	bf, ok := inexact.(*values.BigFloat)
 	c.Assert(ok, qt.IsTrue)
 	c.Assert(bf.Float64() > 0.33, qt.IsTrue)
 }
 
 func TestRationalHashCode(t *testing.T) {
 	c := qt.New(t)
-	r1 := NewRational(1, 2)
-	r2 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(1, 2)
 	c.Assert(r1.HashCode(), qt.Equals, r2.HashCode())
 }
 
@@ -338,19 +341,19 @@ func TestRationalCompare(t *testing.T) {
 
 	tcs := []struct {
 		name string
-		a    *Rational
-		b    Number
+		a    *values.Rational
+		b    values.Number
 		want int
 	}{
-		{"rat<rat", NewRational(1, 4), NewRational(1, 2), -1},
-		{"rat=rat", NewRational(1, 2), NewRational(1, 2), 0},
-		{"rat>rat", NewRational(3, 4), NewRational(1, 4), 1},
-		{"rat<int", NewRational(1, 2), NewInteger(1), -1},
-		{"rat<bigint", NewRational(1, 2), NewBigIntegerFromInt64(1), -1},
-		{"rat<float", NewRational(1, 2), NewFloat(0.75), -1},
-		{"rat<bigfloat", NewRational(1, 2), NewBigFloatFromFloat64(0.75), -1},
-		{"rat<complex", NewRational(1, 2), NewComplexFromParts(1.0, 0.0), -1},
-		{"rat<bigcomplex", NewRational(1, 2), NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(0)), -1},
+		{"rat<rat", values.NewRational(1, 4), values.NewRational(1, 2), -1},
+		{"rat=rat", values.NewRational(1, 2), values.NewRational(1, 2), 0},
+		{"rat>rat", values.NewRational(3, 4), values.NewRational(1, 4), 1},
+		{"rat<int", values.NewRational(1, 2), values.NewInteger(1), -1},
+		{"rat<bigint", values.NewRational(1, 2), values.NewBigIntegerFromInt64(1), -1},
+		{"rat<float", values.NewRational(1, 2), values.NewFloat(0.75), -1},
+		{"rat<bigfloat", values.NewRational(1, 2), values.NewBigFloatFromFloat64(0.75), -1},
+		{"rat<complex", values.NewRational(1, 2), values.NewComplexFromParts(1.0, 0.0), -1},
+		{"rat<bigcomplex", values.NewRational(1, 2), values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(0)), -1},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -364,9 +367,9 @@ func TestRationalCompare(t *testing.T) {
 func TestBigIntegerPredicates(t *testing.T) {
 	c := qt.New(t)
 
-	pos := NewBigIntegerFromInt64(42)
-	neg := NewBigIntegerFromInt64(-7)
-	zero := NewBigIntegerFromInt64(0)
+	pos := values.NewBigIntegerFromInt64(42)
+	neg := values.NewBigIntegerFromInt64(-7)
+	zero := values.NewBigIntegerFromInt64(0)
 
 	c.Assert(pos.IsInteger(), qt.IsTrue)
 	c.Assert(pos.IsRational(), qt.IsTrue)
@@ -377,13 +380,13 @@ func TestBigIntegerPredicates(t *testing.T) {
 	c.Assert(zero.Sign(), qt.Equals, 0)
 
 	abs := neg.Abs()
-	c.Assert(abs.(*BigInteger).value.Int64(), qt.Equals, int64(7))
+	c.Assert(abs.(*values.BigInteger).BigInt().Int64(), qt.Equals, int64(7))
 }
 
 func TestBigIntegerHashCode(t *testing.T) {
 	c := qt.New(t)
-	b1 := NewBigIntegerFromInt64(999)
-	b2 := NewBigIntegerFromInt64(999)
+	b1 := values.NewBigIntegerFromInt64(999)
+	b2 := values.NewBigIntegerFromInt64(999)
 	c.Assert(b1.HashCode(), qt.Equals, b2.HashCode())
 }
 
@@ -392,9 +395,9 @@ func TestBigIntegerHashCode(t *testing.T) {
 func TestBigFloatPredicates(t *testing.T) {
 	c := qt.New(t)
 
-	pos := NewBigFloatFromFloat64(3.14)
-	neg := NewBigFloatFromFloat64(-2.5)
-	intVal := NewBigFloatFromFloat64(7.0)
+	pos := values.NewBigFloatFromFloat64(3.14)
+	neg := values.NewBigFloatFromFloat64(-2.5)
+	intVal := values.NewBigFloatFromFloat64(7.0)
 
 	c.Assert(pos.IsRational(), qt.IsTrue)
 	c.Assert(pos.IsFinite(), qt.IsTrue)
@@ -405,7 +408,7 @@ func TestBigFloatPredicates(t *testing.T) {
 	c.Assert(neg.Sign(), qt.Equals, -1)
 
 	abs := neg.Abs()
-	absF := abs.(*BigFloat)
+	absF := abs.(*values.BigFloat)
 	f, _ := absF.BigFloatValue().Float64()
 	c.Assert(f, qt.Equals, 2.5)
 }
@@ -415,7 +418,7 @@ func TestBigFloatPredicates(t *testing.T) {
 func TestBigComplexPredicates(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplex(NewBigIntegerFromInt64(3), NewBigIntegerFromInt64(4))
+	bc := values.NewBigComplex(values.NewBigIntegerFromInt64(3), values.NewBigIntegerFromInt64(4))
 
 	c.Assert(bc.IsFinite(), qt.IsTrue)
 	c.Assert(bc.IsNaN(), qt.IsFalse)
@@ -423,7 +426,7 @@ func TestBigComplexPredicates(t *testing.T) {
 	c.Assert(bc.IsRational(), qt.IsFalse)
 
 	// Real-only BigComplex
-	bcReal := NewBigComplex(NewBigIntegerFromInt64(5), NewBigIntegerFromInt64(0))
+	bcReal := values.NewBigComplex(values.NewBigIntegerFromInt64(5), values.NewBigIntegerFromInt64(0))
 	c.Assert(bcReal.IsInteger(), qt.IsTrue)
 	c.Assert(bcReal.IsRational(), qt.IsTrue)
 }
@@ -431,16 +434,16 @@ func TestBigComplexPredicates(t *testing.T) {
 func TestBigComplexParts(t *testing.T) {
 	c := qt.New(t)
 
-	bc := NewBigComplex(NewBigIntegerFromInt64(3), NewBigIntegerFromInt64(4))
+	bc := values.NewBigComplex(values.NewBigIntegerFromInt64(3), values.NewBigIntegerFromInt64(4))
 
 	realPart := bc.RealPart()
-	c.Assert(realPart, SchemeEquals, NewBigIntegerFromInt64(3))
+	c.Assert(realPart, valuestest.SchemeEquals, values.NewBigIntegerFromInt64(3))
 
 	imagPart := bc.ImagPart()
-	c.Assert(imagPart, SchemeEquals, NewBigIntegerFromInt64(4))
+	c.Assert(imagPart, valuestest.SchemeEquals, values.NewBigIntegerFromInt64(4))
 
 	abs := bc.Abs()
-	absF := abs.(*BigFloat)
+	absF := abs.(*values.BigFloat)
 	f, _ := absF.BigFloatValue().Float64()
 	c.Assert(f, qt.Equals, 5.0)
 }
@@ -451,19 +454,19 @@ func TestFloatToExactConversions(t *testing.T) {
 	c := qt.New(t)
 
 	// Float that is an integer -> BigInteger
-	intFloat := NewFloat(42.0)
+	intFloat := values.NewFloat(42.0)
 	exact := intFloat.ToExact()
-	_, isBigInt := exact.(*BigInteger)
+	_, isBigInt := exact.(*values.BigInteger)
 	c.Assert(isBigInt, qt.IsTrue)
 
 	// Float that is not an integer -> Rational
-	fracFloat := NewFloat(0.5)
+	fracFloat := values.NewFloat(0.5)
 	exactFrac := fracFloat.ToExact()
-	_, isRat := exactFrac.(*Rational)
+	_, isRat := exactFrac.(*values.Rational)
 	c.Assert(isRat, qt.IsTrue)
 
 	// Large float
-	largeFloat := NewFloat(1e18)
+	largeFloat := values.NewFloat(1e18)
 	exactLarge := largeFloat.ToExact()
 	c.Assert(exactLarge.IsExact(), qt.IsTrue)
 }
@@ -473,34 +476,34 @@ func TestNumericTowerUtilities(t *testing.T) {
 	c := qt.New(t)
 
 	// ExactnessOf
-	c.Assert(ExactnessOf(NewInteger(1)), qt.Equals, Exact)
-	c.Assert(ExactnessOf(NewFloat(1.0)), qt.Equals, Inexact)
-	c.Assert(ExactnessOf(NewRational(1, 2)), qt.Equals, Exact)
-	c.Assert(ExactnessOf(NewBigIntegerFromInt64(1)), qt.Equals, Exact)
-	c.Assert(ExactnessOf(NewBigFloatFromFloat64(1.0)), qt.Equals, Inexact)
-	c.Assert(ExactnessOf(NewComplexFromParts(1.0, 0.0)), qt.Equals, Inexact)
+	c.Assert(values.ExactnessOf(values.NewInteger(1)), qt.Equals, values.Exact)
+	c.Assert(values.ExactnessOf(values.NewFloat(1.0)), qt.Equals, values.Inexact)
+	c.Assert(values.ExactnessOf(values.NewRational(1, 2)), qt.Equals, values.Exact)
+	c.Assert(values.ExactnessOf(values.NewBigIntegerFromInt64(1)), qt.Equals, values.Exact)
+	c.Assert(values.ExactnessOf(values.NewBigFloatFromFloat64(1.0)), qt.Equals, values.Inexact)
+	c.Assert(values.ExactnessOf(values.NewComplexFromParts(1.0, 0.0)), qt.Equals, values.Inexact)
 
 	// Simplify
-	bigInt := NewBigIntegerFromInt64(42)
-	simplified := Simplify(bigInt)
-	_, isInt := simplified.(*Integer)
+	bigInt := values.NewBigIntegerFromInt64(42)
+	simplified := values.Simplify(bigInt)
+	_, isInt := simplified.(*values.Integer)
 	c.Assert(isInt, qt.IsTrue)
 
 	// Simplify a BigComplex with zero imaginary part
-	bc := NewBigComplex(NewBigIntegerFromInt64(5), NewBigIntegerFromInt64(0))
-	simplifiedBC := Simplify(bc)
-	_, isInt2 := simplifiedBC.(*Integer)
+	bc := values.NewBigComplex(values.NewBigIntegerFromInt64(5), values.NewBigIntegerFromInt64(0))
+	simplifiedBC := values.Simplify(bc)
+	_, isInt2 := simplifiedBC.(*values.Integer)
 	c.Assert(isInt2, qt.IsTrue)
 
 	// Simplify a BigFloat that is integer-valued
-	bf := NewBigFloat(new(big.Float).SetInt64(100))
-	simplifiedBF := Simplify(bf)
-	_, isInt3 := simplifiedBF.(*Integer)
+	bf := values.NewBigFloat(new(big.Float).SetInt64(100))
+	simplifiedBF := values.Simplify(bf)
+	_, isInt3 := simplifiedBF.(*values.Integer)
 	c.Assert(isInt3, qt.IsTrue)
 
 	// Simplify a Rational that is integer-valued
-	r := NewRational(6, 2)
-	simplifiedR := Simplify(r)
-	_, isInt4 := simplifiedR.(*Integer)
+	r := values.NewRational(6, 2)
+	simplifiedR := values.Simplify(r)
+	_, isInt4 := simplifiedR.(*values.Integer)
 	c.Assert(isInt4, qt.IsTrue)
 }

--- a/values/numeric_tower_coverage_test.go
+++ b/values/numeric_tower_coverage_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"fmt"
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // NumericTowerCoverageTest tests all 245 type combinations (7 types × 7 operands × 5 operations)
@@ -33,32 +35,32 @@ import (
 // testNumber holds a test value and its type name
 type testNumber struct {
 	name  string
-	value Number
+	value values.Number
 }
 
 // makeTestNumbers creates one test value of each numeric type
 func makeTestNumbers() []testNumber {
 	return []testNumber{
-		{"Integer", NewInteger(5)},
-		{"BigInteger", NewBigIntegerFromInt64(5)},
-		{"Float", NewFloat(5.0)},
-		{"BigFloat", NewBigFloatFromFloat64(5.0)},
-		{"Rational", NewRational(5, 1)},
-		{"Complex", NewComplex(complex(5, 0))},
-		{"BigComplex", NewBigComplexFromBigFloats(NewBigFloatFromFloat64(5), NewBigFloatFromFloat64(0))},
+		{"Integer", values.NewInteger(5)},
+		{"BigInteger", values.NewBigIntegerFromInt64(5)},
+		{"Float", values.NewFloat(5.0)},
+		{"BigFloat", values.NewBigFloatFromFloat64(5.0)},
+		{"Rational", values.NewRational(5, 1)},
+		{"Complex", values.NewComplex(complex(5, 0))},
+		{"BigComplex", values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(5), values.NewBigFloatFromFloat64(0))},
 	}
 }
 
 // makeTestZeros creates zero values of each numeric type for division-by-zero testing
 func makeTestZeros() []testNumber {
 	return []testNumber{
-		{"Integer", NewInteger(0)},
-		{"BigInteger", NewBigIntegerFromInt64(0)},
-		{"Float", NewFloat(0.0)},
-		{"BigFloat", NewBigFloatFromFloat64(0.0)},
-		{"Rational", NewRational(0, 1)},
-		{"Complex", NewComplex(complex(0, 0))},
-		{"BigComplex", NewBigComplexFromBigFloats(NewBigFloatFromFloat64(0), NewBigFloatFromFloat64(0))},
+		{"Integer", values.NewInteger(0)},
+		{"BigInteger", values.NewBigIntegerFromInt64(0)},
+		{"Float", values.NewFloat(0.0)},
+		{"BigFloat", values.NewBigFloatFromFloat64(0.0)},
+		{"Rational", values.NewRational(0, 1)},
+		{"Complex", values.NewComplex(complex(0, 0))},
+		{"BigComplex", values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(0), values.NewBigFloatFromFloat64(0))},
 	}
 }
 
@@ -71,7 +73,7 @@ type operationResult struct {
 }
 
 // tryOperation safely executes an operation and captures the result
-func tryOperation(op func() Number) (result operationResult) {
+func tryOperation(op func() values.Number) (result operationResult) {
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -99,7 +101,7 @@ func TestNumericTower_Add(t *testing.T) {
 		for _, operand := range numbers {
 			name := fmt.Sprintf("%s+%s", receiver.name, operand.name)
 			t.Run(name, func(t *testing.T) {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return receiver.value.Add(operand.value)
 				})
 
@@ -127,7 +129,7 @@ func TestNumericTower_Subtract(t *testing.T) {
 		for _, operand := range numbers {
 			name := fmt.Sprintf("%s-%s", receiver.name, operand.name)
 			t.Run(name, func(t *testing.T) {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return receiver.value.Subtract(operand.value)
 				})
 
@@ -154,7 +156,7 @@ func TestNumericTower_Multiply(t *testing.T) {
 		for _, operand := range numbers {
 			name := fmt.Sprintf("%s*%s", receiver.name, operand.name)
 			t.Run(name, func(t *testing.T) {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return receiver.value.Multiply(operand.value)
 				})
 
@@ -181,7 +183,7 @@ func TestNumericTower_Divide(t *testing.T) {
 		for _, operand := range numbers {
 			name := fmt.Sprintf("%s/%s", receiver.name, operand.name)
 			t.Run(name, func(t *testing.T) {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return receiver.value.Divide(operand.value)
 				})
 
@@ -241,7 +243,7 @@ func TestNumericTower_DivideByZero(t *testing.T) {
 		for _, zero := range zeros {
 			name := fmt.Sprintf("%s/zero_%s", receiver.name, zero.name)
 			t.Run(name, func(t *testing.T) {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return receiver.value.Divide(zero.value)
 				})
 
@@ -274,22 +276,22 @@ func TestNumericTower_ResultTypes(t *testing.T) {
 
 	// Create test values for receivers (a)
 	// Using different values for receiver and operand to avoid simplification
-	integerA := NewInteger(2)
-	bigIntegerA := NewBigIntegerFromInt64(3)
-	rationalA := NewRational(5, 2)
-	floatA := NewFloat(2.5)
-	bigFloatA := NewBigFloatFromFloat64(3.5)
-	complexA := NewComplexFromParts(2.0, 1.0)
-	bigComplexA := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(2), NewBigFloatFromFloat64(1))
+	integerA := values.NewInteger(2)
+	bigIntegerA := values.NewBigIntegerFromInt64(3)
+	rationalA := values.NewRational(5, 2)
+	floatA := values.NewFloat(2.5)
+	bigFloatA := values.NewBigFloatFromFloat64(3.5)
+	complexA := values.NewComplexFromParts(2.0, 1.0)
+	bigComplexA := values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(2), values.NewBigFloatFromFloat64(1))
 
 	// Create test values for operands (b) - different values to avoid simplification
-	integerB := NewInteger(7)
-	bigIntegerB := NewBigIntegerFromInt64(11)
-	rationalB := NewRational(3, 4)
-	floatB := NewFloat(1.5)
-	bigFloatB := NewBigFloatFromFloat64(2.5)
-	complexB := NewComplexFromParts(3.0, 2.0)
-	bigComplexB := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(5), NewBigFloatFromFloat64(3))
+	integerB := values.NewInteger(7)
+	bigIntegerB := values.NewBigIntegerFromInt64(11)
+	rationalB := values.NewRational(3, 4)
+	floatB := values.NewFloat(1.5)
+	bigFloatB := values.NewBigFloatFromFloat64(2.5)
+	complexB := values.NewComplexFromParts(3.0, 2.0)
+	bigComplexB := values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(5), values.NewBigFloatFromFloat64(3))
 
 	// Expected result types for addition (same pattern for subtraction and multiplication)
 	// Format: "ReceiverType+OperandType" -> "ExpectedResultType"
@@ -354,7 +356,7 @@ func TestNumericTower_ResultTypes(t *testing.T) {
 
 	receivers := []struct {
 		name  string
-		value Number
+		value values.Number
 	}{
 		{"Integer", integerA},
 		{"BigInteger", bigIntegerA},
@@ -367,7 +369,7 @@ func TestNumericTower_ResultTypes(t *testing.T) {
 
 	operands := []struct {
 		name  string
-		value Number
+		value values.Number
 	}{
 		{"Integer", integerB},
 		{"BigInteger", bigIntegerB},
@@ -429,22 +431,22 @@ func TestNumericTower_DivisionResultTypes(t *testing.T) {
 	c := qt.New(t)
 
 	// Receivers (a) - numerators
-	integerA := NewInteger(5)
-	bigIntegerA := NewBigIntegerFromInt64(7)
-	rationalA := NewRational(5, 2)
-	floatA := NewFloat(2.5)
-	bigFloatA := NewBigFloatFromFloat64(3.5)
-	complexA := NewComplexFromParts(2.0, 1.0)
-	bigComplexA := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(2), NewBigFloatFromFloat64(1))
+	integerA := values.NewInteger(5)
+	bigIntegerA := values.NewBigIntegerFromInt64(7)
+	rationalA := values.NewRational(5, 2)
+	floatA := values.NewFloat(2.5)
+	bigFloatA := values.NewBigFloatFromFloat64(3.5)
+	complexA := values.NewComplexFromParts(2.0, 1.0)
+	bigComplexA := values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(2), values.NewBigFloatFromFloat64(1))
 
 	// Operands (b) - denominators that won't divide evenly into receivers
-	integerB := NewInteger(3)
-	bigIntegerB := NewBigIntegerFromInt64(11)
-	rationalB := NewRational(3, 4)
-	floatB := NewFloat(1.5)
-	bigFloatB := NewBigFloatFromFloat64(2.5)
-	complexB := NewComplexFromParts(3.0, 2.0)
-	bigComplexB := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(5), NewBigFloatFromFloat64(3))
+	integerB := values.NewInteger(3)
+	bigIntegerB := values.NewBigIntegerFromInt64(11)
+	rationalB := values.NewRational(3, 4)
+	floatB := values.NewFloat(1.5)
+	bigFloatB := values.NewBigFloatFromFloat64(2.5)
+	complexB := values.NewComplexFromParts(3.0, 2.0)
+	bigComplexB := values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(5), values.NewBigFloatFromFloat64(3))
 
 	// Division result types
 	// Note: Integer/Integer returns Rational when not exact (5/3), Integer when exact (6/2)
@@ -509,7 +511,7 @@ func TestNumericTower_DivisionResultTypes(t *testing.T) {
 
 	receivers := []struct {
 		name  string
-		value Number
+		value values.Number
 	}{
 		{"Integer", integerA},
 		{"BigInteger", bigIntegerA},
@@ -522,7 +524,7 @@ func TestNumericTower_DivisionResultTypes(t *testing.T) {
 
 	operands := []struct {
 		name  string
-		value Number
+		value values.Number
 	}{
 		{"Integer", integerB},
 		{"BigInteger", bigIntegerB},
@@ -553,16 +555,16 @@ func TestNumericTower_ExactnessPreservation(t *testing.T) {
 	c := qt.New(t)
 
 	// Exact types
-	exactInt := NewInteger(3)
-	exactBigInt := NewBigIntegerFromInt64(5)
-	exactRational := NewRational(1, 2)
-	exactBigComplex := NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2))
+	exactInt := values.NewInteger(3)
+	exactBigInt := values.NewBigIntegerFromInt64(5)
+	exactRational := values.NewRational(1, 2)
+	exactBigComplex := values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2))
 
 	// Inexact types
-	inexactFloat := NewFloat(3.0)
-	inexactBigFloat := NewBigFloatFromFloat64(5.0)
-	inexactComplex := NewComplexFromParts(1.0, 2.0)
-	inexactBigComplex := NewBigComplexFromBigFloats(NewBigFloatFromFloat64(1), NewBigFloatFromFloat64(2))
+	inexactFloat := values.NewFloat(3.0)
+	inexactBigFloat := values.NewBigFloatFromFloat64(5.0)
+	inexactComplex := values.NewComplexFromParts(1.0, 2.0)
+	inexactBigComplex := values.NewBigComplexFromBigFloats(values.NewBigFloatFromFloat64(1), values.NewBigFloatFromFloat64(2))
 
 	// Test exact + exact = exact
 	t.Run("exact+exact=exact", func(t *testing.T) {
@@ -642,29 +644,29 @@ func TestNumericTower_ExactComplexArithmetic(t *testing.T) {
 	c := qt.New(t)
 
 	// Create exact complex: 3+4i using BigComplex with BigInteger parts
-	exactComplex := NewBigComplex(NewBigIntegerFromInt64(3), NewBigIntegerFromInt64(4))
+	exactComplex := values.NewBigComplex(values.NewBigIntegerFromInt64(3), values.NewBigIntegerFromInt64(4))
 	c.Assert(exactComplex.IsExact(), qt.IsTrue, qt.Commentf("3+4i should be exact"))
 
 	// exact complex + exact integer = exact complex
 	t.Run("exact_complex+integer", func(t *testing.T) {
-		result := exactComplex.Add(NewInteger(5))
+		result := exactComplex.Add(values.NewInteger(5))
 		c.Assert(result.IsExact(), qt.IsTrue)
 		// Result should be 8+4i
-		bc, ok := result.(*BigComplex)
+		bc, ok := result.(*values.BigComplex)
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(8))
-		c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(4))
+		c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(8))
+		c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(4))
 	})
 
 	// exact complex + exact rational = exact complex
 	t.Run("exact_complex+rational", func(t *testing.T) {
-		result := exactComplex.Add(NewRational(1, 2))
+		result := exactComplex.Add(values.NewRational(1, 2))
 		c.Assert(result.IsExact(), qt.IsTrue)
 		// Result should be 7/2+4i (3.5+4i as exact)
-		bc, ok := result.(*BigComplex)
+		bc, ok := result.(*values.BigComplex)
 		c.Assert(ok, qt.IsTrue)
 		// Real part should be Rational 7/2
-		rat, ok := bc.Real().(*Rational)
+		rat, ok := bc.Real().(*values.Rational)
 		c.Assert(ok, qt.IsTrue)
 		c.Assert(rat.Num().Int64(), qt.Equals, int64(7))
 		c.Assert(rat.Denom().Int64(), qt.Equals, int64(2))
@@ -673,18 +675,18 @@ func TestNumericTower_ExactComplexArithmetic(t *testing.T) {
 	// exact complex * exact complex = exact complex
 	t.Run("exact_complex*exact_complex", func(t *testing.T) {
 		// (3+4i) * (1+2i) = 3 + 6i + 4i + 8i² = 3 + 10i - 8 = -5 + 10i
-		other := NewBigComplex(NewBigIntegerFromInt64(1), NewBigIntegerFromInt64(2))
+		other := values.NewBigComplex(values.NewBigIntegerFromInt64(1), values.NewBigIntegerFromInt64(2))
 		result := exactComplex.Multiply(other)
 		c.Assert(result.IsExact(), qt.IsTrue)
-		bc, ok := result.(*BigComplex)
+		bc, ok := result.(*values.BigComplex)
 		c.Assert(ok, qt.IsTrue)
-		c.Assert(bc.Real().(*BigInteger).Int64(), qt.Equals, int64(-5))
-		c.Assert(bc.Imag().(*BigInteger).Int64(), qt.Equals, int64(10))
+		c.Assert(bc.Real().(*values.BigInteger).Int64(), qt.Equals, int64(-5))
+		c.Assert(bc.Imag().(*values.BigInteger).Int64(), qt.Equals, int64(10))
 	})
 
 	// exact complex + inexact float = inexact
 	t.Run("exact_complex+float=inexact", func(t *testing.T) {
-		result := exactComplex.Add(NewFloat(1.5))
+		result := exactComplex.Add(values.NewFloat(1.5))
 		c.Assert(result.IsExact(), qt.IsFalse)
 	})
 }
@@ -698,12 +700,12 @@ func TestNumericTower_CoverageMatrix(t *testing.T) {
 	numbers := makeTestNumbers()
 	operations := []struct {
 		name string
-		op   func(a, b Number) Number
+		op   func(a, b values.Number) values.Number
 	}{
-		{"Add", func(a, b Number) Number { return a.Add(b) }},
-		{"Sub", func(a, b Number) Number { return a.Subtract(b) }},
-		{"Mul", func(a, b Number) Number { return a.Multiply(b) }},
-		{"Div", func(a, b Number) Number { return a.Divide(b) }},
+		{"Add", func(a, b values.Number) values.Number { return a.Add(b) }},
+		{"Sub", func(a, b values.Number) values.Number { return a.Subtract(b) }},
+		{"Mul", func(a, b values.Number) values.Number { return a.Multiply(b) }},
+		{"Div", func(a, b values.Number) values.Number { return a.Divide(b) }},
 	}
 
 	for _, op := range operations {
@@ -719,7 +721,7 @@ func TestNumericTower_CoverageMatrix(t *testing.T) {
 			var row strings.Builder
 			row.WriteString(receiver.name[:3])
 			for _, operand := range numbers {
-				result := tryOperation(func() Number {
+				result := tryOperation(func() values.Number {
 					return op.op(receiver.value, operand.value)
 				})
 				switch {

--- a/values/pair_test.go
+++ b/values/pair_test.go
@@ -12,25 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestPair_SchemeString(t *testing.T) {
 	tcs := []struct {
-		in  *Pair
+		in  *values.Pair
 		out string
 	}{
 		{nil, "#<void>"},
-		{NewCons(nil, nil), "(#<void> . #<void>)"},
-		{NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList)), "(1 2)"},
-		{NewCons(NewInteger(1), NewCons(NewInteger(2), NewCons(NewInteger(3), EmptyList))), "(1 2 3)"},
-		{NewCons(NewCons(NewInteger(1), NewInteger(2)), EmptyList), "((1 . 2))"},
-		{NewCons(NewCons(NewInteger(1), (*Pair)(nil)), EmptyList), "((1 . #<void>))"},
+		{values.NewCons(nil, nil), "(#<void> . #<void>)"},
+		{values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList)), "(1 2)"},
+		{values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.NewCons(values.NewInteger(3), values.EmptyList))), "(1 2 3)"},
+		{values.NewCons(values.NewCons(values.NewInteger(1), values.NewInteger(2)), values.EmptyList), "((1 . 2))"},
+		{values.NewCons(values.NewCons(values.NewInteger(1), (*values.Pair)(nil)), values.EmptyList), "((1 . #<void>))"},
 	}
 
 	for _, tc := range tcs {
@@ -42,98 +45,98 @@ func TestPair_SchemeString(t *testing.T) {
 func TestPair_EqualTo(t *testing.T) {
 	tcs := []struct {
 		nm  string
-		in0 *Pair
-		in1 Value
+		in0 *values.Pair
+		in1 values.Value
 		out bool
 	}{
 		{
 			nm:  "1",
-			in0: (*Pair)(nil),
-			in1: (*Pair)(nil),
+			in0: (*values.Pair)(nil),
+			in1: (*values.Pair)(nil),
 			out: true,
 		},
 		{
 			nm:  "3",
-			in0: &Pair{nil, nil},
-			in1: &Pair{nil, nil},
+			in0: &values.Pair{nil, nil},
+			in1: &values.Pair{nil, nil},
 			out: true,
 		},
 		{
 			nm:  "5",
-			in0: (*Pair)(nil),
-			in1: (*Pair)(nil),
+			in0: (*values.Pair)(nil),
+			in1: (*values.Pair)(nil),
 			out: true,
 		},
 		{
 			nm:  "6",
-			in0: NewCons(NewInteger(10), EmptyList),
-			in1: NewCons(NewInteger(10), EmptyList),
+			in0: values.NewCons(values.NewInteger(10), values.EmptyList),
+			in1: values.NewCons(values.NewInteger(10), values.EmptyList),
 			out: true,
 		},
 		{
 			nm:  "7",
-			in0: NewCons(NewInteger(10), (*Pair)(nil)),
-			in1: NewCons(NewInteger(10), Value(nil)),
+			in0: values.NewCons(values.NewInteger(10), (*values.Pair)(nil)),
+			in1: values.NewCons(values.NewInteger(10), values.Value(nil)),
 			out: true,
 		},
 		{
 			nm:  "8",
-			in0: NewCons(NewInteger(10), (*Pair)(nil)),
-			in1: NewCons(NewInteger(10), Void),
+			in0: values.NewCons(values.NewInteger(10), (*values.Pair)(nil)),
+			in1: values.NewCons(values.NewInteger(10), values.Void),
 			out: true,
 		},
 		{
 			nm:  "9",
-			in0: NewCons(NewCons(NewInteger(10), EmptyList), EmptyList),
-			in1: NewCons(NewCons(NewInteger(10), EmptyList), EmptyList),
+			in0: values.NewCons(values.NewCons(values.NewInteger(10), values.EmptyList), values.EmptyList),
+			in1: values.NewCons(values.NewCons(values.NewInteger(10), values.EmptyList), values.EmptyList),
 			out: true,
 		},
 		{
 			nm:  "10",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
 			out: true,
 		},
 		{
 			nm:  "11",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(30), EmptyList)),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(30), values.EmptyList)),
 			out: false,
 		},
 		{
 			nm:  "12",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(30), EmptyList)),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(30), values.EmptyList)),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
 			out: false,
 		},
 		{
 			nm:  "13",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 			out: true,
 		},
 		{
 			nm:  "14",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
 			out: false,
 		},
 		{
 			nm:  "15",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 			out: false,
 		},
 		{
 			nm:  "16",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), Void)),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.Void)),
 			out: false,
 		},
 		{
 			nm:  "17",
-			in0: NewCons(NewInteger(10), NewCons(NewInteger(20), Void)),
-			in1: NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in0: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.Void)),
+			in1: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 			out: false,
 		},
 	}
@@ -146,27 +149,27 @@ func TestPair_EqualTo(t *testing.T) {
 }
 
 func TestEmptyList_EqualTo(t *testing.T) {
-	qt.Assert(t, EmptyList.EqualTo(EmptyList), qt.IsTrue)
-	qt.Assert(t, EqualTo(EmptyList, EmptyList), qt.IsTrue)
-	qt.Assert(t, EmptyList.EqualTo(NewCons(NewInteger(1), EmptyList)), qt.IsFalse)
+	qt.Assert(t, values.EmptyList.EqualTo(values.EmptyList), qt.IsTrue)
+	qt.Assert(t, values.EqualTo(values.EmptyList, values.EmptyList), qt.IsTrue)
+	qt.Assert(t, values.EmptyList.EqualTo(values.NewCons(values.NewInteger(1), values.EmptyList)), qt.IsFalse)
 }
 
 func TestPair_NewCons(t *testing.T) {
-	pr := NewCons(nil, nil)
+	pr := values.NewCons(nil, nil)
 	qt.Assert(t, pr, qt.Not(qt.IsNil))
 }
 
 func TestPair_IsList(t *testing.T) {
 	tcs := []struct {
-		in  *Pair
+		in  *values.Pair
 		out bool
 	}{
 		{in: nil, out: false},
-		{in: NewCons(NewInteger(10), EmptyList), out: true},
-		{in: NewCons(NewCons(NewInteger(10), EmptyList), EmptyList), out: true},
-		{in: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)), out: true},
+		{in: values.NewCons(values.NewInteger(10), values.EmptyList), out: true},
+		{in: values.NewCons(values.NewCons(values.NewInteger(10), values.EmptyList), values.EmptyList), out: true},
+		{in: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)), out: true},
 		{
-			in:  NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in:  values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 			out: false,
 		},
 	}
@@ -179,7 +182,7 @@ func TestPair_IsList(t *testing.T) {
 }
 
 func TestEmptyList_IsList(t *testing.T) {
-	qt.Assert(t, EmptyList.IsList(), qt.IsTrue)
+	qt.Assert(t, values.EmptyList.IsList(), qt.IsTrue)
 }
 
 func TestPair_IsList_Circular(t *testing.T) {
@@ -188,15 +191,15 @@ func TestPair_IsList_Circular(t *testing.T) {
 
 	t.Run("self-referential", func(t *testing.T) {
 		// (set-cdr! x x) - cdr points to self
-		p := NewCons(NewSymbol("a"), EmptyList)
+		p := values.NewCons(values.NewSymbol("a"), values.EmptyList)
 		p.SetCdr(p)
 		qt.Assert(t, p.IsList(), qt.Equals, false)
 	})
 
 	t.Run("cycle after one element", func(t *testing.T) {
 		// (a . #0=(b . #0#))
-		p1 := NewCons(NewSymbol("a"), EmptyList)
-		p2 := NewCons(NewSymbol("b"), EmptyList)
+		p1 := values.NewCons(values.NewSymbol("a"), values.EmptyList)
+		p2 := values.NewCons(values.NewSymbol("b"), values.EmptyList)
 		p1.SetCdr(p2)
 		p2.SetCdr(p2) // p2 points to itself
 		qt.Assert(t, p1.IsList(), qt.Equals, false)
@@ -204,8 +207,8 @@ func TestPair_IsList_Circular(t *testing.T) {
 
 	t.Run("cycle back to start", func(t *testing.T) {
 		// #0=(a b . #0#)
-		p1 := NewCons(NewSymbol("a"), EmptyList)
-		p2 := NewCons(NewSymbol("b"), EmptyList)
+		p1 := values.NewCons(values.NewSymbol("a"), values.EmptyList)
+		p2 := values.NewCons(values.NewSymbol("b"), values.EmptyList)
 		p1.SetCdr(p2)
 		p2.SetCdr(p1) // cycle back to start
 		qt.Assert(t, p1.IsList(), qt.Equals, false)
@@ -213,9 +216,9 @@ func TestPair_IsList_Circular(t *testing.T) {
 
 	t.Run("longer cycle", func(t *testing.T) {
 		// (a b c d . #0=(e f . #0#))
-		cells := make([]*Pair, 6)
+		cells := make([]*values.Pair, 6)
 		for i := range cells {
-			cells[i] = NewCons(NewInteger(int64(i)), EmptyList)
+			cells[i] = values.NewCons(values.NewInteger(int64(i)), values.EmptyList)
 		}
 		for i := range 5 {
 			cells[i].SetCdr(cells[i+1])
@@ -227,7 +230,7 @@ func TestPair_IsList_Circular(t *testing.T) {
 
 func TestPair_Length(t *testing.T) {
 	tcs := []struct {
-		in           *Pair
+		in           *values.Pair
 		out          int
 		panicMatches string
 	}{
@@ -236,11 +239,11 @@ func TestPair_Length(t *testing.T) {
 			panicMatches: "not a list",
 			out:          -1,
 		},
-		{in: NewCons(NewInteger(10), EmptyList), out: 1},
-		{in: NewCons(NewCons(NewInteger(10), EmptyList), EmptyList), out: 1},
-		{in: NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)), out: 2},
+		{in: values.NewCons(values.NewInteger(10), values.EmptyList), out: 1},
+		{in: values.NewCons(values.NewCons(values.NewInteger(10), values.EmptyList), values.EmptyList), out: 1},
+		{in: values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)), out: 2},
 		{
-			in:           NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in:           values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 			panicMatches: "not a list",
 			out:          -1,
 		},
@@ -258,60 +261,60 @@ func TestPair_Length(t *testing.T) {
 }
 
 func TestEmptyList_Length(t *testing.T) {
-	qt.Assert(t, EmptyList.Length(), qt.Equals, 0)
+	qt.Assert(t, values.EmptyList.Length(), qt.Equals, 0)
 }
 
 func TestPair_IsVoid(t *testing.T) {
-	qt.Assert(t, (*Pair)(nil).IsVoid(), qt.IsTrue)
-	qt.Assert(t, NewCons(NewInteger(1), EmptyList).IsVoid(), qt.IsFalse)
+	qt.Assert(t, (*values.Pair)(nil).IsVoid(), qt.IsTrue)
+	qt.Assert(t, values.NewCons(values.NewInteger(1), values.EmptyList).IsVoid(), qt.IsFalse)
 }
 
 func TestPair_IsEmptyList(t *testing.T) {
 	// *Pair.IsEmptyList() always returns false now that EmptyList is a separate type
-	qt.Assert(t, (*Pair)(nil).IsEmptyList(), qt.IsFalse)
-	qt.Assert(t, NewCons(NewInteger(1), EmptyList).IsEmptyList(), qt.IsFalse)
+	qt.Assert(t, (*values.Pair)(nil).IsEmptyList(), qt.IsFalse)
+	qt.Assert(t, values.NewCons(values.NewInteger(1), values.EmptyList).IsEmptyList(), qt.IsFalse)
 }
 
 func TestEmptyList_IsVoidAndIsEmptyList(t *testing.T) {
-	qt.Assert(t, EmptyList.IsEmptyList(), qt.IsTrue)
-	qt.Assert(t, EmptyList.IsVoid(), qt.IsFalse)
-	qt.Assert(t, IsEmptyList(EmptyList), qt.IsTrue)
-	qt.Assert(t, IsVoid(EmptyList), qt.IsFalse)
+	qt.Assert(t, values.EmptyList.IsEmptyList(), qt.IsTrue)
+	qt.Assert(t, values.EmptyList.IsVoid(), qt.IsFalse)
+	qt.Assert(t, values.IsEmptyList(values.EmptyList), qt.IsTrue)
+	qt.Assert(t, values.IsVoid(values.EmptyList), qt.IsFalse)
 }
 
 func TestEmptyList_AsVector(t *testing.T) {
-	got := EmptyList.AsVector()
+	got := values.EmptyList.AsVector()
 	qt.Assert(t, got, qt.Not(qt.IsNil))
 	qt.Assert(t, len(got.Datum()), qt.Equals, 0)
 }
 
 func TestEmptyList_Append(t *testing.T) {
 	// Appending to empty list returns the argument
-	got := EmptyList.Append(NewCons(NewInteger(10), EmptyList))
-	qt.Assert(t, got, SchemeEquals, NewCons(NewInteger(10), EmptyList))
+	got := values.EmptyList.Append(values.NewCons(values.NewInteger(10), values.EmptyList))
+	qt.Assert(t, got, valuestest.SchemeEquals, values.NewCons(values.NewInteger(10), values.EmptyList))
 
 	// Appending nil/void returns it
-	got = EmptyList.Append((*Pair)(nil))
-	qt.Assert(t, got, qt.Equals, Value((*Pair)(nil)))
+	got = values.EmptyList.Append((*values.Pair)(nil))
+	qt.Assert(t, got, qt.Equals, values.Value((*values.Pair)(nil)))
 }
 
 func TestEmptyList_SchemeString(t *testing.T) {
-	qt.Assert(t, EmptyList.SchemeString(), qt.Equals, "()")
+	qt.Assert(t, values.EmptyList.SchemeString(), qt.Equals, "()")
 }
 
 func TestEmptyList_Car_Panics(t *testing.T) {
-	qt.Assert(t, func() { EmptyList.Car() }, qt.PanicMatches, "not a pair")
+	qt.Assert(t, func() { values.EmptyList.Car() }, qt.PanicMatches, "not a pair")
 }
 
 func TestEmptyList_Cdr_Panics(t *testing.T) {
-	qt.Assert(t, func() { EmptyList.Cdr() }, qt.PanicMatches, "not a pair")
+	qt.Assert(t, func() { values.EmptyList.Cdr() }, qt.PanicMatches, "not a pair")
 }
 
 func TestPair_AsVector(t *testing.T) {
 	tcs := []struct {
 		name         string
-		in           *Pair
-		out          *Vector
+		in           *values.Pair
+		out          *values.Vector
 		panicMatches string
 	}{
 		{
@@ -321,42 +324,42 @@ func TestPair_AsVector(t *testing.T) {
 		},
 		{
 			name:         "void pair panics",
-			in:           NewCons(nil, nil),
+			in:           values.NewCons(nil, nil),
 			panicMatches: "not a list",
 		},
 		{
 			name: "single element list",
-			in:   NewCons(NewInteger(10), EmptyList),
-			out:  NewVector(NewInteger(10)),
+			in:   values.NewCons(values.NewInteger(10), values.EmptyList),
+			out:  values.NewVector(values.NewInteger(10)),
 		},
 		{
 			name: "two element list",
-			in:   NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
-			out:  NewVector(NewInteger(10), NewInteger(20)),
+			in:   values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
+			out:  values.NewVector(values.NewInteger(10), values.NewInteger(20)),
 		},
 		{
 			name: "three element list",
-			in:   NewCons(NewInteger(1), NewCons(NewInteger(2), NewCons(NewInteger(3), EmptyList))),
-			out:  NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:   values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.NewCons(values.NewInteger(3), values.EmptyList))),
+			out:  values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 		},
 		{
 			name: "nested list as element",
-			in:   NewCons(NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList)), EmptyList),
-			out:  NewVector(NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList))),
+			in:   values.NewCons(values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList)), values.EmptyList),
+			out:  values.NewVector(values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList))),
 		},
 		{
 			name: "mixed types",
-			in:   NewCons(NewInteger(1), NewCons(NewString("hello"), NewCons(TrueValue, EmptyList))),
-			out:  NewVector(NewInteger(1), NewString("hello"), TrueValue),
+			in:   values.NewCons(values.NewInteger(1), values.NewCons(values.NewString("hello"), values.NewCons(values.TrueValue, values.EmptyList))),
+			out:  values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 		},
 		{
 			name:         "improper list panics",
-			in:           NewCons(NewInteger(1), NewInteger(2)),
+			in:           values.NewCons(values.NewInteger(1), values.NewInteger(2)),
 			panicMatches: "not a list",
 		},
 		{
 			name:         "improper list with multiple elements panics",
-			in:           NewCons(NewInteger(1), NewCons(NewInteger(2), NewInteger(3))),
+			in:           values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.NewInteger(3))),
 			panicMatches: "not a list",
 		},
 	}
@@ -369,7 +372,7 @@ func TestPair_AsVector(t *testing.T) {
 				if tc.out == nil {
 					qt.Assert(t, got, qt.IsNil)
 				} else {
-					qt.Assert(t, got, SchemeEquals, tc.out)
+					qt.Assert(t, got, valuestest.SchemeEquals, tc.out)
 				}
 			}
 		})
@@ -379,70 +382,70 @@ func TestPair_AsVector(t *testing.T) {
 func TestPair_Append(t *testing.T) {
 	tcs := []struct {
 		name         string
-		in           *Pair
-		vs           Value
-		out          Value
+		in           *values.Pair
+		vs           values.Value
+		out          values.Value
 		panicMatches string
 	}{
 		{
 			name:         "nil input",
-			in:           (*Pair)(nil),
-			vs:           (*Pair)(nil),
-			out:          (*Pair)(nil),
+			in:           (*values.Pair)(nil),
+			vs:           (*values.Pair)(nil),
+			out:          (*values.Pair)(nil),
 			panicMatches: "not a list",
 		},
 		{
 			name:         "void pair input",
-			in:           NewCons(nil, nil),
-			vs:           (*Pair)(nil),
+			in:           values.NewCons(nil, nil),
+			vs:           (*values.Pair)(nil),
 			panicMatches: "not a list",
 		},
 		{
 			name: "empty vs with nil",
-			in:   NewCons(NewInteger(10), EmptyList),
-			vs:   EmptyList,
-			out:  NewCons(NewInteger(10), EmptyList),
+			in:   values.NewCons(values.NewInteger(10), values.EmptyList),
+			vs:   values.EmptyList,
+			out:  values.NewCons(values.NewInteger(10), values.EmptyList),
 		},
 		{
 			name: "append to empty list",
-			in:   NewCons(NewInteger(10), EmptyList),
-			vs:   NewCons(NewInteger(20), EmptyList),
-			out:  NewCons(NewInteger(10), NewCons(NewInteger(20), EmptyList)),
+			in:   values.NewCons(values.NewInteger(10), values.EmptyList),
+			vs:   values.NewCons(values.NewInteger(20), values.EmptyList),
+			out:  values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.EmptyList)),
 		},
 		{
 			name: "append to empty list with nil",
-			in:   NewCons(NewInteger(10), EmptyList),
-			vs:   NewCons(NewInteger(20), NewInteger(30)),
-			out:  NewCons(NewInteger(10), NewCons(NewInteger(20), NewInteger(30))),
+			in:   values.NewCons(values.NewInteger(10), values.EmptyList),
+			vs:   values.NewCons(values.NewInteger(20), values.NewInteger(30)),
+			out:  values.NewCons(values.NewInteger(10), values.NewCons(values.NewInteger(20), values.NewInteger(30))),
 		},
 		{
 			name:         "append to non-list pair",
-			in:           NewCons(NewInteger(1), NewInteger(2)),
-			vs:           NewCons(NewInteger(3), EmptyList),
+			in:           values.NewCons(values.NewInteger(1), values.NewInteger(2)),
+			vs:           values.NewCons(values.NewInteger(3), values.EmptyList),
 			panicMatches: "not a list",
 		},
 		{
 			name: "append non-list value",
-			in:   NewCons(NewInteger(1), EmptyList),
-			vs:   NewInteger(2),
-			out:  NewCons(NewInteger(1), NewInteger(2)),
+			in:   values.NewCons(values.NewInteger(1), values.EmptyList),
+			vs:   values.NewInteger(2),
+			out:  values.NewCons(values.NewInteger(1), values.NewInteger(2)),
 		},
 		{
 			name: "append Void to list",
-			in:   NewCons(NewInteger(1), EmptyList),
-			vs:   Void,
-			out:  NewCons(NewInteger(1), Void),
+			in:   values.NewCons(values.NewInteger(1), values.EmptyList),
+			vs:   values.Void,
+			out:  values.NewCons(values.NewInteger(1), values.Void),
 		},
 		{
 			name:         "append Void to non-list",
-			in:           NewCons(NewInteger(1), NewInteger(2)),
-			vs:           Void,
+			in:           values.NewCons(values.NewInteger(1), values.NewInteger(2)),
+			vs:           values.Void,
 			panicMatches: "not a list",
 		},
 		{
 			name:         "append Void to list",
-			in:           NewCons(NewInteger(1), NewInteger(2)),
-			vs:           Void,
+			in:           values.NewCons(values.NewInteger(1), values.NewInteger(2)),
+			vs:           values.Void,
 			panicMatches: "not a list",
 		},
 	}
@@ -454,7 +457,7 @@ func TestPair_Append(t *testing.T) {
 				}, qt.PanicMatches, tc.panicMatches)
 			} else {
 				got := tc.in.Append(tc.vs)
-				qt.Assert(t, got, SchemeEquals, tc.out)
+				qt.Assert(t, got, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}
@@ -464,25 +467,25 @@ func TestPair_Append_DoesNotMutateOriginal(t *testing.T) {
 	c := qt.New(t)
 
 	// Create list (1 2 3)
-	original := List(NewInteger(1), NewInteger(2), NewInteger(3))
+	original := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
 
 	// Append (4 5)
-	toAppend := List(NewInteger(4), NewInteger(5))
-	result := original.(*Pair).Append(toAppend)
+	toAppend := values.List(values.NewInteger(4), values.NewInteger(5))
+	result := original.(*values.Pair).Append(toAppend)
 
 	// Verify result is correct
-	expected := List(NewInteger(1), NewInteger(2), NewInteger(3), NewInteger(4), NewInteger(5))
-	c.Assert(result, SchemeEquals, expected)
+	expected := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3), values.NewInteger(4), values.NewInteger(5))
+	c.Assert(result, valuestest.SchemeEquals, expected)
 
 	// Verify original is unchanged
-	originalExpected := List(NewInteger(1), NewInteger(2), NewInteger(3))
-	c.Assert(original, SchemeEquals, originalExpected)
+	originalExpected := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
+	c.Assert(original, valuestest.SchemeEquals, originalExpected)
 
 	// Verify they don't share spine by mutating result
-	result.(*Pair).SetCar(NewInteger(99))
-	c.Assert(original.(*Pair).Car(), SchemeEquals, NewInteger(1),
+	result.(*values.Pair).SetCar(values.NewInteger(99))
+	c.Assert(original.(*values.Pair).Car(), valuestest.SchemeEquals, values.NewInteger(1),
 		qt.Commentf("original should still have 1, not 99"))
-	c.Assert(result.(*Pair).Car(), SchemeEquals, NewInteger(99),
+	c.Assert(result.(*values.Pair).Car(), valuestest.SchemeEquals, values.NewInteger(99),
 		qt.Commentf("result should have 99"))
 }
 
@@ -490,14 +493,14 @@ func TestPair_Append_SharesStructureWithLastArgument(t *testing.T) {
 	c := qt.New(t)
 
 	// R7RS §6.4: the last argument shares structure
-	list1 := List(NewInteger(1), NewInteger(2))
-	list2 := List(NewInteger(3), NewInteger(4))
+	list1 := values.List(values.NewInteger(1), values.NewInteger(2))
+	list2 := values.List(values.NewInteger(3), values.NewInteger(4))
 
-	result := list1.(*Pair).Append(list2)
+	result := list1.(*values.Pair).Append(list2)
 
 	// The tail of result should be the same pointer as list2
 	// result is (1 2 3 4), so cdr of cdr should point to list2
-	resultTail := result.(*Pair).Cdr().(*Pair).Cdr()
+	resultTail := result.(*values.Pair).Cdr().(*values.Pair).Cdr()
 	c.Assert(resultTail, qt.Equals, list2,
 		qt.Commentf("last argument should share structure"))
 }
@@ -507,11 +510,11 @@ func TestPair_Append_EmptyList(t *testing.T) {
 
 	// Appending empty list should return the original list
 	// but R7RS allows returning p when vs is empty since no mutation occurs
-	original := List(NewInteger(1), NewInteger(2))
-	result := original.(*Pair).Append(EmptyList)
+	original := values.List(values.NewInteger(1), values.NewInteger(2))
+	result := original.(*values.Pair).Append(values.EmptyList)
 
 	// Verify result equals original
-	c.Assert(result, SchemeEquals, original)
+	c.Assert(result, valuestest.SchemeEquals, original)
 
 	// When vs is empty, returning p is allowed (no copy needed)
 	// because there's no mutation risk
@@ -523,59 +526,59 @@ func TestPair_Append_MultipleElements(t *testing.T) {
 	c := qt.New(t)
 
 	// Test appending longer lists
-	list1 := List(NewInteger(1), NewInteger(2), NewInteger(3))
-	list2 := List(NewInteger(4), NewInteger(5), NewInteger(6), NewInteger(7))
-	result := list1.(*Pair).Append(list2)
+	list1 := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
+	list2 := values.List(values.NewInteger(4), values.NewInteger(5), values.NewInteger(6), values.NewInteger(7))
+	result := list1.(*values.Pair).Append(list2)
 
-	expected := List(
-		NewInteger(1), NewInteger(2), NewInteger(3),
-		NewInteger(4), NewInteger(5), NewInteger(6), NewInteger(7),
+	expected := values.List(
+		values.NewInteger(1), values.NewInteger(2), values.NewInteger(3),
+		values.NewInteger(4), values.NewInteger(5), values.NewInteger(6), values.NewInteger(7),
 	)
-	c.Assert(result, SchemeEquals, expected)
+	c.Assert(result, valuestest.SchemeEquals, expected)
 
 	// Verify original list1 is unchanged
-	c.Assert(list1, SchemeEquals, List(NewInteger(1), NewInteger(2), NewInteger(3)))
+	c.Assert(list1, valuestest.SchemeEquals, values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)))
 
 	// Verify structure sharing with list2
-	resultTail := result.(*Pair).Cdr().(*Pair).Cdr().(*Pair).Cdr()
+	resultTail := result.(*values.Pair).Cdr().(*values.Pair).Cdr().(*values.Pair).Cdr()
 	c.Assert(resultTail, qt.Equals, list2)
 }
 
 func TestPair_Car(t *testing.T) {
-	p := NewCons(NewInteger(42), NewInteger(99))
-	qt.Assert(t, p.Car(), SchemeEquals, NewInteger(42))
+	p := values.NewCons(values.NewInteger(42), values.NewInteger(99))
+	qt.Assert(t, p.Car(), valuestest.SchemeEquals, values.NewInteger(42))
 
-	p2 := NewCons(NewString("hello"), EmptyList)
-	qt.Assert(t, p2.Car(), SchemeEquals, NewString("hello"))
+	p2 := values.NewCons(values.NewString("hello"), values.EmptyList)
+	qt.Assert(t, p2.Car(), valuestest.SchemeEquals, values.NewString("hello"))
 }
 
 func TestPair_SetCar(t *testing.T) {
-	p := NewCons(NewInteger(1), NewInteger(2))
-	p.SetCar(NewInteger(10))
-	qt.Assert(t, p.Car(), SchemeEquals, NewInteger(10))
-	qt.Assert(t, p.Cdr(), SchemeEquals, NewInteger(2))
+	p := values.NewCons(values.NewInteger(1), values.NewInteger(2))
+	p.SetCar(values.NewInteger(10))
+	qt.Assert(t, p.Car(), valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, p.Cdr(), valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestPair_SetCdr(t *testing.T) {
-	p := NewCons(NewInteger(1), NewInteger(2))
-	p.SetCdr(NewInteger(20))
-	qt.Assert(t, p.Car(), SchemeEquals, NewInteger(1))
-	qt.Assert(t, p.Cdr(), SchemeEquals, NewInteger(20))
+	p := values.NewCons(values.NewInteger(1), values.NewInteger(2))
+	p.SetCdr(values.NewInteger(20))
+	qt.Assert(t, p.Car(), valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, p.Cdr(), valuestest.SchemeEquals, values.NewInteger(20))
 }
 
 func TestPair_Datum(t *testing.T) {
-	p := NewCons(NewInteger(1), NewInteger(2))
+	p := values.NewCons(values.NewInteger(1), values.NewInteger(2))
 	datum := p.Datum()
-	qt.Assert(t, datum[0], SchemeEquals, NewInteger(1))
-	qt.Assert(t, datum[1], SchemeEquals, NewInteger(2))
+	qt.Assert(t, datum[0], valuestest.SchemeEquals, values.NewInteger(1))
+	qt.Assert(t, datum[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
 func TestPair_String(t *testing.T) {
-	p := NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList))
+	p := values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList))
 	s := p.String()
 	qt.Assert(t, s, qt.Equals, "(1 2)")
 
-	p2 := NewCons(NewInteger(1), NewInteger(2))
+	p2 := values.NewCons(values.NewInteger(1), values.NewInteger(2))
 	s2 := p2.String()
 	qt.Assert(t, s2, qt.Equals, "(1 . 2)")
 }

--- a/values/port_coverage_test.go
+++ b/values/port_coverage_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"bytes"
@@ -20,13 +20,15 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // ByteVectorInputOutputPort
 
 func TestByteVectorInputOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorInputOutputPort()
+	port := values.NewByteVectorInputOutputPort()
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -43,10 +45,10 @@ func TestByteVectorInputOutputPort_Basic(t *testing.T) {
 	c.Assert(buf, qt.DeepEquals, []byte{1, 2, 3})
 
 	// EqualTo
-	port2 := NewByteVectorInputOutputPort()
+	port2 := values.NewByteVectorInputOutputPort()
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -57,7 +59,7 @@ func TestByteVectorInputOutputPort_Basic(t *testing.T) {
 func TestByteVectorInputOutputPort_FromBuffer(t *testing.T) {
 	c := qt.New(t)
 	buf := bytes.NewBuffer([]byte{10, 20, 30})
-	port := NewByteVectorInputOutputPortFromBuffer(buf)
+	port := values.NewByteVectorInputOutputPortFromBuffer(buf)
 	c.Assert(port, qt.IsNotNil)
 
 	b := make([]byte, 3)
@@ -69,7 +71,7 @@ func TestByteVectorInputOutputPort_FromBuffer(t *testing.T) {
 
 func TestByteVectorInputOutputPort_ByteOps(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorInputOutputPort()
+	port := values.NewByteVectorInputOutputPort()
 
 	err := port.WriteByte(42)
 	c.Assert(err, qt.IsNil)
@@ -81,7 +83,7 @@ func TestByteVectorInputOutputPort_ByteOps(t *testing.T) {
 
 func TestByteVectorInputOutputPort_ReadByteVector(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorInputOutputPort()
+	port := values.NewByteVectorInputOutputPort()
 	_, err := port.Write([]byte{1, 2, 3})
 	c.Assert(err, qt.IsNil)
 
@@ -92,7 +94,7 @@ func TestByteVectorInputOutputPort_ReadByteVector(t *testing.T) {
 
 func TestByteVectorInputOutputPort_Flush(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorInputOutputPort()
+	port := values.NewByteVectorInputOutputPort()
 	err := port.Flush()
 	c.Assert(err, qt.IsNil)
 }
@@ -101,7 +103,7 @@ func TestByteVectorInputOutputPort_Flush(t *testing.T) {
 
 func TestByteVectorBufferdOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorBufferdOutputPort()
+	port := values.NewByteVectorBufferdOutputPort()
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -125,10 +127,10 @@ func TestByteVectorBufferdOutputPort_Basic(t *testing.T) {
 	c.Assert(bv, qt.IsNotNil)
 
 	// EqualTo
-	port2 := NewByteVectorBufferdOutputPort()
+	port2 := values.NewByteVectorBufferdOutputPort()
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -139,7 +141,7 @@ func TestByteVectorBufferdOutputPort_Basic(t *testing.T) {
 func TestByteVectorBufferdOutputPort_FromBuffer(t *testing.T) {
 	c := qt.New(t)
 	buf := &bytes.Buffer{}
-	port := NewByteVectorBufferdOutputPortFromBuffer(buf)
+	port := values.NewByteVectorBufferdOutputPortFromBuffer(buf)
 	c.Assert(port, qt.IsNotNil)
 
 	_, err := port.Write([]byte{1})
@@ -150,7 +152,7 @@ func TestByteVectorBufferdOutputPort_FromBuffer(t *testing.T) {
 
 func TestStringInputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewStringInputPortWithBuffer(bytes.NewBufferString("hello world"))
+	port := values.NewStringInputPortWithBuffer(bytes.NewBufferString("hello world"))
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -172,10 +174,10 @@ func TestStringInputPort_Basic(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// EqualTo
-	port2 := NewStringInputPortWithBuffer(bytes.NewBufferString("hello"))
+	port2 := values.NewStringInputPortWithBuffer(bytes.NewBufferString("hello"))
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Flush and Close
 	err = port.Flush()
@@ -189,7 +191,7 @@ func TestStringInputPort_Basic(t *testing.T) {
 
 func TestStringOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewStringOutputPort()
+	port := values.NewStringOutputPort()
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -217,10 +219,10 @@ func TestStringOutputPort_Basic(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// EqualTo
-	port2 := NewStringOutputPort()
+	port2 := values.NewStringOutputPort()
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -232,7 +234,7 @@ func TestStringOutputPort_Basic(t *testing.T) {
 
 func TestCharacterInputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewCharacterInputPortFromReader(strings.NewReader("abc"))
+	port := values.NewCharacterInputPortFromReader(strings.NewReader("abc"))
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -253,10 +255,10 @@ func TestCharacterInputPort_Basic(t *testing.T) {
 	c.Assert(n, qt.Equals, 3)
 
 	// EqualTo
-	port2 := NewCharacterInputPortFromReader(strings.NewReader("def"))
+	port2 := values.NewCharacterInputPortFromReader(strings.NewReader("def"))
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -269,7 +271,7 @@ func TestCharacterInputPort_Basic(t *testing.T) {
 func TestCharacterOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
 	var buf bytes.Buffer
-	port := NewCharacterOutputPortFromWriter(&buf)
+	port := values.NewCharacterOutputPortFromWriter(&buf)
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -296,10 +298,10 @@ func TestCharacterOutputPort_Basic(t *testing.T) {
 
 	// EqualTo
 	var buf2 bytes.Buffer
-	port2 := NewCharacterOutputPortFromWriter(&buf2)
+	port2 := values.NewCharacterOutputPortFromWriter(&buf2)
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -311,7 +313,7 @@ func TestCharacterOutputPort_Basic(t *testing.T) {
 
 func TestByteVectorInputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewByteVectorInputPortFromReader(bytes.NewReader([]byte{10, 20, 30}))
+	port := values.NewByteVectorInputPortFromReader(bytes.NewReader([]byte{10, 20, 30}))
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -332,10 +334,10 @@ func TestByteVectorInputPort_Basic(t *testing.T) {
 	c.Assert(n, qt.Equals, 3)
 
 	// EqualTo
-	port2 := NewByteVectorInputPortFromReader(bytes.NewReader([]byte{1}))
+	port2 := values.NewByteVectorInputPortFromReader(bytes.NewReader([]byte{1}))
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -348,7 +350,7 @@ func TestByteVectorInputPort_Basic(t *testing.T) {
 func TestByteVectorOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
 	var buf bytes.Buffer
-	port := NewByteVectorOutputPortFromWriter(&buf)
+	port := values.NewByteVectorOutputPortFromWriter(&buf)
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -368,10 +370,10 @@ func TestByteVectorOutputPort_Basic(t *testing.T) {
 
 	// EqualTo
 	var buf2 bytes.Buffer
-	port2 := NewByteVectorOutputPortFromWriter(&buf2)
+	port2 := values.NewByteVectorOutputPortFromWriter(&buf2)
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -383,7 +385,7 @@ func TestByteVectorOutputPort_Basic(t *testing.T) {
 
 func TestBinaryInputPort_Basic(t *testing.T) {
 	c := qt.New(t)
-	port := NewBinaryInputPortFromReader(bytes.NewReader([]byte{5, 6, 7}))
+	port := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{5, 6, 7}))
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -404,10 +406,10 @@ func TestBinaryInputPort_Basic(t *testing.T) {
 	c.Assert(n, qt.Equals, 3)
 
 	// EqualTo
-	port2 := NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
+	port2 := values.NewBinaryInputPortFromReader(bytes.NewReader([]byte{1}))
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()
@@ -420,7 +422,7 @@ func TestBinaryInputPort_Basic(t *testing.T) {
 func TestBinaryOutputPort_Basic(t *testing.T) {
 	c := qt.New(t)
 	var buf bytes.Buffer
-	port := NewBinaryOutputPortFromWriter(&buf)
+	port := values.NewBinaryOutputPortFromWriter(&buf)
 	c.Assert(port.IsVoid(), qt.IsFalse)
 	c.Assert(port.SchemeString(), qt.Matches, ".*port.*")
 	c.Assert(port.IsClosed(), qt.IsFalse)
@@ -440,10 +442,10 @@ func TestBinaryOutputPort_Basic(t *testing.T) {
 
 	// EqualTo
 	var buf2 bytes.Buffer
-	port2 := NewBinaryOutputPortFromWriter(&buf2)
+	port2 := values.NewBinaryOutputPortFromWriter(&buf2)
 	c.Assert(port.EqualTo(port), qt.IsTrue)
 	c.Assert(port.EqualTo(port2), qt.IsFalse)
-	c.Assert(port.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(port.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
 	// Close
 	err = port.Close()

--- a/values/promise_test.go
+++ b/values/promise_test.go
@@ -12,54 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestPromise_NewPromise(t *testing.T) {
-	thunk := NewSymbol("thunk-placeholder")
-	p := NewPromise(thunk)
+	thunk := values.NewSymbol("thunk-placeholder")
+	p := values.NewPromise(thunk)
 
 	qt.Assert(t, p.Forced, qt.IsFalse)
-	qt.Assert(t, p.Thunk, SchemeEquals, thunk)
+	qt.Assert(t, p.Thunk, valuestest.SchemeEquals, thunk)
 	qt.Assert(t, p.Result == nil, qt.IsTrue)
 }
 
 func TestPromise_NewForcedPromise(t *testing.T) {
-	val := NewInteger(42)
-	p := NewForcedPromise(val)
+	val := values.NewInteger(42)
+	p := values.NewForcedPromise(val)
 
 	qt.Assert(t, p.Forced, qt.IsTrue)
 	qt.Assert(t, p.Thunk == nil, qt.IsTrue)
-	qt.Assert(t, p.Result, SchemeEquals, val)
+	qt.Assert(t, p.Result, valuestest.SchemeEquals, val)
 }
 
 func TestPromise_IsVoid(t *testing.T) {
-	p := NewPromise(NewSymbol("thunk"))
+	p := values.NewPromise(values.NewSymbol("thunk"))
 	qt.Assert(t, p.IsVoid(), qt.IsFalse)
 
-	var nilPromise *Promise
+	var nilPromise *values.Promise
 	qt.Assert(t, nilPromise.IsVoid(), qt.IsTrue)
 }
 
 func TestPromise_EqualTo(t *testing.T) {
-	p1 := NewPromise(NewSymbol("thunk"))
-	p2 := NewPromise(NewSymbol("thunk"))
+	p1 := values.NewPromise(values.NewSymbol("thunk"))
+	p2 := values.NewPromise(values.NewSymbol("thunk"))
 
 	// Identity only
 	qt.Assert(t, p1.EqualTo(p1), qt.IsTrue)
 	qt.Assert(t, p1.EqualTo(p2), qt.IsFalse)
-	qt.Assert(t, p1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, p1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestPromise_SchemeString(t *testing.T) {
-	unforced := NewPromise(NewSymbol("thunk"))
+	unforced := values.NewPromise(values.NewSymbol("thunk"))
 	qt.Assert(t, unforced.SchemeString(), qt.Equals, "#<promise>")
 
-	forced := NewForcedPromise(NewInteger(42))
+	forced := values.NewForcedPromise(values.NewInteger(42))
 	qt.Assert(t, forced.SchemeString(), qt.Equals, "#<promise (forced)>")
 }

--- a/values/rational_test.go
+++ b/values/rational_test.go
@@ -12,182 +12,185 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"math/big"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestRational_EqualTo(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(1, 2)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(1, 2)
 	qt.Assert(t, r1.EqualTo(r2), qt.IsTrue)
 
-	r3 := NewRational(2, 4)
+	r3 := values.NewRational(2, 4)
 	qt.Assert(t, r1.EqualTo(r3), qt.IsTrue)
 
-	r4 := NewRational(1, 3)
+	r4 := values.NewRational(1, 3)
 	qt.Assert(t, r1.EqualTo(r4), qt.IsFalse)
 }
 
 func TestRational_Add(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(1, 3)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(1, 3)
 	result := r1.Add(r2)
-	qt.Assert(t, result, SchemeEquals, NewRational(5, 6))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(5, 6))
 
-	r3 := NewRational(0, 1)
+	r3 := values.NewRational(0, 1)
 	result = r1.Add(r3)
-	qt.Assert(t, result, SchemeEquals, NewRational(1, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(1, 2))
 
-	i1 := NewInteger(2)
+	i1 := values.NewInteger(2)
 	result = r1.Add(i1)
-	qt.Assert(t, result, SchemeEquals, NewRational(5, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(5, 2))
 
-	f1 := NewFloat(2.5)
+	f1 := values.NewFloat(2.5)
 	result = r1.Add(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(3.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(3.0))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = r1.Add(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(1.5, 2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(1.5, 2)))
 }
 
 func TestRational_Subtract(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(1, 3)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(1, 3)
 	result := r1.Subtract(r2)
-	qt.Assert(t, result, SchemeEquals, NewRational(1, 6))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(1, 6))
 
-	r3 := NewRational(0, 1)
+	r3 := values.NewRational(0, 1)
 	result = r1.Subtract(r3)
-	qt.Assert(t, result, SchemeEquals, NewRational(1, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(1, 2))
 
-	i1 := NewInteger(2)
+	i1 := values.NewInteger(2)
 	result = r1.Subtract(i1)
-	qt.Assert(t, result, SchemeEquals, NewRational(-3, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(-3, 2))
 
-	f1 := NewFloat(0.5)
+	f1 := values.NewFloat(0.5)
 	result = r1.Subtract(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(0.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(0.0))
 
-	c1 := NewComplex(complex(1, 2))
+	c1 := values.NewComplex(complex(1, 2))
 	result = r1.Subtract(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(-0.5, -2)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(-0.5, -2)))
 }
 
 func TestRational_Multiply(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(2, 3)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(2, 3)
 	result := r1.Multiply(r2)
-	qt.Assert(t, result, SchemeEquals, NewRational(1, 3))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(1, 3))
 
-	r3 := NewRational(0, 1)
+	r3 := values.NewRational(0, 1)
 	result = r1.Multiply(r3)
-	qt.Assert(t, result, SchemeEquals, NewRational(0, 1))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(0, 1))
 
-	i1 := NewInteger(3)
+	i1 := values.NewInteger(3)
 	result = r1.Multiply(i1)
-	qt.Assert(t, result, SchemeEquals, NewRational(3, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(3, 2))
 
-	f1 := NewFloat(2.0)
+	f1 := values.NewFloat(2.0)
 	result = r1.Multiply(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(1.0))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(1.0))
 
-	c1 := NewComplex(complex(2, 3))
+	c1 := values.NewComplex(complex(2, 3))
 	result = r1.Multiply(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(1, 1.5)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(1, 1.5)))
 }
 
 func TestRational_Divide(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(1, 3)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(1, 3)
 	result := r1.Divide(r2)
-	qt.Assert(t, result, SchemeEquals, NewRational(3, 2))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(3, 2))
 
-	i1 := NewInteger(2)
+	i1 := values.NewInteger(2)
 	result = r1.Divide(i1)
-	qt.Assert(t, result, SchemeEquals, NewRational(1, 4))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewRational(1, 4))
 
-	f1 := NewFloat(2.0)
+	f1 := values.NewFloat(2.0)
 	result = r1.Divide(f1)
-	qt.Assert(t, result, SchemeEquals, NewFloat(0.25))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewFloat(0.25))
 
-	c1 := NewComplex(complex(2, 0))
+	c1 := values.NewComplex(complex(2, 0))
 	result = r1.Divide(c1)
-	qt.Assert(t, result, SchemeEquals, NewComplex(complex(0.25, 0)))
+	qt.Assert(t, result, valuestest.SchemeEquals, values.NewComplex(complex(0.25, 0)))
 }
 
 func TestRational_IsZero(t *testing.T) {
-	r1 := NewRational(0, 1)
+	r1 := values.NewRational(0, 1)
 	qt.Assert(t, r1.IsZero(), qt.IsTrue)
 
-	r2 := NewRational(1, 2)
+	r2 := values.NewRational(1, 2)
 	qt.Assert(t, r2.IsZero(), qt.IsFalse)
 }
 
 func TestRational_LessThan(t *testing.T) {
-	r1 := NewRational(1, 2)
-	r2 := NewRational(2, 3)
+	r1 := values.NewRational(1, 2)
+	r2 := values.NewRational(2, 3)
 	qt.Assert(t, r1.LessThan(r2), qt.IsTrue)
 	qt.Assert(t, r2.LessThan(r1), qt.IsFalse)
 
-	i1 := NewInteger(1)
+	i1 := values.NewInteger(1)
 	qt.Assert(t, r1.LessThan(i1), qt.IsTrue)
 
-	f1 := NewFloat(0.6)
+	f1 := values.NewFloat(0.6)
 	qt.Assert(t, r1.LessThan(f1), qt.IsTrue)
 
-	c1 := NewComplex(complex(1, 0))
+	c1 := values.NewComplex(complex(1, 0))
 	qt.Assert(t, r1.LessThan(c1), qt.IsTrue)
 }
 
 func TestRational_IsInteger(t *testing.T) {
-	r1 := NewRational(4, 2)
+	r1 := values.NewRational(4, 2)
 	qt.Assert(t, r1.IsInteger(), qt.IsTrue)
 
-	r2 := NewRational(1, 2)
+	r2 := values.NewRational(1, 2)
 	qt.Assert(t, r2.IsInteger(), qt.IsFalse)
 }
 
 func TestRational_NumInt64(t *testing.T) {
-	r := NewRational(5, 3)
+	r := values.NewRational(5, 3)
 	qt.Assert(t, r.NumInt64(), qt.Equals, int64(5))
 }
 
 func TestRational_DenomInt64(t *testing.T) {
-	r := NewRational(5, 3)
+	r := values.NewRational(5, 3)
 	qt.Assert(t, r.DenomInt64(), qt.Equals, int64(3))
 }
 
 func TestRational_Float64(t *testing.T) {
-	r := NewRational(1, 2)
+	r := values.NewRational(1, 2)
 	qt.Assert(t, r.Float64(), qt.Equals, 0.5)
 }
 
 func TestRational_SchemeString(t *testing.T) {
-	r := NewRational(1, 2)
+	r := values.NewRational(1, 2)
 	qt.Assert(t, r.SchemeString(), qt.Equals, "1/2")
 }
 
 func TestRational_Rat(t *testing.T) {
-	r := NewRational(1, 2)
+	r := values.NewRational(1, 2)
 	rat := r.Rat()
 	qt.Assert(t, rat.RatString(), qt.Equals, "1/2")
 }
 
 func TestRational_Num(t *testing.T) {
-	r := NewRational(5, 3)
+	r := values.NewRational(5, 3)
 	num := r.Num()
 	expected := big.NewInt(5)
 	qt.Assert(t, num.Cmp(expected), qt.Equals, 0)
 }
 
 func TestRational_Denom(t *testing.T) {
-	r := NewRational(5, 3)
+	r := values.NewRational(5, 3)
 	denom := r.Denom()
 	expected := big.NewInt(3)
 	qt.Assert(t, denom.Cmp(expected), qt.Equals, 0)
@@ -196,12 +199,12 @@ func TestRational_Denom(t *testing.T) {
 func TestNewRationalFromBigInt(t *testing.T) {
 	num := big.NewInt(7)
 	denom := big.NewInt(4)
-	r := NewRationalFromBigInt(num, denom)
+	r := values.NewRationalFromBigInt(num, denom)
 	qt.Assert(t, r.SchemeString(), qt.Equals, "7/4")
 }
 
 func TestNewRationalFromRat(t *testing.T) {
 	rat := big.NewRat(3, 5)
-	r := NewRationalFromRat(rat)
+	r := values.NewRationalFromRat(rat)
 	qt.Assert(t, r.SchemeString(), qt.Equals, "3/5")
 }

--- a/values/record_test.go
+++ b/values/record_test.go
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestRecordTypeCreation(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
 
 	qt.Assert(t, rt, qt.Not(qt.IsNil))
 	qt.Assert(t, rt.Name(), qt.Equals, name)
@@ -34,11 +37,11 @@ func TestRecordTypeCreation(t *testing.T) {
 }
 
 func TestRecordTypeFieldIndex(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	fieldZ := NewSymbol("z")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	fieldZ := values.NewSymbol("z")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
 
 	qt.Assert(t, rt.FieldIndex(fieldX), qt.Equals, 0)
 	qt.Assert(t, rt.FieldIndex(fieldY), qt.Equals, 1)
@@ -48,7 +51,7 @@ func TestRecordTypeFieldIndex(t *testing.T) {
 func TestRecordTypeIsVoid(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   *RecordType
+		in   *values.RecordType
 		out  bool
 	}{
 		{
@@ -58,7 +61,7 @@ func TestRecordTypeIsVoid(t *testing.T) {
 		},
 		{
 			name: "valid record type is not void",
-			in:   NewRecordType(NewSymbol("test"), []*Symbol{}),
+			in:   values.NewRecordType(values.NewSymbol("test"), []*values.Symbol{}),
 			out:  false,
 		},
 	}
@@ -71,87 +74,87 @@ func TestRecordTypeIsVoid(t *testing.T) {
 }
 
 func TestRecordTypeEqualTo(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	rt1 := NewRecordType(name, []*Symbol{fieldX})
-	rt2 := NewRecordType(name, []*Symbol{fieldX})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	rt1 := values.NewRecordType(name, []*values.Symbol{fieldX})
+	rt2 := values.NewRecordType(name, []*values.Symbol{fieldX})
 
 	// Record types use identity equality
 	qt.Assert(t, rt1.EqualTo(rt1), qt.IsTrue)
 	qt.Assert(t, rt1.EqualTo(rt2), qt.IsFalse) // Different objects
-	qt.Assert(t, rt1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, rt1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestRecordTypeSchemeString(t *testing.T) {
-	name := NewSymbol("point")
-	rt := NewRecordType(name, []*Symbol{})
+	name := values.NewSymbol("point")
+	rt := values.NewRecordType(name, []*values.Symbol{})
 	qt.Assert(t, rt.SchemeString(), qt.Equals, "#<record-type:point>")
 
-	var nilRT *RecordType
+	var nilRT *values.RecordType
 	qt.Assert(t, nilRT.SchemeString(), qt.Equals, "#<record-type>")
 }
 
 func TestRecordCreation(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
 
-	r := NewRecord(rt, []Value{NewInteger(3), NewInteger(4)})
+	r := values.NewRecord(rt, []values.Value{values.NewInteger(3), values.NewInteger(4)})
 
 	qt.Assert(t, r, qt.Not(qt.IsNil))
 	qt.Assert(t, r.RecordType(), qt.Equals, rt)
-	qt.Assert(t, r.Field(0), SchemeEquals, NewInteger(3))
-	qt.Assert(t, r.Field(1), SchemeEquals, NewInteger(4))
+	qt.Assert(t, r.Field(0), valuestest.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, r.Field(1), valuestest.SchemeEquals, values.NewInteger(4))
 }
 
 func TestRecordFieldAccess(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
 
-	r := NewRecord(rt, []Value{NewInteger(3), NewInteger(4)})
+	r := values.NewRecord(rt, []values.Value{values.NewInteger(3), values.NewInteger(4)})
 
 	// By index
-	qt.Assert(t, r.Field(0), SchemeEquals, NewInteger(3))
-	qt.Assert(t, r.Field(1), SchemeEquals, NewInteger(4))
+	qt.Assert(t, r.Field(0), valuestest.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, r.Field(1), valuestest.SchemeEquals, values.NewInteger(4))
 	qt.Assert(t, r.Field(-1), qt.IsNil)
 	qt.Assert(t, r.Field(2), qt.IsNil)
 
 	// By name
-	qt.Assert(t, r.FieldByName(fieldX), SchemeEquals, NewInteger(3))
-	qt.Assert(t, r.FieldByName(fieldY), SchemeEquals, NewInteger(4))
-	qt.Assert(t, r.FieldByName(NewSymbol("z")), qt.IsNil)
+	qt.Assert(t, r.FieldByName(fieldX), valuestest.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, r.FieldByName(fieldY), valuestest.SchemeEquals, values.NewInteger(4))
+	qt.Assert(t, r.FieldByName(values.NewSymbol("z")), qt.IsNil)
 }
 
 func TestRecordFieldMutation(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
 
-	r := NewRecord(rt, []Value{NewInteger(3), NewInteger(4)})
+	r := values.NewRecord(rt, []values.Value{values.NewInteger(3), values.NewInteger(4)})
 
 	// Mutate by index
-	r.SetField(0, NewInteger(10))
-	qt.Assert(t, r.Field(0), SchemeEquals, NewInteger(10))
+	r.SetField(0, values.NewInteger(10))
+	qt.Assert(t, r.Field(0), valuestest.SchemeEquals, values.NewInteger(10))
 
 	// Mutate by name
-	r.SetFieldByName(fieldY, NewInteger(20))
-	qt.Assert(t, r.Field(1), SchemeEquals, NewInteger(20))
+	r.SetFieldByName(fieldY, values.NewInteger(20))
+	qt.Assert(t, r.Field(1), valuestest.SchemeEquals, values.NewInteger(20))
 
 	// Out of bounds mutation does nothing
-	r.SetField(-1, NewInteger(100))
-	r.SetField(10, NewInteger(100))
+	r.SetField(-1, values.NewInteger(100))
+	r.SetField(10, values.NewInteger(100))
 }
 
 func TestRecordIsVoid(t *testing.T) {
-	rt := NewRecordType(NewSymbol("test"), []*Symbol{})
+	rt := values.NewRecordType(values.NewSymbol("test"), []*values.Symbol{})
 
 	tcs := []struct {
 		name string
-		in   *Record
+		in   *values.Record
 		out  bool
 	}{
 		{
@@ -161,7 +164,7 @@ func TestRecordIsVoid(t *testing.T) {
 		},
 		{
 			name: "valid record is not void",
-			in:   NewRecord(rt, []Value{}),
+			in:   values.NewRecord(rt, []values.Value{}),
 			out:  false,
 		},
 	}
@@ -174,58 +177,58 @@ func TestRecordIsVoid(t *testing.T) {
 }
 
 func TestRecordEqualTo(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	fieldY := NewSymbol("y")
-	rt := NewRecordType(name, []*Symbol{fieldX, fieldY})
-	rt2 := NewRecordType(NewSymbol("point2"), []*Symbol{fieldX, fieldY})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	fieldY := values.NewSymbol("y")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX, fieldY})
+	rt2 := values.NewRecordType(values.NewSymbol("point2"), []*values.Symbol{fieldX, fieldY})
 
 	tcs := []struct {
 		name string
-		a    *Record
-		b    Value
+		a    *values.Record
+		b    values.Value
 		out  bool
 	}{
 		{
 			name: "equal records same type and fields",
-			a:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
-			b:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
+			a:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
+			b:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
 			out:  true,
 		},
 		{
 			name: "different field values",
-			a:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
-			b:    NewRecord(rt, []Value{NewInteger(1), NewInteger(3)}),
+			a:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
+			b:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(3)}),
 			out:  false,
 		},
 		{
 			name: "different record types",
-			a:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
-			b:    NewRecord(rt2, []Value{NewInteger(1), NewInteger(2)}),
+			a:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
+			b:    values.NewRecord(rt2, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
 			out:  false,
 		},
 		{
 			name: "comparison with non-record",
-			a:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
-			b:    NewInteger(1),
+			a:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
+			b:    values.NewInteger(1),
 			out:  false,
 		},
 		{
 			name: "comparison with nil record",
-			a:    NewRecord(rt, []Value{NewInteger(1), NewInteger(2)}),
-			b:    (*Record)(nil),
+			a:    values.NewRecord(rt, []values.Value{values.NewInteger(1), values.NewInteger(2)}),
+			b:    (*values.Record)(nil),
 			out:  false,
 		},
 		{
 			name: "nil records equal",
 			a:    nil,
-			b:    (*Record)(nil),
+			b:    (*values.Record)(nil),
 			out:  true,
 		},
 		{
 			name: "empty records same type equal",
-			a:    NewRecord(rt, []Value{}),
-			b:    NewRecord(rt, []Value{}),
+			a:    values.NewRecord(rt, []values.Value{}),
+			b:    values.NewRecord(rt, []values.Value{}),
 			out:  true,
 		},
 	}
@@ -238,13 +241,13 @@ func TestRecordEqualTo(t *testing.T) {
 }
 
 func TestRecordSchemeString(t *testing.T) {
-	name := NewSymbol("point")
-	fieldX := NewSymbol("x")
-	rt := NewRecordType(name, []*Symbol{fieldX})
+	name := values.NewSymbol("point")
+	fieldX := values.NewSymbol("x")
+	rt := values.NewRecordType(name, []*values.Symbol{fieldX})
 
-	r := NewRecord(rt, []Value{NewInteger(42)})
+	r := values.NewRecord(rt, []values.Value{values.NewInteger(42)})
 	qt.Assert(t, r.SchemeString(), qt.Equals, "#<record:point>")
 
-	var nilR *Record
+	var nilR *values.Record
 	qt.Assert(t, nilR.SchemeString(), qt.Equals, "#<record>")
 }

--- a/values/scheme_writer_test.go
+++ b/values/scheme_writer_test.go
@@ -12,36 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestWriteValueToString_SimpleValues(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  string
 	}{
-		{"integer", NewInteger(42), "42"},
-		{"negative integer", NewInteger(-7), "-7"},
-		{"float", NewFloat(3.14), "3.14"},
-		{"string", NewString("hello"), "\"hello\""},
-		{"symbol", NewSymbol("foo"), "foo"},
-		{"true", TrueValue, "#t"},
-		{"false", FalseValue, "#f"},
-		{"void", Void, "#!void"},
-		{"eof", EOFObject, "#!eof"},
+		{"integer", values.NewInteger(42), "42"},
+		{"negative integer", values.NewInteger(-7), "-7"},
+		{"float", values.NewFloat(3.14), "3.14"},
+		{"string", values.NewString("hello"), "\"hello\""},
+		{"symbol", values.NewSymbol("foo"), "foo"},
+		{"true", values.TrueValue, "#t"},
+		{"false", values.FalseValue, "#f"},
+		{"void", values.Void, "#!void"},
+		{"eof", values.EOFObject, "#!eof"},
 		{"nil", nil, "#<void>"},
-		{"character", NewCharacter('a'), "#\\a"},
-		{"character space", NewCharacter(' '), "#\\ "},
+		{"character", values.NewCharacter('a'), "#\\a"},
+		{"character space", values.NewCharacter(' '), "#\\ "},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, WriteValueToString(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.WriteValueToString(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
@@ -49,19 +51,19 @@ func TestWriteValueToString_SimpleValues(t *testing.T) {
 func TestWriteValueToString_Lists(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  string
 	}{
-		{"empty list", EmptyList, "()"},
-		{"single element", List(NewInteger(1)), "(1)"},
-		{"proper list", List(NewInteger(1), NewInteger(2), NewInteger(3)), "(1 2 3)"},
-		{"improper pair", NewCons(NewInteger(1), NewInteger(2)), "(1 . 2)"},
-		{"nested list", List(List(NewInteger(1), NewInteger(2)), NewInteger(3)), "((1 2) 3)"},
-		{"list with string", List(NewString("a"), NewString("b")), "(\"a\" \"b\")"},
+		{"empty list", values.EmptyList, "()"},
+		{"single element", values.List(values.NewInteger(1)), "(1)"},
+		{"proper list", values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)), "(1 2 3)"},
+		{"improper pair", values.NewCons(values.NewInteger(1), values.NewInteger(2)), "(1 . 2)"},
+		{"nested list", values.List(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)), "((1 2) 3)"},
+		{"list with string", values.List(values.NewString("a"), values.NewString("b")), "(\"a\" \"b\")"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, WriteValueToString(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.WriteValueToString(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
@@ -69,76 +71,76 @@ func TestWriteValueToString_Lists(t *testing.T) {
 func TestWriteValueToString_Vectors(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  string
 	}{
-		{"empty vector", NewVector(), "#()"},
-		{"single element", NewVector(NewInteger(1)), "#(1)"},
-		{"multiple elements", NewVector(NewInteger(1), NewSymbol("a"), NewString("b")), "#(1 a \"b\")"},
-		{"nil vector", (*Vector)(nil), "#()"},
+		{"empty vector", values.NewVector(), "#()"},
+		{"single element", values.NewVector(values.NewInteger(1)), "#(1)"},
+		{"multiple elements", values.NewVector(values.NewInteger(1), values.NewSymbol("a"), values.NewString("b")), "#(1 a \"b\")"},
+		{"nil vector", (*values.Vector)(nil), "#()"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, WriteValueToString(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.WriteValueToString(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
 
 func TestWriteValueToString_CircularPair(t *testing.T) {
 	// Create a circular list: (1 . #0#) where #0# is the pair itself
-	p := NewCons(NewInteger(1), EmptyList)
+	p := values.NewCons(values.NewInteger(1), values.EmptyList)
 	p[1] = p // make circular
 
-	result := WriteValueToString(p)
+	result := values.WriteValueToString(p)
 	qt.Assert(t, result, qt.Equals, "#0=(1 . #0#)")
 }
 
 func TestWriteValueToString_CircularVector(t *testing.T) {
 	// Create a vector that contains itself
-	v := NewVector(NewInteger(1), nil)
+	v := values.NewVector(values.NewInteger(1), nil)
 	(*v)[1] = v // make circular
 
-	result := WriteValueToString(v)
+	result := values.WriteValueToString(v)
 	qt.Assert(t, result, qt.Equals, "#0=#(1 #0#)")
 }
 
 func TestWriteSharedValueToString_SharedStructure(t *testing.T) {
 	// Create shared structure: (#0=(1 2) #0#)
-	shared := List(NewInteger(1), NewInteger(2))
-	outer := List(shared, shared)
+	shared := values.List(values.NewInteger(1), values.NewInteger(2))
+	outer := values.List(shared, shared)
 
-	result := WriteSharedValueToString(outer)
+	result := values.WriteSharedValueToString(outer)
 	qt.Assert(t, result, qt.Equals, "(#0=(1 2) #0#)")
 }
 
 func TestWriteSharedValueToString_NoSharing(t *testing.T) {
 	// No shared structure => no labels
-	l := List(NewInteger(1), NewInteger(2))
-	result := WriteSharedValueToString(l)
+	l := values.List(values.NewInteger(1), values.NewInteger(2))
+	result := values.WriteSharedValueToString(l)
 	qt.Assert(t, result, qt.Equals, "(1 2)")
 }
 
 func TestWriteValueToString_SharedButNotCircular(t *testing.T) {
 	// WriteModeWrite should NOT label shared-but-not-circular structures
-	shared := List(NewInteger(1), NewInteger(2))
-	outer := List(shared, shared)
+	shared := values.List(values.NewInteger(1), values.NewInteger(2))
+	outer := values.List(shared, shared)
 
-	result := WriteValueToString(outer)
+	result := values.WriteValueToString(outer)
 	qt.Assert(t, result, qt.Equals, "((1 2) (1 2))")
 }
 
 func TestDisplayValueToString_Strings(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  string
 	}{
-		{"string unquoted", NewString("hello"), "hello"},
-		{"string with spaces", NewString("hello world"), "hello world"},
+		{"string unquoted", values.NewString("hello"), "hello"},
+		{"string with spaces", values.NewString("hello world"), "hello world"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, DisplayValueToString(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.DisplayValueToString(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
@@ -146,43 +148,43 @@ func TestDisplayValueToString_Strings(t *testing.T) {
 func TestDisplayValueToString_Characters(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  string
 	}{
-		{"char a", NewCharacter('a'), "a"},
-		{"char space", NewCharacter(' '), " "},
-		{"char newline", NewCharacter('\n'), "\n"},
+		{"char a", values.NewCharacter('a'), "a"},
+		{"char space", values.NewCharacter(' '), " "},
+		{"char newline", values.NewCharacter('\n'), "\n"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, DisplayValueToString(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.DisplayValueToString(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
 
 func TestDisplayValueToString_NonStringValues(t *testing.T) {
 	// Non-string/character values are the same as write
-	qt.Assert(t, DisplayValueToString(NewInteger(42)), qt.Equals, "42")
-	qt.Assert(t, DisplayValueToString(NewSymbol("foo")), qt.Equals, "foo")
-	qt.Assert(t, DisplayValueToString(TrueValue), qt.Equals, "#t")
+	qt.Assert(t, values.DisplayValueToString(values.NewInteger(42)), qt.Equals, "42")
+	qt.Assert(t, values.DisplayValueToString(values.NewSymbol("foo")), qt.Equals, "foo")
+	qt.Assert(t, values.DisplayValueToString(values.TrueValue), qt.Equals, "#t")
 }
 
 func TestDisplayValueToString_List(t *testing.T) {
-	l := List(NewString("hello"), NewCharacter('!'))
-	result := DisplayValueToString(l)
+	l := values.List(values.NewString("hello"), values.NewCharacter('!'))
+	result := values.DisplayValueToString(l)
 	qt.Assert(t, result, qt.Equals, "(hello !)")
 }
 
 func TestWriteValueToString_NilPair(t *testing.T) {
-	result := WriteValueToString((*Pair)(nil))
+	result := values.WriteValueToString((*values.Pair)(nil))
 	qt.Assert(t, result, qt.Equals, "#<void>")
 }
 
 func TestWriteSharedValueToString_SharedVector(t *testing.T) {
 	// Shared vector structure
-	shared := NewVector(NewInteger(1))
-	outer := NewVector(shared, shared)
+	shared := values.NewVector(values.NewInteger(1))
+	outer := values.NewVector(shared, shared)
 
-	result := WriteSharedValueToString(outer)
+	result := values.WriteSharedValueToString(outer)
 	qt.Assert(t, result, qt.Equals, "#(#0=#(1) #0#)")
 }

--- a/values/string_port_test.go
+++ b/values/string_port_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"bytes"
@@ -20,15 +20,17 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestStringInputOutputPort_NewStringInputPort(t *testing.T) {
-	port := NewStringInputPortWithBuffer(bytes.NewBufferString("hello"))
+	port := values.NewStringInputPortWithBuffer(bytes.NewBufferString("hello"))
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestStringInputOutputPort_ReadRune(t *testing.T) {
-	port := NewStringInputPortWithBuffer(bytes.NewBufferString("abc"))
+	port := values.NewStringInputPortWithBuffer(bytes.NewBufferString("abc"))
 	r1, _, err := port.ReadRune()
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, r1, qt.Equals, 'a')
@@ -39,7 +41,7 @@ func TestStringInputOutputPort_ReadRune(t *testing.T) {
 }
 
 func TestStringInputOutputPort_UnreadRune(t *testing.T) {
-	port := NewStringInputPortWithBuffer(bytes.NewBufferString("abc"))
+	port := values.NewStringInputPortWithBuffer(bytes.NewBufferString("abc"))
 	r1, _, _ := port.ReadRune()
 	qt.Assert(t, r1, qt.Equals, 'a')
 
@@ -51,40 +53,40 @@ func TestStringInputOutputPort_UnreadRune(t *testing.T) {
 }
 
 func TestStringInputOutputPort_IsVoid(t *testing.T) {
-	port := NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
+	port := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
 	qt.Assert(t, port.IsVoid(), qt.IsFalse)
 
-	var nilPort *StringOutputPort
+	var nilPort *values.StringOutputPort
 	qt.Assert(t, nilPort.IsVoid(), qt.IsTrue)
 }
 
 func TestStringInputOutputPort_Datum(t *testing.T) {
-	port := NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
+	port := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
 	datum := port.Datum()
 	qt.Assert(t, datum, qt.Not(qt.IsNil))
 }
 
 func TestStringInputOutputPort_EqualTo(t *testing.T) {
-	port1 := NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
-	port2 := NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
+	port1 := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
+	port2 := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
 	qt.Assert(t, port1.EqualTo(port2), qt.IsFalse)
 
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
 }
 
 func TestStringInputOutputPort_SchemeString(t *testing.T) {
-	port := NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
+	port := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
 	s := port.SchemeString()
 	qt.Assert(t, strings.Contains(s, "string-input-output-port"), qt.IsTrue)
 }
 
 func TestStringInputOutputPort_NewStringOutputPort(t *testing.T) {
-	port := NewStringOutputPort()
+	port := values.NewStringOutputPort()
 	qt.Assert(t, port, qt.Not(qt.IsNil))
 }
 
 func TestStringInputOutputPort_Write(t *testing.T) {
-	port := NewStringOutputPort()
+	port := values.NewStringOutputPort()
 	n, err := port.WriteString("hello")
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, n, qt.Equals, 5)
@@ -95,7 +97,7 @@ func TestStringInputOutputPort_Write(t *testing.T) {
 }
 
 func TestStringInputOutputPort_GetString(t *testing.T) {
-	port := NewStringOutputPort()
+	port := values.NewStringOutputPort()
 	port.WriteString("hello") //nolint:errcheck
 	port.WriteString(" ")     //nolint:errcheck
 	port.WriteString("world") //nolint:errcheck

--- a/values/string_test.go
+++ b/values/string_test.go
@@ -12,74 +12,76 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestString_EqualTo(t *testing.T) {
-	s1 := NewString("hello")
-	s2 := NewString("hello")
+	s1 := values.NewString("hello")
+	s2 := values.NewString("hello")
 	qt.Assert(t, s1.EqualTo(s2), qt.IsTrue)
 
-	s3 := NewString("world")
+	s3 := values.NewString("world")
 	qt.Assert(t, s1.EqualTo(s3), qt.IsFalse)
 
-	i := NewInteger(42)
+	i := values.NewInteger(42)
 	qt.Assert(t, s1.EqualTo(i), qt.IsFalse)
 }
 
 func TestString_Datum(t *testing.T) {
-	s := NewString("hello")
+	s := values.NewString("hello")
 	qt.Assert(t, s.Datum(), qt.Equals, "hello")
 }
 
 func TestString_String(t *testing.T) {
-	s := NewString("hello")
+	s := values.NewString("hello")
 	qt.Assert(t, s.String(), qt.Equals, "hello")
 }
 
 func TestString_SchemeString(t *testing.T) {
-	s := NewString("hello")
+	s := values.NewString("hello")
 	qt.Assert(t, s.SchemeString(), qt.Equals, `"hello"`)
 }
 
 func TestString_IsVoid(t *testing.T) {
-	s := NewString("hello")
+	s := values.NewString("hello")
 	qt.Assert(t, s.IsVoid(), qt.IsFalse)
 
-	var nilString *String
+	var nilString *values.String
 	qt.Assert(t, nilString.IsVoid(), qt.IsTrue)
 }
 
 func TestString_Interning(t *testing.T) {
 	// Short strings should be interned (same pointer)
-	s1 := NewString("hello")
-	s2 := NewString("hello")
+	s1 := values.NewString("hello")
+	s2 := values.NewString("hello")
 	qt.Assert(t, s1 == s2, qt.IsTrue, qt.Commentf("short strings should return same pointer"))
 
 	// Different strings should have different pointers
-	s3 := NewString("world")
+	s3 := values.NewString("world")
 	qt.Assert(t, s1 != s3, qt.IsTrue, qt.Commentf("different strings should have different pointers"))
 
 	// Empty string should be interned
-	sEmpty1 := NewString("")
-	sEmpty2 := NewString("")
+	sEmpty1 := values.NewString("")
+	sEmpty2 := values.NewString("")
 	qt.Assert(t, sEmpty1 == sEmpty2, qt.IsTrue, qt.Commentf("empty strings should return same pointer"))
 
 	// Strings at the boundary (64 chars) should be interned
 	boundary := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 64 chars
-	sBoundary1 := NewString(boundary)
-	sBoundary2 := NewString(boundary)
+	sBoundary1 := values.NewString(boundary)
+	sBoundary2 := values.NewString(boundary)
 	qt.Assert(t, sBoundary1 == sBoundary2, qt.IsTrue, qt.Commentf("64-char strings should be interned"))
 
 	// Long strings (>64 chars) should NOT be interned
 	longStr := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" // 65 chars
-	sLong1 := NewString(longStr)
-	sLong2 := NewString(longStr)
+	sLong1 := values.NewString(longStr)
+	sLong2 := values.NewString(longStr)
 	qt.Assert(t, sLong1 != sLong2, qt.IsTrue, qt.Commentf("strings over 64 chars should not be interned"))
 
 	// Interned strings should still have correct values
@@ -90,13 +92,13 @@ func TestString_Interning(t *testing.T) {
 func TestString_InternString(t *testing.T) {
 	// InternString should always intern regardless of length
 	longStr := "this is a very long string that exceeds the automatic interning threshold of 64 characters"
-	sIntern1 := InternString(longStr)
-	sIntern2 := InternString(longStr)
+	sIntern1 := values.InternString(longStr)
+	sIntern2 := values.InternString(longStr)
 	qt.Assert(t, sIntern1 == sIntern2, qt.IsTrue, qt.Commentf("InternString should always return same pointer"))
 
 	// InternString should work for short strings too
-	sShort1 := InternString("short")
-	sShort2 := InternString("short")
+	sShort1 := values.InternString("short")
+	sShort2 := values.InternString("short")
 	qt.Assert(t, sShort1 == sShort2, qt.IsTrue)
 
 	// Values should be correct
@@ -107,67 +109,67 @@ func TestStringImmutability(t *testing.T) {
 	c := qt.New(t)
 
 	t.Run("interned strings are immutable", func(t *testing.T) {
-		s := NewString("hello") // ≤64 bytes, gets interned
+		s := values.NewString("hello") // ≤64 bytes, gets interned
 		c.Assert(s.IsImmutable(), qt.IsTrue)
 	})
 
 	t.Run("mutable strings are mutable", func(t *testing.T) {
-		s := NewMutableString("hello")
+		s := values.NewMutableString("hello")
 		c.Assert(s.IsImmutable(), qt.IsFalse)
 	})
 
 	t.Run("SetChar fails on immutable", func(t *testing.T) {
-		s := NewString("x")
+		s := values.NewString("x")
 		err := s.SetChar(0, 'y')
 		c.Assert(err, qt.Not(qt.IsNil))
 		c.Assert(err, qt.ErrorMatches, ".*immutable.*")
 	})
 
 	t.Run("SetChar succeeds on mutable", func(t *testing.T) {
-		s := NewMutableString("x")
+		s := values.NewMutableString("x")
 		err := s.SetChar(0, 'y')
 		c.Assert(err, qt.IsNil)
 		c.Assert(s.Value, qt.Equals, "y")
 	})
 
 	t.Run("Fill fails on immutable", func(t *testing.T) {
-		s := NewString("hello")
+		s := values.NewString("hello")
 		err := s.Fill('x', 0, 5)
 		c.Assert(err, qt.Not(qt.IsNil))
 		c.Assert(err, qt.ErrorMatches, ".*immutable.*")
 	})
 
 	t.Run("Fill succeeds on mutable", func(t *testing.T) {
-		s := NewMutableString("hello")
+		s := values.NewMutableString("hello")
 		err := s.Fill('x', 0, 5)
 		c.Assert(err, qt.IsNil)
 		c.Assert(s.Value, qt.Equals, "xxxxx")
 	})
 
 	t.Run("SetValue fails on immutable", func(t *testing.T) {
-		s := NewString("hello")
+		s := values.NewString("hello")
 		err := s.SetValue("world")
 		c.Assert(err, qt.Not(qt.IsNil))
 		c.Assert(err, qt.ErrorMatches, ".*immutable.*")
 	})
 
 	t.Run("SetValue succeeds on mutable", func(t *testing.T) {
-		s := NewMutableString("hello")
+		s := values.NewMutableString("hello")
 		err := s.SetValue("world")
 		c.Assert(err, qt.IsNil)
 		c.Assert(s.Value, qt.Equals, "world")
 	})
 
 	t.Run("Set fails on immutable", func(t *testing.T) {
-		s := NewString("hello")
-		err := s.Set(0, NewCharacter('H'))
+		s := values.NewString("hello")
+		err := s.Set(0, values.NewCharacter('H'))
 		c.Assert(err, qt.Not(qt.IsNil))
 		c.Assert(err, qt.ErrorMatches, ".*immutable.*")
 	})
 
 	t.Run("Set succeeds on mutable", func(t *testing.T) {
-		s := NewMutableString("hello")
-		err := s.Set(0, NewCharacter('H'))
+		s := values.NewMutableString("hello")
+		err := s.Set(0, values.NewCharacter('H'))
 		c.Assert(err, qt.IsNil)
 		c.Assert(s.Value, qt.Equals, "Hello")
 	})
@@ -176,8 +178,8 @@ func TestStringImmutability(t *testing.T) {
 func TestStringInternPreserved(t *testing.T) {
 	c := qt.New(t)
 
-	s1 := NewString("test")
-	s2 := NewString("test")
+	s1 := values.NewString("test")
+	s2 := values.NewString("test")
 
 	// Same interned pointer
 	c.Assert(s1 == s2, qt.IsTrue)

--- a/values/symbol_test.go
+++ b/values/symbol_test.go
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestSymbol_EqualTo(t *testing.T) {
-	s0 := NewSymbol("a")
-	s1 := NewSymbol("b")
-	s2 := NewSymbol("a")
+	s0 := values.NewSymbol("a")
+	s1 := values.NewSymbol("b")
+	s2 := values.NewSymbol("a")
 	// check pointer equality first
 	qt.Assert(t, s0.EqualTo(s1), qt.Equals, false)
 	qt.Assert(t, s0.EqualTo(s2), qt.Equals, true)
@@ -34,28 +36,28 @@ func TestSymbol_EqualTo(t *testing.T) {
 }
 
 func TestSymbol_Datum(t *testing.T) {
-	s := NewSymbol("test")
+	s := values.NewSymbol("test")
 	qt.Assert(t, s.Datum(), qt.Equals, "test")
 }
 
 func TestSymbol_Copy(t *testing.T) {
-	s := NewSymbol("original")
+	s := values.NewSymbol("original")
 	copyVal := s.Copy()
-	cpy, ok := copyVal.(*Symbol)
+	cpy, ok := copyVal.(*values.Symbol)
 	qt.Assert(t, ok, qt.IsTrue)
 	qt.Assert(t, cpy.Key, qt.Equals, "original")
 	qt.Assert(t, cpy, qt.Not(qt.Equals), s)
 }
 
 func TestSymbol_SchemeString(t *testing.T) {
-	s := NewSymbol("lambda")
+	s := values.NewSymbol("lambda")
 	qt.Assert(t, s.SchemeString(), qt.Equals, "lambda")
 }
 
 func TestSymbol_IsVoid(t *testing.T) {
-	s := NewSymbol("test")
+	s := values.NewSymbol("test")
 	qt.Assert(t, s.IsVoid(), qt.IsFalse)
 
-	var nilSym *Symbol
+	var nilSym *values.Symbol
 	qt.Assert(t, nilSym.IsVoid(), qt.IsTrue)
 }

--- a/values/thread_test.go
+++ b/values/thread_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"context"
@@ -21,45 +21,48 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestThread_NewThread(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test-thread")
+	th := values.NewThread(values.NewSymbol("thunk"), "test-thread")
 	qt.Assert(t, th, qt.Not(qt.IsNil))
 	qt.Assert(t, th.Name(), qt.Equals, "test-thread")
 	qt.Assert(t, th.ID() > 0, qt.IsTrue)
-	qt.Assert(t, th.State(), qt.Equals, ThreadNew)
+	qt.Assert(t, th.State(), qt.Equals, values.ThreadNew)
 }
 
 func TestThread_DefaultName(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "")
+	th := values.NewThread(values.NewSymbol("thunk"), "")
 	qt.Assert(t, strings.HasPrefix(th.Name(), "thread-"), qt.IsTrue)
 }
 
 func TestThread_Specific(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
 	qt.Assert(t, th.Specific() == nil, qt.IsTrue)
 
-	th.SetSpecific(NewInteger(42))
-	qt.Assert(t, th.Specific(), SchemeEquals, NewInteger(42))
+	th.SetSpecific(values.NewInteger(42))
+	qt.Assert(t, th.Specific(), valuestest.SchemeEquals, values.NewInteger(42))
 }
 
 func TestThread_StateSymbol(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
 	sym := th.StateSymbol()
 	qt.Assert(t, sym.Key, qt.Equals, "new")
 }
 
 func TestThreadState_String(t *testing.T) {
 	tcs := []struct {
-		state ThreadState
+		state values.ThreadState
 		str   string
 	}{
-		{ThreadNew, "new"},
-		{ThreadRunnable, "runnable"},
-		{ThreadBlocked, "blocked"},
-		{ThreadTerminated, "terminated"},
-		{ThreadState(99), "unknown"},
+		{values.ThreadNew, "new"},
+		{values.ThreadRunnable, "runnable"},
+		{values.ThreadBlocked, "blocked"},
+		{values.ThreadTerminated, "terminated"},
+		{values.ThreadState(99), "unknown"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.str, func(t *testing.T) {
@@ -69,15 +72,15 @@ func TestThreadState_String(t *testing.T) {
 }
 
 func TestThread_StartNoRunFunc(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
 	err := th.Start(context.Background())
 	qt.Assert(t, err, qt.Not(qt.IsNil))
 	qt.Assert(t, strings.Contains(err.Error(), "no run function"), qt.IsTrue)
 }
 
 func TestThread_StartAlreadyStarted(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
-	th.RunFunc = func(_ context.Context, _ Value) (Value, error) {
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
+	th.RunFunc = func(_ context.Context, _ values.Value) (values.Value, error) {
 		return nil, nil
 	}
 	err := th.Start(context.Background())
@@ -85,72 +88,72 @@ func TestThread_StartAlreadyStarted(t *testing.T) {
 	<-th.Done()
 
 	err = th.Start(context.Background())
-	qt.Assert(t, errors.Is(err, ErrThreadAlreadyStarted), qt.IsTrue)
+	qt.Assert(t, errors.Is(err, values.ErrThreadAlreadyStarted), qt.IsTrue)
 }
 
 func TestThread_IsVoid(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
 	qt.Assert(t, th.IsVoid(), qt.IsFalse)
 
-	var nilTh *Thread
+	var nilTh *values.Thread
 	qt.Assert(t, nilTh.IsVoid(), qt.IsTrue)
 }
 
 func TestThread_EqualTo(t *testing.T) {
-	th1 := NewThread(NewSymbol("thunk"), "a")
-	th2 := NewThread(NewSymbol("thunk"), "b")
+	th1 := values.NewThread(values.NewSymbol("thunk"), "a")
+	th2 := values.NewThread(values.NewSymbol("thunk"), "b")
 	qt.Assert(t, th1.EqualTo(th1), qt.IsTrue)
 	qt.Assert(t, th1.EqualTo(th2), qt.IsFalse)
-	qt.Assert(t, th1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, th1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestThread_SchemeString(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "my-thread")
+	th := values.NewThread(values.NewSymbol("thunk"), "my-thread")
 	s := th.SchemeString()
 	qt.Assert(t, strings.Contains(s, "my-thread"), qt.IsTrue)
 	qt.Assert(t, strings.Contains(s, "new"), qt.IsTrue)
 
-	var nilTh *Thread
+	var nilTh *values.Thread
 	qt.Assert(t, nilTh.SchemeString(), qt.Equals, "#<thread:void>")
 }
 
 func TestThread_Done(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test")
+	th := values.NewThread(values.NewSymbol("thunk"), "test")
 	qt.Assert(t, th.Done(), qt.Not(qt.IsNil))
 }
 
 // --- Thread Exception Types ---
 
 func TestJoinTimeoutException_Error(t *testing.T) {
-	e := &JoinTimeoutException{}
+	e := &values.JoinTimeoutException{}
 	qt.Assert(t, e.Error(), qt.Equals, "thread-join!: timeout")
 }
 
 func TestTerminatedThreadException_Error(t *testing.T) {
-	th := NewThread(NewSymbol("thunk"), "test-thread")
-	e := &TerminatedThreadException{Thread: th}
+	th := values.NewThread(values.NewSymbol("thunk"), "test-thread")
+	e := &values.TerminatedThreadException{Thread: th}
 	qt.Assert(t, strings.Contains(e.Error(), "test-thread"), qt.IsTrue)
 
-	e2 := &TerminatedThreadException{Thread: nil}
+	e2 := &values.TerminatedThreadException{Thread: nil}
 	qt.Assert(t, e2.Error(), qt.Equals, "thread terminated")
 }
 
 func TestUncaughtThreadException_Error(t *testing.T) {
 	cause := errors.New("something broke")
-	e := &UncaughtThreadException{Reason: cause}
+	e := &values.UncaughtThreadException{Reason: cause}
 	qt.Assert(t, strings.Contains(e.Error(), "something broke"), qt.IsTrue)
 
-	e2 := &UncaughtThreadException{Reason: nil}
+	e2 := &values.UncaughtThreadException{Reason: nil}
 	qt.Assert(t, e2.Error(), qt.Equals, "uncaught exception in thread")
 }
 
 func TestUncaughtThreadException_Unwrap(t *testing.T) {
 	cause := errors.New("root cause")
-	e := &UncaughtThreadException{Reason: cause}
+	e := &values.UncaughtThreadException{Reason: cause}
 	qt.Assert(t, errors.Unwrap(e), qt.Equals, cause)
 }
 
 func TestAbandonedMutexException_Error(t *testing.T) {
-	e := &AbandonedMutexException{}
+	e := &values.AbandonedMutexException{}
 	qt.Assert(t, e.Error(), qt.Equals, "mutex abandoned by terminated thread")
 }

--- a/values/time_test.go
+++ b/values/time_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"strings"
@@ -20,17 +20,19 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 func TestTime_NewTime(t *testing.T) {
 	goTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
-	tm := NewTime(goTime)
+	tm := values.NewTime(goTime)
 	qt.Assert(t, tm, qt.Not(qt.IsNil))
 	qt.Assert(t, tm.GoTime().Equal(goTime), qt.IsTrue)
 }
 
 func TestTime_NewTimeFromSeconds(t *testing.T) {
-	tm := NewTimeFromSeconds(1000.5)
+	tm := values.NewTimeFromSeconds(1000.5)
 	qt.Assert(t, tm, qt.Not(qt.IsNil))
 
 	// Round-trip check
@@ -41,9 +43,9 @@ func TestTime_NewTimeFromSeconds(t *testing.T) {
 
 func TestTime_Seconds_RoundTrip(t *testing.T) {
 	goTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	tm := NewTime(goTime)
+	tm := values.NewTime(goTime)
 	secs := tm.Seconds()
-	tm2 := NewTimeFromSeconds(secs)
+	tm2 := values.NewTimeFromSeconds(secs)
 
 	// Should be within a microsecond
 	diff := tm.GoTime().Sub(tm2.GoTime())
@@ -52,7 +54,7 @@ func TestTime_Seconds_RoundTrip(t *testing.T) {
 
 func TestTime_CurrentTime(t *testing.T) {
 	before := time.Now()
-	tm := CurrentTime()
+	tm := values.CurrentTime()
 	after := time.Now()
 
 	qt.Assert(t, !tm.GoTime().Before(before), qt.IsTrue)
@@ -61,7 +63,7 @@ func TestTime_CurrentTime(t *testing.T) {
 
 func TestTime_Add(t *testing.T) {
 	goTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	tm := NewTime(goTime)
+	tm := values.NewTime(goTime)
 	tm2 := tm.Add(time.Hour)
 
 	expected := goTime.Add(time.Hour)
@@ -69,16 +71,16 @@ func TestTime_Add(t *testing.T) {
 }
 
 func TestTime_Sub(t *testing.T) {
-	t1 := NewTime(time.Date(2025, 1, 1, 1, 0, 0, 0, time.UTC))
-	t2 := NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	t1 := values.NewTime(time.Date(2025, 1, 1, 1, 0, 0, 0, time.UTC))
+	t2 := values.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 
 	d := t1.Sub(t2)
 	qt.Assert(t, d, qt.Equals, time.Hour)
 }
 
 func TestTime_BeforeAfter(t *testing.T) {
-	t1 := NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
-	t2 := NewTime(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+	t1 := values.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	t2 := values.NewTime(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
 
 	qt.Assert(t, t1.Before(t2), qt.IsTrue)
 	qt.Assert(t, t2.Before(t1), qt.IsFalse)
@@ -87,29 +89,29 @@ func TestTime_BeforeAfter(t *testing.T) {
 }
 
 func TestTime_IsVoid(t *testing.T) {
-	tm := CurrentTime()
+	tm := values.CurrentTime()
 	qt.Assert(t, tm.IsVoid(), qt.IsFalse)
 
-	var nilTime *Time
+	var nilTime *values.Time
 	qt.Assert(t, nilTime.IsVoid(), qt.IsTrue)
 }
 
 func TestTime_EqualTo(t *testing.T) {
 	goTime := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
-	t1 := NewTime(goTime)
-	t2 := NewTime(goTime)
-	t3 := NewTime(goTime.Add(time.Second))
+	t1 := values.NewTime(goTime)
+	t2 := values.NewTime(goTime)
+	t3 := values.NewTime(goTime.Add(time.Second))
 
 	qt.Assert(t, t1.EqualTo(t2), qt.IsTrue)
 	qt.Assert(t, t1.EqualTo(t3), qt.IsFalse)
-	qt.Assert(t, t1.EqualTo(NewInteger(1)), qt.IsFalse)
+	qt.Assert(t, t1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 }
 
 func TestTime_SchemeString(t *testing.T) {
-	tm := CurrentTime()
+	tm := values.CurrentTime()
 	s := tm.SchemeString()
 	qt.Assert(t, strings.Contains(s, "#<time"), qt.IsTrue)
 
-	var nilTime *Time
+	var nilTime *values.Time
 	qt.Assert(t, nilTime.SchemeString(), qt.Equals, "#<time:void>")
 }

--- a/values/utils_test.go
+++ b/values/utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"context"
@@ -20,32 +20,35 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func Test_List(t *testing.T) {
 	tcs := []struct {
-		in     Tuple
-		out    Tuple
+		in     values.Tuple
+		out    values.Tuple
 		expect bool
 	}{
 		{
-			in:     List(),
-			out:    EmptyList,
+			in:     values.List(),
+			out:    values.EmptyList,
 			expect: true,
 		},
 		{
-			in:     List(nil),
-			out:    NewCons(nil, EmptyList),
+			in:     values.List(nil),
+			out:    values.NewCons(nil, values.EmptyList),
 			expect: true,
 		},
 		{
-			in:     List(NewSymbol("first")),
-			out:    NewCons(NewSymbol("first"), EmptyList),
+			in:     values.List(values.NewSymbol("first")),
+			out:    values.NewCons(values.NewSymbol("first"), values.EmptyList),
 			expect: true,
 		},
 		{
-			in:     List(NewSymbol("first"), NewSymbol("second")),
-			out:    NewCons(NewSymbol("first"), NewCons(NewSymbol("second"), EmptyList)),
+			in:     values.List(values.NewSymbol("first"), values.NewSymbol("second")),
+			out:    values.NewCons(values.NewSymbol("first"), values.NewCons(values.NewSymbol("second"), values.EmptyList)),
 			expect: true,
 		},
 	}
@@ -61,62 +64,62 @@ func Test_List(t *testing.T) {
 func Test_FlipVectorToList(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   *Vector
-		out  Tuple
+		in   *values.Vector
+		out  values.Tuple
 	}{
 		{
 			name: "nil vector returns empty list",
 			in:   nil,
-			out:  EmptyList,
+			out:  values.EmptyList,
 		},
 		{
 			name: "empty vector returns empty list",
-			in:   NewVector(),
-			out:  EmptyList,
+			in:   values.NewVector(),
+			out:  values.EmptyList,
 		},
 		{
 			name: "single element vector",
-			in:   NewVector(NewInteger(1)),
-			out:  List(NewInteger(1)),
+			in:   values.NewVector(values.NewInteger(1)),
+			out:  values.List(values.NewInteger(1)),
 		},
 		{
 			name: "two element vector",
-			in:   NewVector(NewInteger(1), NewInteger(2)),
-			out:  List(NewInteger(1), NewInteger(2)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2)),
+			out:  values.List(values.NewInteger(1), values.NewInteger(2)),
 		},
 		{
 			name: "three element vector",
-			in:   NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
-			out:  List(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+			out:  values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 		},
 		{
 			name: "mixed types",
-			in:   NewVector(NewInteger(1), NewString("hello"), TrueValue),
-			out:  List(NewInteger(1), NewString("hello"), TrueValue),
+			in:   values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
+			out:  values.List(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 		},
 		{
 			name: "nested list as element",
-			in:   NewVector(List(NewInteger(1), NewInteger(2)), NewInteger(3)),
-			out:  List(List(NewInteger(1), NewInteger(2)), NewInteger(3)),
+			in:   values.NewVector(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
+			out:  values.List(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			got := VectorToList(tc.in)
-			qt.Assert(t, got, SchemeEquals, tc.out)
+			got := values.VectorToList(tc.in)
+			qt.Assert(t, got, valuestest.SchemeEquals, tc.out)
 		})
 	}
 }
 
 func Test_ForEach(t *testing.T) {
-	list := List(NewInteger(1), NewInteger(2), NewInteger(3))
+	list := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
 	count := 0
 	sum := int64(0)
 
-	tail, err := ForEach(context.TODO(), list, func(_ context.Context, _ int, _ bool, v Value) error {
+	tail, err := values.ForEach(context.TODO(), list, func(_ context.Context, _ int, _ bool, v values.Value) error {
 		count++
-		intVal, ok := v.(*Integer)
+		intVal, ok := v.(*values.Integer)
 		if ok {
 			sum += intVal.Value
 		}
@@ -124,23 +127,23 @@ func Test_ForEach(t *testing.T) {
 	})
 
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, tail, SchemeEquals, EmptyList)
+	qt.Assert(t, tail, valuestest.SchemeEquals, values.EmptyList)
 	qt.Assert(t, count, qt.Equals, 3)
 	qt.Assert(t, sum, qt.Equals, int64(6))
 }
 
 func Test_ForEach_NonTuple(t *testing.T) {
-	i := NewInteger(42)
-	tail, err := ForEach(context.TODO(), i, func(_ context.Context, _ int, _ bool, _ Value) error {
+	i := values.NewInteger(42)
+	tail, err := values.ForEach(context.TODO(), i, func(_ context.Context, _ int, _ bool, _ values.Value) error {
 		return fmt.Errorf("should not be called")
 	})
 	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, tail, SchemeEquals, i)
+	qt.Assert(t, tail, valuestest.SchemeEquals, i)
 }
 
 func Test_NewTemporaryVariableName(t *testing.T) {
-	sym1 := NewTemporaryVariableName()
-	sym2 := NewTemporaryVariableName()
+	sym1 := values.NewTemporaryVariableName()
+	sym2 := values.NewTemporaryVariableName()
 
 	qt.Assert(t, sym1.Key[:4], qt.Equals, "__T_")
 	qt.Assert(t, sym2.Key[:4], qt.Equals, "__T_")
@@ -153,7 +156,7 @@ func Test_NewTemporaryVariableName_Uniqueness(t *testing.T) {
 
 	// Generate 1000 names rapidly to test PRNG initialization and uniqueness
 	for range 1000 {
-		name := NewTemporaryVariableName()
+		name := values.NewTemporaryVariableName()
 		if seen[name.Key] {
 			c.Fatalf("duplicate name generated: %s", name.Key)
 		}
@@ -167,22 +170,22 @@ func Test_NewTemporaryVariableName_Uniqueness(t *testing.T) {
 func Test_IsList(t *testing.T) {
 	tests := []struct {
 		name string
-		in   Value
+		in   values.Value
 		out  bool
 	}{
 		{"nil is not a list", nil, false},
-		{"empty list is a list", EmptyList, true},
-		{"proper list is a list", List(NewInteger(1), NewInteger(2)), true},
-		{"improper list is not a list", NewCons(NewInteger(1), NewInteger(2)), false},
-		{"arraylist proper list is a list", NewArrayList(NewInteger(1), NewInteger(2), EmptyList), true},
-		{"arraylist improper list is not a list", NewArrayList(NewInteger(1), NewInteger(2)), false},
-		{"integer is not a list", NewInteger(42), false},
-		{"string is not a list", NewString("hello"), false},
+		{"empty list is a list", values.EmptyList, true},
+		{"proper list is a list", values.List(values.NewInteger(1), values.NewInteger(2)), true},
+		{"improper list is not a list", values.NewCons(values.NewInteger(1), values.NewInteger(2)), false},
+		{"arraylist proper list is a list", values.NewArrayList(values.NewInteger(1), values.NewInteger(2), values.EmptyList), true},
+		{"arraylist improper list is not a list", values.NewArrayList(values.NewInteger(1), values.NewInteger(2)), false},
+		{"integer is not a list", values.NewInteger(42), false},
+		{"string is not a list", values.NewString("hello"), false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			qt.Assert(t, IsList(tc.in), qt.Equals, tc.out)
+			qt.Assert(t, values.IsList(tc.in), qt.Equals, tc.out)
 		})
 	}
 }
@@ -191,98 +194,98 @@ func TestEqualTo_CircularPair(t *testing.T) {
 	c := qt.New(t)
 
 	// Self-referential pair: x = (1 . x)
-	x := NewCons(NewInteger(1), EmptyList)
+	x := values.NewCons(values.NewInteger(1), values.EmptyList)
 	x.SetCdr(x)
-	c.Assert(EqualTo(x, x), qt.IsTrue)
+	c.Assert(values.EqualTo(x, x), qt.IsTrue)
 
 	// Two structurally identical circular pairs: a = (1 . a), b = (1 . b)
-	a := NewCons(NewInteger(1), EmptyList)
+	a := values.NewCons(values.NewInteger(1), values.EmptyList)
 	a.SetCdr(a)
-	b := NewCons(NewInteger(1), EmptyList)
+	b := values.NewCons(values.NewInteger(1), values.EmptyList)
 	b.SetCdr(b)
-	c.Assert(EqualTo(a, b), qt.IsTrue)
+	c.Assert(values.EqualTo(a, b), qt.IsTrue)
 
 	// Different circular pairs: c = (1 . c), d = (2 . d)
-	d := NewCons(NewInteger(1), EmptyList)
+	d := values.NewCons(values.NewInteger(1), values.EmptyList)
 	d.SetCdr(d)
-	e := NewCons(NewInteger(2), EmptyList)
+	e := values.NewCons(values.NewInteger(2), values.EmptyList)
 	e.SetCdr(e)
-	c.Assert(EqualTo(d, e), qt.IsFalse)
+	c.Assert(values.EqualTo(d, e), qt.IsFalse)
 
 	// Circular list: (1 2 1 2 ...) vs itself
-	p1 := NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList))
-	p1.Cdr().(*Pair).SetCdr(p1)
-	p2 := NewCons(NewInteger(1), NewCons(NewInteger(2), EmptyList))
-	p2.Cdr().(*Pair).SetCdr(p2)
-	c.Assert(EqualTo(p1, p2), qt.IsTrue)
+	p1 := values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList))
+	p1.Cdr().(*values.Pair).SetCdr(p1)
+	p2 := values.NewCons(values.NewInteger(1), values.NewCons(values.NewInteger(2), values.EmptyList))
+	p2.Cdr().(*values.Pair).SetCdr(p2)
+	c.Assert(values.EqualTo(p1, p2), qt.IsTrue)
 }
 
 func TestEqualTo_CircularVector(t *testing.T) {
 	c := qt.New(t)
 
 	// Vector containing itself: #(v)
-	v := NewVector(NewInteger(0))
+	v := values.NewVector(values.NewInteger(0))
 	v.Set(0, v)
-	c.Assert(EqualTo(v, v), qt.IsTrue)
+	c.Assert(values.EqualTo(v, v), qt.IsTrue)
 
 	// Two vectors each containing themselves
-	v1 := NewVector(NewInteger(0))
+	v1 := values.NewVector(values.NewInteger(0))
 	v1.Set(0, v1)
-	v2 := NewVector(NewInteger(0))
+	v2 := values.NewVector(values.NewInteger(0))
 	v2.Set(0, v2)
-	c.Assert(EqualTo(v1, v2), qt.IsTrue)
+	c.Assert(values.EqualTo(v1, v2), qt.IsTrue)
 }
 
 func TestEqualTo_NonCircular(t *testing.T) {
 	c := qt.New(t)
 
 	// Ensure non-circular comparisons still work
-	c.Assert(EqualTo(List(NewInteger(1), NewInteger(2)), List(NewInteger(1), NewInteger(2))), qt.IsTrue)
-	c.Assert(EqualTo(List(NewInteger(1)), List(NewInteger(2))), qt.IsFalse)
-	c.Assert(EqualTo(NewVector(NewInteger(1)), NewVector(NewInteger(1))), qt.IsTrue)
-	c.Assert(EqualTo(NewVector(NewInteger(1)), NewVector(NewInteger(2))), qt.IsFalse)
-	c.Assert(EqualTo(NewInteger(42), NewInteger(42)), qt.IsTrue)
-	c.Assert(EqualTo(nil, nil), qt.IsTrue)
+	c.Assert(values.EqualTo(values.List(values.NewInteger(1), values.NewInteger(2)), values.List(values.NewInteger(1), values.NewInteger(2))), qt.IsTrue)
+	c.Assert(values.EqualTo(values.List(values.NewInteger(1)), values.List(values.NewInteger(2))), qt.IsFalse)
+	c.Assert(values.EqualTo(values.NewVector(values.NewInteger(1)), values.NewVector(values.NewInteger(1))), qt.IsTrue)
+	c.Assert(values.EqualTo(values.NewVector(values.NewInteger(1)), values.NewVector(values.NewInteger(2))), qt.IsFalse)
+	c.Assert(values.EqualTo(values.NewInteger(42), values.NewInteger(42)), qt.IsTrue)
+	c.Assert(values.EqualTo(nil, nil), qt.IsTrue)
 }
 
 func Test_ExactInteger(t *testing.T) {
 	tests := []struct {
 		name   string
-		in     Value
+		in     values.Value
 		want   int64
 		wantOk bool
 	}{
 		// Integer cases
-		{"positive integer", NewInteger(42), 42, true},
-		{"zero integer", NewInteger(0), 0, true},
-		{"negative integer", NewInteger(-5), -5, true},
-		{"max int64", NewInteger(9223372036854775807), 9223372036854775807, true},
+		{"positive integer", values.NewInteger(42), 42, true},
+		{"zero integer", values.NewInteger(0), 0, true},
+		{"negative integer", values.NewInteger(-5), -5, true},
+		{"max int64", values.NewInteger(9223372036854775807), 9223372036854775807, true},
 
 		// BigInteger cases
-		{"small bigint", NewBigIntegerFromInt64(100), 100, true},
-		{"bigint at int64 max", NewBigIntegerFromString("9223372036854775807", 10), 9223372036854775807, true},
-		{"bigint too large", NewBigIntegerFromString("9223372036854775808", 10), 0, false},
+		{"small bigint", values.NewBigIntegerFromInt64(100), 100, true},
+		{"bigint at int64 max", values.NewBigIntegerFromString("9223372036854775807", 10), 9223372036854775807, true},
+		{"bigint too large", values.NewBigIntegerFromString("9223372036854775808", 10), 0, false},
 
 		// Rational cases - integers
-		{"rational 2/1", NewRational(2, 1), 2, true},
-		{"rational 0/1", NewRational(0, 1), 0, true},
-		{"rational -3/1", NewRational(-3, 1), -3, true},
+		{"rational 2/1", values.NewRational(2, 1), 2, true},
+		{"rational 0/1", values.NewRational(0, 1), 0, true},
+		{"rational -3/1", values.NewRational(-3, 1), -3, true},
 
 		// Rational cases - non-integers
-		{"rational 1/2", NewRational(1, 2), 0, false},
-		{"rational 5/3", NewRational(5, 3), 0, false},
+		{"rational 1/2", values.NewRational(1, 2), 0, false},
+		{"rational 5/3", values.NewRational(5, 3), 0, false},
 
 		// Non-numeric types
-		{"float", NewFloat(2.0), 0, false},
-		{"string", NewString("2"), 0, false},
-		{"symbol", NewSymbol("x"), 0, false},
+		{"float", values.NewFloat(2.0), 0, false},
+		{"string", values.NewString("2"), 0, false},
+		{"symbol", values.NewSymbol("x"), 0, false},
 		{"nil", nil, 0, false},
-		{"pair", NewCons(NewInteger(1), EmptyList), 0, false},
+		{"pair", values.NewCons(values.NewInteger(1), values.EmptyList), 0, false},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := ExactInteger(tc.in)
+			got, ok := values.ExactInteger(tc.in)
 			qt.Assert(t, ok, qt.Equals, tc.wantOk)
 			if tc.wantOk {
 				qt.Assert(t, got, qt.Equals, tc.want)

--- a/values/value_methods_coverage_test.go
+++ b/values/value_methods_coverage_test.go
@@ -12,37 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
 )
 
 // NativeError comprehensive coverage
 
 func TestNativeError_NewNativeError(t *testing.T) {
 	c := qt.New(t)
-	err := NewNativeError("something went wrong")
+	err := values.NewNativeError("something went wrong")
 	c.Assert(err.Message().Datum(), qt.Equals, "something went wrong")
 	c.Assert(err.Irritants().IsVoid(), qt.IsFalse) // EmptyList is not void
-	c.Assert(err.Kind(), qt.Equals, NativeErrorKindGeneric)
+	c.Assert(err.Kind(), qt.Equals, values.NativeErrorKindGeneric)
 	c.Assert(err.Error(), qt.Equals, "something went wrong")
 }
 
 func TestNativeError_NewErrorObject(t *testing.T) {
 	c := qt.New(t)
-	err := NewErrorObject("bad value", NewInteger(42), NewString("extra"))
+	err := values.NewErrorObject("bad value", values.NewInteger(42), values.NewString("extra"))
 	c.Assert(err.Message().Datum(), qt.Equals, "bad value")
-	c.Assert(err.Kind(), qt.Equals, NativeErrorKindGeneric)
+	c.Assert(err.Kind(), qt.Equals, values.NativeErrorKindGeneric)
 }
 
 func TestNativeError_NewErrorObjectWithCause(t *testing.T) {
 	c := qt.New(t)
 	cause := errors.New("root cause")
-	err := NewErrorObjectWithCause("wrapped", cause, NewInteger(1))
+	err := values.NewErrorObjectWithCause("wrapped", cause, values.NewInteger(1))
 	c.Assert(err.Datum(), qt.Equals, cause)
 	c.Assert(err.Unwrap(), qt.Equals, cause)
 	c.Assert(err.Error(), qt.Equals, "wrapped")
@@ -50,45 +52,45 @@ func TestNativeError_NewErrorObjectWithCause(t *testing.T) {
 
 func TestNativeError_IsVoid(t *testing.T) {
 	c := qt.New(t)
-	err := NewNativeError("test")
+	err := values.NewNativeError("test")
 	c.Assert(err.IsVoid(), qt.IsFalse)
 
-	var nilErr *NativeError
+	var nilErr *values.NativeError
 	c.Assert(nilErr.IsVoid(), qt.IsTrue)
 }
 
 func TestNativeError_SchemeString(t *testing.T) {
 	c := qt.New(t)
-	err := NewNativeError("hello")
+	err := values.NewNativeError("hello")
 	c.Assert(err.SchemeString(), qt.Equals, `#<error-object "hello">`)
 
-	var nilErr *NativeError
+	var nilErr *values.NativeError
 	c.Assert(nilErr.SchemeString(), qt.Equals, "#<error-object>")
 }
 
 func TestNativeError_EqualTo_Coverage(t *testing.T) {
 	c := qt.New(t)
 
-	err1 := NewErrorObject("msg", NewInteger(1))
-	err2 := NewErrorObject("msg", NewInteger(1))
-	err3 := NewErrorObject("other", NewInteger(1))
-	err4 := NewReadError("msg", NewInteger(1))
+	err1 := values.NewErrorObject("msg", values.NewInteger(1))
+	err2 := values.NewErrorObject("msg", values.NewInteger(1))
+	err3 := values.NewErrorObject("other", values.NewInteger(1))
+	err4 := values.NewReadError("msg", values.NewInteger(1))
 
 	c.Assert(err1.EqualTo(err1), qt.IsTrue)
 	c.Assert(err1.EqualTo(err2), qt.IsTrue)
 	c.Assert(err1.EqualTo(err3), qt.IsFalse) // different message
 	c.Assert(err1.EqualTo(err4), qt.IsFalse) // different kind
-	c.Assert(err1.EqualTo(NewInteger(1)), qt.IsFalse)
+	c.Assert(err1.EqualTo(values.NewInteger(1)), qt.IsFalse)
 
-	var nilErr *NativeError
+	var nilErr *values.NativeError
 	c.Assert(nilErr.EqualTo(nilErr), qt.IsTrue)
 }
 
 func TestNativeError_NilReceiver(t *testing.T) {
 	c := qt.New(t)
-	var nilErr *NativeError
+	var nilErr *values.NativeError
 	c.Assert(nilErr.Message(), qt.IsNil)
-	c.Assert(nilErr.Kind(), qt.Equals, NativeErrorKindGeneric)
+	c.Assert(nilErr.Kind(), qt.Equals, values.NativeErrorKindGeneric)
 	c.Assert(nilErr.Datum(), qt.IsNil)
 	c.Assert(nilErr.Unwrap(), qt.IsNil)
 	c.Assert(nilErr.Error(), qt.Equals, "")
@@ -98,10 +100,10 @@ func TestNativeError_NilReceiver(t *testing.T) {
 
 func TestNativeError_Irritants(t *testing.T) {
 	c := qt.New(t)
-	err := NewErrorObject("msg", NewInteger(1), NewString("two"))
+	err := values.NewErrorObject("msg", values.NewInteger(1), values.NewString("two"))
 	irr := err.Irritants()
 	c.Assert(irr, qt.IsNotNil)
 
-	var nilErr *NativeError
-	c.Assert(nilErr.Irritants(), qt.Equals, EmptyList)
+	var nilErr *values.NativeError
+	c.Assert(nilErr.Irritants(), qt.Equals, values.EmptyList)
 }

--- a/values/valuestest/scheme_equals.go
+++ b/values/valuestest/scheme_equals.go
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+// Package valuestest provides test helpers for the values package.
+package valuestest
 
 import (
 	"errors"
 	"fmt"
 	"reflect"
 
+	"github.com/aalpar/wile/values"
+
 	qt "github.com/frankban/quicktest"
 )
 
 // SchemeEquals is a quicktest checker for Scheme value equality.
-var SchemeEquals qt.Checker = &schemeEqualsChecker{}
+var SchemeEquals qt.Checker = &schemeEqualsChecker{} //nolint:gocritic // test helper, not Scheme runtime
 
 type schemeEqualsChecker struct{}
 
@@ -37,7 +40,7 @@ func (p *schemeEqualsChecker) Check(got any, args []any, note func(key string, v
 		// A panic is raised when the provided args are not comparable.
 		r := recover()
 		if r != nil {
-			err = fmt.Errorf("%s", r) //nolint:gocritic // quicktest checker, not Scheme runtime
+			err = fmt.Errorf("%s", r) //nolint:gocritic // test helper, not Scheme runtime
 		}
 	}()
 
@@ -46,7 +49,7 @@ func (p *schemeEqualsChecker) Check(got any, args []any, note func(key string, v
 	// Customize error message for non-nil errors.
 	_, ok := got.(error)
 	if ok && got == nil {
-		return errors.New("got non-nil error") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("got non-nil error") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
 	// Show error types when comparing errors with different types.
@@ -61,19 +64,19 @@ func (p *schemeEqualsChecker) Check(got any, args []any, note func(key string, v
 				note("want type", qt.Unquoted(wantType.String()))
 			}
 		}
-		return errors.New("values are not equal") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("values are not equal") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
-	gotValue, ok0 := got.(Value)
-	wantValue, ok1 := want.(Value)
+	gotValue, ok0 := got.(values.Value)
+	wantValue, ok1 := want.(values.Value)
 	if !ok0 || !ok1 {
-		return errors.New("got and want must be of type Datum") //nolint:gocritic // quicktest checker, not Scheme runtime
+		return errors.New("got and want must be of type Datum") //nolint:gocritic // test helper, not Scheme runtime
 	}
 
 	// Binding(nil).(Binding) == false so check
-	if EqualTo(gotValue, wantValue) {
+	if values.EqualTo(gotValue, wantValue) {
 		return nil
 	}
 
-	return errors.New("values are not equal") //nolint:gocritic // quicktest checker, not Scheme runtime
+	return errors.New("values are not equal") //nolint:gocritic // test helper, not Scheme runtime
 }

--- a/values/valuestest/scheme_equals_test.go
+++ b/values/valuestest/scheme_equals_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valuestest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestSchemeEquals(t *testing.T) {
+	checker := SchemeEquals
+	qt.Assert(t, checker.ArgNames(), qt.DeepEquals, []string{"got", "want"})
+
+	a := values.NewInteger(42)
+	b := values.NewInteger(42)
+	c := values.NewInteger(99)
+
+	err := checker.Check(a, []any{b}, nil)
+	qt.Assert(t, err, qt.IsNil)
+
+	err = checker.Check(a, []any{c}, nil)
+	qt.Assert(t, err, qt.IsNotNil)
+}
+
+func TestSchemeEqualsEdgeCases(t *testing.T) {
+	c := qt.New(t)
+	checker := SchemeEquals
+
+	t.Run("panic recovery on nil args", func(t *testing.T) {
+		err := checker.Check(values.NewInteger(1), nil, nil)
+		c.Assert(err, qt.IsNotNil)
+	})
+
+	t.Run("got is error want is error different types", func(t *testing.T) {
+		gotErr := values.WrapForeignErrorf(values.ErrNotANumber, "test")
+		wantErr := errors.New("test")
+		var noteKeys []string
+		note := func(key string, value any) {
+			noteKeys = append(noteKeys, key)
+		}
+		err := checker.Check(gotErr, []any{wantErr}, note)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+		c.Assert(noteKeys, qt.DeepEquals, []string{"got type", "want type"})
+	})
+
+	t.Run("got is error want is error same type", func(t *testing.T) {
+		gotErr := errors.New("a")
+		wantErr := errors.New("b")
+		var noteKeys []string
+		note := func(key string, value any) {
+			noteKeys = append(noteKeys, key)
+		}
+		err := checker.Check(gotErr, []any{wantErr}, note)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+		c.Assert(len(noteKeys), qt.Equals, 0)
+	})
+
+	t.Run("got is error want is non-error", func(t *testing.T) {
+		err := checker.Check(errors.New("oops"), []any{values.NewInteger(1)}, nil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "values are not equal")
+	})
+
+	t.Run("non-Value arguments", func(t *testing.T) {
+		err := checker.Check("not a value", []any{"also not"}, nil)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Equals, "got and want must be of type Datum")
+	})
+}

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -12,55 +12,58 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package values
+package values_test
 
 import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/values"
+	"github.com/aalpar/wile/values/valuestest"
 )
 
 func TestVectorCreation(t *testing.T) {
 	tcs := []struct {
 		name   string
-		values []Value
+		values []values.Value
 		length int
 	}{
 		{
 			name:   "empty vector",
-			values: []Value{},
+			values: []values.Value{},
 			length: 0,
 		},
 		{
 			name:   "single element",
-			values: []Value{NewInteger(1)},
+			values: []values.Value{values.NewInteger(1)},
 			length: 1,
 		},
 		{
 			name:   "two elements",
-			values: []Value{NewInteger(1), NewInteger(2)},
+			values: []values.Value{values.NewInteger(1), values.NewInteger(2)},
 			length: 2,
 		},
 		{
 			name:   "three elements",
-			values: []Value{NewInteger(1), NewInteger(2), NewInteger(3)},
+			values: []values.Value{values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)},
 			length: 3,
 		},
 		{
 			name:   "mixed types",
-			values: []Value{NewInteger(1), NewString("hello"), TrueValue},
+			values: []values.Value{values.NewInteger(1), values.NewString("hello"), values.TrueValue},
 			length: 3,
 		},
 		{
 			name:   "nil element",
-			values: []Value{nil},
+			values: []values.Value{nil},
 			length: 1,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			v := NewVector(tc.values...)
+			v := values.NewVector(tc.values...)
 			qt.Assert(t, v, qt.Not(qt.IsNil))
 			qt.Assert(t, len(*v), qt.Equals, tc.length)
 		})
@@ -70,10 +73,10 @@ func TestVectorCreation(t *testing.T) {
 func TestVectorDatum(t *testing.T) {
 	tcs := []struct {
 		name   string
-		in     *Vector
+		in     *values.Vector
 		isNil  bool
 		length int
-		values []Value
+		values []values.Value
 	}{
 		{
 			name:  "nil vector returns nil",
@@ -82,26 +85,26 @@ func TestVectorDatum(t *testing.T) {
 		},
 		{
 			name:   "empty vector returns empty slice",
-			in:     NewVector(),
+			in:     values.NewVector(),
 			length: 0,
 		},
 		{
 			name:   "single element",
-			in:     NewVector(NewInteger(42)),
+			in:     values.NewVector(values.NewInteger(42)),
 			length: 1,
-			values: []Value{NewInteger(42)},
+			values: []values.Value{values.NewInteger(42)},
 		},
 		{
 			name:   "multiple elements",
-			in:     NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:     values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 			length: 3,
-			values: []Value{NewInteger(1), NewInteger(2), NewInteger(3)},
+			values: []values.Value{values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)},
 		},
 		{
 			name:   "mixed types",
-			in:     NewVector(NewInteger(1), NewString("hello"), TrueValue),
+			in:     values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 			length: 3,
-			values: []Value{NewInteger(1), NewString("hello"), TrueValue},
+			values: []values.Value{values.NewInteger(1), values.NewString("hello"), values.TrueValue},
 		},
 	}
 
@@ -113,7 +116,7 @@ func TestVectorDatum(t *testing.T) {
 			} else {
 				qt.Assert(t, datum, qt.HasLen, tc.length)
 				for i, v := range tc.values {
-					qt.Assert(t, datum[i], SchemeEquals, v)
+					qt.Assert(t, datum[i], valuestest.SchemeEquals, v)
 				}
 			}
 		})
@@ -123,7 +126,7 @@ func TestVectorDatum(t *testing.T) {
 func TestVectorIsVoid(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   *Vector
+		in   *values.Vector
 		out  bool
 	}{
 		{
@@ -133,17 +136,17 @@ func TestVectorIsVoid(t *testing.T) {
 		},
 		{
 			name: "empty vector is not void",
-			in:   NewVector(),
+			in:   values.NewVector(),
 			out:  false,
 		},
 		{
 			name: "single element vector is not void",
-			in:   NewVector(NewInteger(1)),
+			in:   values.NewVector(values.NewInteger(1)),
 			out:  false,
 		},
 		{
 			name: "multiple element vector is not void",
-			in:   NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 			out:  false,
 		},
 	}
@@ -158,80 +161,80 @@ func TestVectorIsVoid(t *testing.T) {
 func TestVectorEqualTo(t *testing.T) {
 	tcs := []struct {
 		name string
-		a    *Vector
-		b    Value
+		a    *values.Vector
+		b    values.Value
 		out  bool
 	}{
 		{
 			name: "equal vectors same content",
-			a:    NewVector(NewInteger(1), NewInteger(2)),
-			b:    NewVector(NewInteger(1), NewInteger(2)),
+			a:    values.NewVector(values.NewInteger(1), values.NewInteger(2)),
+			b:    values.NewVector(values.NewInteger(1), values.NewInteger(2)),
 			out:  true,
 		},
 		{
 			name: "different content same length",
-			a:    NewVector(NewInteger(1), NewInteger(2)),
-			b:    NewVector(NewInteger(2), NewInteger(1)),
+			a:    values.NewVector(values.NewInteger(1), values.NewInteger(2)),
+			b:    values.NewVector(values.NewInteger(2), values.NewInteger(1)),
 			out:  false,
 		},
 		{
 			name: "different lengths",
-			a:    NewVector(NewInteger(1), NewInteger(2)),
-			b:    NewVector(NewInteger(1)),
+			a:    values.NewVector(values.NewInteger(1), values.NewInteger(2)),
+			b:    values.NewVector(values.NewInteger(1)),
 			out:  false,
 		},
 		{
 			name: "empty vectors equal",
-			a:    NewVector(),
-			b:    NewVector(),
+			a:    values.NewVector(),
+			b:    values.NewVector(),
 			out:  true,
 		},
 		{
 			name: "comparison with non-vector",
-			a:    NewVector(NewInteger(1)),
-			b:    NewInteger(1),
+			a:    values.NewVector(values.NewInteger(1)),
+			b:    values.NewInteger(1),
 			out:  false,
 		},
 		{
 			name: "comparison with nil vector",
-			a:    NewVector(NewInteger(1)),
-			b:    (*Vector)(nil),
+			a:    values.NewVector(values.NewInteger(1)),
+			b:    (*values.Vector)(nil),
 			out:  false,
 		},
 		{
 			name: "nil vectors equal",
 			a:    nil,
-			b:    (*Vector)(nil),
+			b:    (*values.Vector)(nil),
 			out:  true,
 		},
 		{
 			name: "single element equal",
-			a:    NewVector(NewInteger(42)),
-			b:    NewVector(NewInteger(42)),
+			a:    values.NewVector(values.NewInteger(42)),
+			b:    values.NewVector(values.NewInteger(42)),
 			out:  true,
 		},
 		{
 			name: "nested vectors equal",
-			a:    NewVector(NewVector(NewInteger(1), NewInteger(2))),
-			b:    NewVector(NewVector(NewInteger(1), NewInteger(2))),
+			a:    values.NewVector(values.NewVector(values.NewInteger(1), values.NewInteger(2))),
+			b:    values.NewVector(values.NewVector(values.NewInteger(1), values.NewInteger(2))),
 			out:  true,
 		},
 		{
 			name: "nested vectors different",
-			a:    NewVector(NewVector(NewInteger(1), NewInteger(2))),
-			b:    NewVector(NewVector(NewInteger(1), NewInteger(3))),
+			a:    values.NewVector(values.NewVector(values.NewInteger(1), values.NewInteger(2))),
+			b:    values.NewVector(values.NewVector(values.NewInteger(1), values.NewInteger(3))),
 			out:  false,
 		},
 		{
 			name: "mixed types equal",
-			a:    NewVector(NewInteger(1), NewString("hello"), TrueValue),
-			b:    NewVector(NewInteger(1), NewString("hello"), TrueValue),
+			a:    values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
+			b:    values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 			out:  true,
 		},
 		{
 			name: "mixed types different",
-			a:    NewVector(NewInteger(1), NewString("hello")),
-			b:    NewVector(NewInteger(1), NewString("world")),
+			a:    values.NewVector(values.NewInteger(1), values.NewString("hello")),
+			b:    values.NewVector(values.NewInteger(1), values.NewString("world")),
 			out:  false,
 		},
 	}
@@ -246,47 +249,47 @@ func TestVectorEqualTo(t *testing.T) {
 func TestVectorSchemeString(t *testing.T) {
 	tcs := []struct {
 		name string
-		in   *Vector
+		in   *values.Vector
 		out  string
 	}{
 		{
 			name: "empty vector",
-			in:   NewVector(),
+			in:   values.NewVector(),
 			out:  "#()",
 		},
 		{
 			name: "single element",
-			in:   NewVector(NewInteger(42)),
+			in:   values.NewVector(values.NewInteger(42)),
 			out:  "#( 42 )",
 		},
 		{
 			name: "two elements",
-			in:   NewVector(NewInteger(1), NewInteger(2)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2)),
 			out:  "#( 1 2 )",
 		},
 		{
 			name: "three elements",
-			in:   NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 			out:  "#( 1 2 3 )",
 		},
 		{
 			name: "mixed types",
-			in:   NewVector(NewInteger(1), NewString("hello"), TrueValue),
+			in:   values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 			out:  "#( 1 \"hello\" #t )",
 		},
 		{
 			name: "nested vector",
-			in:   NewVector(NewVector(NewInteger(1), NewInteger(2)), NewInteger(3)),
+			in:   values.NewVector(values.NewVector(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
 			out:  "#( #( 1 2 ) 3 )",
 		},
 		{
 			name: "nested list",
-			in:   NewVector(List(NewInteger(1), NewInteger(2)), NewInteger(3)),
+			in:   values.NewVector(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
 			out:  "#( (1 2) 3 )",
 		},
 		{
 			name: "symbols",
-			in:   NewVector(NewSymbol("a"), NewSymbol("b")),
+			in:   values.NewVector(values.NewSymbol("a"), values.NewSymbol("b")),
 			out:  "#( a b )",
 		},
 	}
@@ -301,8 +304,8 @@ func TestVectorSchemeString(t *testing.T) {
 func TestVectorAsList(t *testing.T) {
 	tcs := []struct {
 		name  string
-		in    *Vector
-		out   Tuple
+		in    *values.Vector
+		out   values.Tuple
 		isNil bool
 	}{
 		{
@@ -312,33 +315,33 @@ func TestVectorAsList(t *testing.T) {
 		},
 		{
 			name: "empty vector returns empty list",
-			in:   NewVector(),
-			out:  EmptyList,
+			in:   values.NewVector(),
+			out:  values.EmptyList,
 		},
 		{
 			name: "single element vector",
-			in:   NewVector(NewInteger(42)),
-			out:  List(NewInteger(42)),
+			in:   values.NewVector(values.NewInteger(42)),
+			out:  values.List(values.NewInteger(42)),
 		},
 		{
 			name: "two element vector",
-			in:   NewVector(NewInteger(1), NewInteger(2)),
-			out:  List(NewInteger(1), NewInteger(2)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2)),
+			out:  values.List(values.NewInteger(1), values.NewInteger(2)),
 		},
 		{
 			name: "three element vector",
-			in:   NewVector(NewInteger(1), NewInteger(2), NewInteger(3)),
-			out:  List(NewInteger(1), NewInteger(2), NewInteger(3)),
+			in:   values.NewVector(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+			out:  values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
 		},
 		{
 			name: "mixed types",
-			in:   NewVector(NewInteger(1), NewString("hello"), TrueValue),
-			out:  List(NewInteger(1), NewString("hello"), TrueValue),
+			in:   values.NewVector(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
+			out:  values.List(values.NewInteger(1), values.NewString("hello"), values.TrueValue),
 		},
 		{
 			name: "nested list as element",
-			in:   NewVector(List(NewInteger(1), NewInteger(2)), NewInteger(3)),
-			out:  List(List(NewInteger(1), NewInteger(2)), NewInteger(3)),
+			in:   values.NewVector(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
+			out:  values.List(values.List(values.NewInteger(1), values.NewInteger(2)), values.NewInteger(3)),
 		},
 	}
 
@@ -348,7 +351,7 @@ func TestVectorAsList(t *testing.T) {
 			if tc.isNil {
 				qt.Assert(t, got, qt.IsNil)
 			} else {
-				qt.Assert(t, got, SchemeEquals, tc.out)
+				qt.Assert(t, got, valuestest.SchemeEquals, tc.out)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Move `SchemeEquals` checker from production `values` package to `values/valuestest/` sub-package, eliminating `github.com/frankban/quicktest` (and 6 transitive deps) from the production import graph
- Convert all 45 `values/` test files from `package values` to `package values_test` (black-box testing)
- Update 138 external test files to use `valuestest.SchemeEquals`
- Move `internal/syntax/syntax_equals.go` to `syntaxtest/` sub-package (same pattern)

The `values` package now has **zero third-party production dependencies**.

## Test plan

- [x] `go build ./values/...` — no quicktest in production imports
- [x] `go list -deps github.com/aalpar/wile/values` — all stdlib
- [x] `go test ./...` — all packages pass
- [x] `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)