### PR TITLE
docs: add sandboxing, dialect, and module decomposition plans

### DIFF
--- a/plans/CLAUDE.md
+++ b/plans/CLAUDE.md
@@ -41,7 +41,10 @@ When investigating R7RS conformance issues:
 |------|---------|--------|
 | `EXTERNAL_EXTENSIONS_PLAN.md` | Public extension system — Phase 5 + Tier 2 remaining | Phase 5+ remaining |
 | `PLUGIN_SHADOWING_DESIGN.md` | Primitive shadowing for extensions | Proposed |
-| `AUTHORIZATION_FRAMEWORK.md` | K8s-style verb+resource authorization for sandboxing | Proposed |
+| `SANDBOXING_MODEL.md` | Extension-level sandboxing: security classification, SafeExtensions API, isolation tests | Proposed |
+| `AUTHORIZATION_FRAMEWORK.md` | K8s-style verb+resource authorization for sandboxing (fine-grained layer) | Proposed |
+| `DIALECT_SYSTEM.md` | Multi-dialect support: de-globalize forms registry, Dialect type, extract R7RS as default | Proposed |
+| `MODULE_DECOMPOSITION.md` | Split extensions into separate Go modules: core boundary, extraction order, go workspace | Proposed |
 | `FUSED_LEXING_PARSING.md` | Flap paper analysis + sketch for fusing tokenizer into parser | Research |
 
 ### Architectural Review

--- a/plans/DIALECT_SYSTEM.md
+++ b/plans/DIALECT_SYSTEM.md
@@ -1,0 +1,263 @@
+# Plan: Dialect System
+
+**Status**: Proposed
+**Date**: 2026-02-20
+**Related**: `SANDBOXING_MODEL.md` (prerequisite patterns), `docs/EXTENSIONS.md`
+
+## Motivation
+
+Wile's engine is language-agnostic below the surface. The bytecode VM, continuation model, scope system, and eval stack don't encode R7RS — they encode "a Lisp with hygienic macros." The R7RS personality lives in four configurable layers on top. Three of these layers are already per-engine configurable. One isn't.
+
+Making all four layers configurable turns Wile from "an R7RS implementation" into "a Lisp platform that ships with R7RS as the default dialect." An embedder could use R6RS, a custom DSL, or a Clojure-flavored Lisp — same VM, different personality.
+
+This aligns with "embedding is the product": embedders choose not just which capabilities their engine has, but which *language* it speaks.
+
+## Architecture: Four Layers of Language Personality
+
+```
+┌──────────────────────────────────────────────────────┐
+│ Layer 1: Runtime Primitives           [per-registry] │
+│ What: names, arities, implementations                │
+│ Examples: car/cdr, +/-, string-ref, eval             │
+│ Configurable today: YES (WithRegistry, WithExtension)│
+└──────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│ Layer 2: Bootstrap Macros             [per-registry] │
+│ What: derived forms as Scheme source text             │
+│ Examples: and, or, let, cond, guard, define-values   │
+│ Configurable today: YES (AddMacroSource)             │
+└──────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│ Layer 3: Syntax Compilers + Expanders [per-environment]│
+│ What: how special forms are expanded and compiled     │
+│ Examples: define-syntax, import, syntax-case          │
+│ Configurable today: YES (RegisterSyntaxCompilers is  │
+│   a data table bound per-environment)                │
+└──────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────┐
+│ Layer 4: Forms Registry                    [GLOBAL]  │
+│ What: core form validators + compilers               │
+│ Examples: if, lambda, define, set!, quote, begin     │
+│ Configurable today: NO — package-level global in     │
+│   internal/forms/form_spec.go:58                     │
+│ THIS IS THE ONLY STRUCTURAL BLOCKER                  │
+└──────────────────────────────────────────────────────┘
+```
+
+## The Blocker: Global Forms Registry
+
+`internal/forms/form_spec.go:58`:
+
+```go
+var registry = make(map[string]*FormSpec)
+```
+
+Populated by `init()` in `machine/register.go`. Maps form names (`"if"`, `"lambda"`, `"define"`, `"set!"`, `"quote"`, `"begin"`, `"quasiquote"`, `"dynamic-wind"`) to validator + compiler function pairs. Every engine in the same process shares this map.
+
+**Why it's global:** The forms registry is used by both the validator (`internal/validate/`) and the compiler (`machine/compile_validated.go:53`). The validator needs to know "is this name a special form?" to produce the right `ValidatedExpr` type. The compiler needs to know "which compiler handles this form?" to emit bytecode. Both currently call `forms.Lookup()` which hits the global.
+
+**Two-tier dispatch** (`machine/syntax_compilers_registry.go:29-34`):
+
+- **Tier 1 (Validated Forms)**: `if`, `lambda`, `define`, `set!`, `quote`, `begin`, `quasiquote`, `dynamic-wind`, `case-lambda` — go through the validation layer to produce typed `ValidatedExpr` nodes, then compile via `compileValidated*` methods. Registered in the global forms registry.
+- **Tier 2 (Registry Forms)**: `define-syntax`, `import`, `syntax-case`, `include`, `cond-expand`, etc. — pass through validation as `ValidatedLiteral`, dispatched via the per-environment syntax compiler table.
+
+Tier 2 is already per-environment. Only Tier 1 is global.
+
+## What a Dialect Bundles
+
+```go
+// Dialect defines a complete language personality for a Wile engine.
+type Dialect struct {
+    // Layer 1: runtime primitives and their names
+    Registry func(*registry.Registry) error
+
+    // Layer 2: derived forms as Scheme source
+    MacroSources []string
+
+    // Layer 3: syntax compilers (Tier 2 forms)
+    SyntaxCompilers func(*environment.EnvironmentFrame) error
+
+    // Layer 3: primitive expanders
+    PrimitiveExpanders func(*environment.EnvironmentFrame) error
+
+    // Layer 4: core form validators + compilers (Tier 1 forms)
+    FormSpecs map[string]*forms.FormSpec
+
+    // Compile-time binding names (special forms + auxiliary syntax)
+    CompileTimeBindings []string
+
+    // Features for cond-expand
+    Features []string
+}
+```
+
+Usage:
+
+```go
+eng, err := wile.NewEngine(ctx,
+    wile.WithDialect(r7rs.Dialect),
+    wile.WithExtension(files.Extension),
+    wile.WithLibraryPaths("./lib"),
+)
+```
+
+`r7rs.Dialect` is the default — identical to today's behavior. If no dialect is specified, `NewEngine` uses R7RS.
+
+## Dialect Variations: What Changes Where
+
+### R6RS
+
+| What changes | Layer | Detail |
+|-------------|-------|--------|
+| Library syntax | 3 | R6RS `(library ...)` has fixed-order declarations (export, import, body). Different syntax compiler for `library`. R7RS `define-library` allows any-order declarations. |
+| Condition system | 1+2 | `&condition`, `&assertion`, `condition`, `make-assertion-violation` — new primitives + macros replacing R7RS `error` objects |
+| Error strictness | 1 | R6RS "must raise" vs R7RS "is an error" (undefined). Primitives check a strictness flag or are separate implementations. |
+| Records | 1+2 | R6RS `define-record-type` with inheritance, sealed, opaque — richer than R7RS SRFI-9 style |
+| `syntax-case` emphasis | already supported | Both `syntax-rules` and `syntax-case` work today |
+| Hashtables | 1 | R6RS `(rnrs hashtables)` has different API from Wile's current hashtables |
+| Tail context strictness | 4 | R6RS requires tail position in more contexts (e.g., `let-values`) |
+| `import` semantics | 3 | R6RS `import` only inside `library`, not at top-level (different expander rule) |
+
+### Custom Lisp / DSL
+
+| What changes | Layer | Detail |
+|-------------|-------|--------|
+| Rename special forms | 4 | `fn` instead of `lambda`, `def` instead of `define` |
+| Rename primitives | 1 | `first`/`rest` instead of `car`/`cdr` |
+| Different derived forms | 2 | Clojure-style `defn`, `let` with vector bindings |
+| Remove mutation | 1+4 | No `set!`, `set-car!`, `set-cdr!` — remove from forms registry + primitives |
+| Add new types | values pkg | Persistent vectors, atoms, keywords — deeper change, outside dialect system |
+
+## Concrete Work Items
+
+### Phase 1: De-globalize the forms registry
+
+Replace the global `map[string]*FormSpec` in `internal/forms/form_spec.go` with a `FormRegistry` type that can be instantiated per-engine.
+
+**Current:**
+
+```go
+// internal/forms/form_spec.go:58
+var registry = make(map[string]*FormSpec)
+
+func Lookup(name string) *FormSpec {
+    return registry[name]
+}
+```
+
+**Proposed:**
+
+```go
+type FormRegistry struct {
+    specs map[string]*FormSpec
+}
+
+func NewFormRegistry() *FormRegistry { ... }
+func (r *FormRegistry) Register(spec *FormSpec) { ... }
+func (r *FormRegistry) Lookup(name string) *FormSpec { ... }
+func (r *FormRegistry) Clone() *FormRegistry { ... }
+```
+
+A default `FormRegistry` is built once (equivalent to today's `init()`) and cloned per-engine.
+
+**Blast radius:**
+
+| What | Where | Change |
+|------|-------|--------|
+| Global registry | `internal/forms/form_spec.go` | Replace with `FormRegistry` type |
+| Init registration | `machine/register.go` `init()` | Build a default `FormRegistry` instead of mutating global |
+| Compiler dispatch | `machine/compile_validated.go:53` | `forms.Lookup(...)` → `p.formRegistry.Lookup(...)` |
+| CompileTimeContinuation | `machine/compile_time_continuation.go` | Add `formRegistry *forms.FormRegistry` field |
+| Validator | `internal/validate/` | Validators call `forms.Lookup()` to check special-form status; need registry passed in |
+| Expander | `machine/expander_time_continuation.go` | May reference forms registry for form detection |
+| Engine construction | `engine.go` | Build/clone forms registry, pass to compiler |
+
+The validator is the subtlest part. `internal/validate/` uses `forms.Lookup()` to decide whether an identifier names a special form (which determines which `ValidatedExpr` type to produce). The registry needs to flow into the validation path, likely through the validation context.
+
+### Phase 2: Dialect type and WithDialect option
+
+Define the `Dialect` type and `WithDialect()` engine option.
+
+```go
+// wile/dialect.go
+type Dialect struct {
+    Name               string
+    BuildRegistry      func(*registry.Registry) error
+    MacroSources       []string
+    FormSpecs          *forms.FormRegistry
+    SyntaxCompilers    func(*environment.EnvironmentFrame) error
+    PrimitiveExpanders func(*environment.EnvironmentFrame) error
+    CompileTimeBindings []string
+    Features           []string
+}
+```
+
+`NewEngine` uses `Dialect.FormSpecs` instead of the global forms registry. If no dialect is specified, it uses `r7rs.DefaultDialect`.
+
+### Phase 3: Extract R7RS as the default dialect
+
+Move all current R7RS-specific configuration into `r7rs.DefaultDialect`:
+
+- `core.AddToRegistry` → `Dialect.BuildRegistry`
+- `core.compileTimeBindings` → `Dialect.CompileTimeBindings`
+- `core.bootstrapMacroSource` → `Dialect.MacroSources`
+- `machine.RegisterSyntaxCompilers` table → `Dialect.SyntaxCompilers`
+- `machine.RegisterPrimitiveExpanders` table → `Dialect.PrimitiveExpanders`
+- `machine/register.go` `init()` registrations → `Dialect.FormSpecs`
+- `machine.Features()` → `Dialect.Features`
+
+After this phase, Wile behaves identically but R7RS is a configuration, not hardcoded.
+
+### Phase 4: Second dialect (validates the abstraction)
+
+Implement one non-R7RS dialect to prove the abstraction works. Candidates:
+
+**Option A: R7RS-minimal** — R7RS without mutation. Removes `set!`, `set-car!`, `set-cdr!`, `vector-set!`, `string-set!`, `list-set!`, `hashtable-set!`, `set-box!` from primitives and removes `set!` from the forms registry. Simple, verifiable, useful for sandboxing. Connects to `SANDBOXING_MODEL.md` Phase 4 (registry filtering).
+
+**Option B: R6RS-core** — R6RS library syntax + condition system. More ambitious, proves the library system is dialect-configurable. Requires a new `CompileR6RSLibrary` syntax compiler and condition type primitives.
+
+**Option C: Custom DSL** — Minimal Lisp with renamed forms (`fn`, `def`, `let`). Proves form-name independence. Least useful for production but fastest to implement.
+
+Recommendation: **Option A first** (validates the forms registry de-globalization with minimal risk), then **Option B** (validates the full dialect system with real semantic differences).
+
+## Scope Boundaries
+
+**Covered by this plan:**
+- De-globalizing the forms registry
+- `Dialect` type and `WithDialect()` option
+- Extracting R7RS as the default dialect
+- Validating with a second dialect
+
+**Not covered:**
+- New value types (persistent vectors, condition types) — these require `values/` package changes, orthogonal to the dialect system
+- Parser changes — the tokenizer/parser is Scheme-generic (s-expressions). A dialect that needs different syntax (e.g., Clojure's `[]`, `{}`) would need parser extensions, which is a separate effort
+- REPL personality — prompt strings, error formatting, help text. Cosmetic, handled by `cmd/scheme/` configuration
+- R6RS full compliance — would be a large effort; the dialect system enables it but doesn't deliver it
+
+## Dependencies
+
+- Phase 1 (forms registry): None — internal refactor
+- Phase 2 (Dialect type): Phase 1
+- Phase 3 (extract R7RS): Phase 2
+- Phase 4 (second dialect): Phase 3
+- `SANDBOXING_MODEL.md` Phase 4 (`Registry.Without`) composes with dialect system for mutation-free dialects
+
+## Relationship to Sandboxing
+
+The dialect system and sandboxing address orthogonal axes:
+
+- **Sandboxing**: Which *capabilities* does code have? (filesystem, eval, system)
+- **Dialects**: Which *language* does code speak? (R7RS, R6RS, custom)
+
+They compose: an embedder can use an R6RS dialect with sandboxed capabilities, or an R7RS dialect with full access. The `WithRegistry()` / `Without()` / `WithExtension()` API works identically regardless of dialect — dialects configure the compiler and macro layer, extensions configure the runtime primitive layer.
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| De-globalize forms registry, not per-environment | Per-environment would require the forms registry in `EnvironmentFrame`, adding weight to every environment. Per-engine (via `CompileTimeContinuation`) is sufficient — all code in one engine speaks one dialect. |
+| Dialect as struct, not interface | Dialects are data (tables of specs), not behavior. A struct with function fields is simpler than an interface with methods. |
+| R7RS as default, not special | After extraction, R7RS is just `r7rs.DefaultDialect`. No special-casing in the engine. |
+| Validator needs registry access | Validators produce different `ValidatedExpr` types based on whether a name is a special form. The forms registry must flow into validation, not just compilation. |
+| Phase 4 starts with mutation-free variant | Smallest delta from R7RS. Validates the abstraction without requiring new primitives, types, or library system changes. |
+| Parser not included | S-expression syntax is shared across all Lisp dialects. Dialects that need different surface syntax (brackets, braces) are a parser concern, not a dialect concern. |

--- a/plans/MODULE_DECOMPOSITION.md
+++ b/plans/MODULE_DECOMPOSITION.md
@@ -1,0 +1,571 @@
+# Plan: Module Decomposition
+
+**Status**: Proposed
+**Date**: 2026-02-20
+**Related**: `SANDBOXING_MODEL.md` (extension-level capability control), `DIALECT_SYSTEM.md` (dialect configurability), `EXTERNAL_EXTENSIONS_PLAN.md` (earlier extension extraction work)
+
+## Motivation
+
+The sandboxing plan establishes that extensions are opt-in capabilities. The dialect plan establishes that the language personality is configurable. The logical conclusion: the core repo should contain only what's irreducible, and everything else should be a separate Go module that embedders compose via `go get` and `WithExtension()`.
+
+This gives embedders precise control over binary size, capability surface, and dependency footprint. A minimal embedded Scheme that does pure computation imports only `github.com/aalpar/wile`. One that needs I/O adds `github.com/aalpar/wile-io`. No unused code compiles in.
+
+## The Core Boundary
+
+The boundary is determined by answering: **what can't be removed without making the engine unable to function?**
+
+### What stays in `github.com/aalpar/wile`
+
+| Package | Contents | Why irreducible |
+|---------|----------|----------------|
+| `values/` | Type system: Value interface, Pair, Symbol, Number, String, Vector, ByteVector, Boolean, Char, Port, etc. | Every package depends on this |
+| `environment/` | Bindings, scopes, phases, TopLevelEnvironment, GlobalEnvironmentFrame | Compiler and VM require it |
+| `machine/` | VM (MachineContext.Run), compiler, expander, continuations, bytecode, operations | The execution engine |
+| `registry/` | Registry type, Extension interface, Phase, RegistryBuilder, PrimitiveSpec | The composition mechanism |
+| `registry/core/` | ~148 primitives in 15 categories + core bootstrap macros | Language doesn't function without `cons`, `+`, `if`, `lambda` |
+| `internal/*` | Tokenizer, parser, syntax objects, validator, forms registry, pattern matcher, bootstrap | Compilation pipeline |
+| Root package | Engine, EngineOption, Dialect, public API | Embedder entry point |
+
+### Core primitives (15 categories, ~148 primitives)
+
+These are in `registry/core/` and are truly irreducible:
+
+| Category | File | Key primitives |
+|----------|------|---------------|
+| special forms | `specialforms.go` | `if`, `lambda`, `define`, `set!`, `begin`, `quote`, `quasiquote`, `dynamic-wind`, `case-lambda`, `else`, `=>`, `...`, `_`, `syntax-rules`, `define-syntax`, `import`, `include`, `cond-expand` |
+| predicates | `predicates.go` | `null?`, `pair?`, `boolean?`, `number?`, `symbol?`, `string?`, `char?`, `vector?`, `bytevector?`, `procedure?`, `list?`, `zero?`, `positive?`, `negative?`, `odd?`, `even?`, `exact?`, `inexact?`, `exact-integer?` |
+| equality | `equality.go` | `eq?`, `eqv?`, `equal?`, `boolean=?`, `symbol=?`, `not` |
+| pairs | `pairs.go` | `cons`, `car`, `cdr`, `set-car!`, `set-cdr!`, 28 CxR accessors |
+| lists | `lists.go` | `list`, `make-list`, `append`, `reverse`, `length`, `list-ref`, `list-set!`, `list-tail`, `list-copy`, `memq`, `memv`, `member`, `assq`, `assv`, `assoc` |
+| arithmetic | `arithmetic.go` | `+`, `-`, `*`, `/`, `<`, `>`, `<=`, `>=`, `=`, `abs`, `min`, `max`, `quotient`, `remainder`, `modulo`, `gcd`, `lcm`, `exact`, `inexact`, `number->string`, `string->number`, `floor`, `ceiling`, `truncate`, `round`, `rationalize`, `make-rectangular`, `real-part`, `imag-part`, `magnitude`, `angle` |
+| control | `control.go` | `apply`, `call/cc`, `call-with-current-continuation`, `values`, `call-with-values`, `call-with-continuation-barrier` |
+| vectors | `vectors.go` | `make-vector`, `vector`, `vector-length`, `vector-ref`, `vector-set!`, `vector->list`, `list->vector`, `vector-copy`, `vector-fill!`, `vector-copy!`, `vector-append`, `vector-map`, `vector-for-each` |
+| strings | `strings.go` | `make-string`, `string`, `string-length`, `string-ref`, `string-set!`, `substring`, `string-append`, `string->list`, `list->string`, `string-copy`, `string->symbol`, `symbol->string`, string comparisons |
+| characters | `characters.go` | `char->integer`, `integer->char`, char comparisons |
+| bytevectors | `byte_vectors.go` | `make-bytevector`, `bytevector`, `bytevector-length`, `bytevector-u8-ref`, `bytevector-u8-set!`, `bytevector-copy`, `bytevector-copy!`, `bytevector-append`, `utf8->string`, `string->utf8` |
+| syntax | `syntax.go` | `identifier?`, `syntax->datum`, `datum->syntax`, `generate-temporaries`, `bound-identifier=?`, `free-identifier=?` |
+| parameters | `parameters.go` | `make-parameter`, `parameter?` |
+| boxes | `boxes.go` | `box`, `box?`, `unbox`, `set-box!` |
+| hashtables | `hashtables.go` | `make-hashtable`, `hashtable?`, `hashtable-ref`, `hashtable-set!`, `hashtable-delete!`, `hashtable-keys`, `hashtable-values`, `hashtable-size`, `hashtable-copy`, `hashtable-clear!` |
+| continuations | `prompts.go` | `make-continuation-prompt-tag`, `default-continuation-prompt-tag`, `continuation-prompt-tag?`, `call-with-continuation-prompt`, `abort-current-continuation`, `call-with-composable-continuation` |
+
+### Core bootstrap macros
+
+These macros depend ONLY on core primitives and stay in `registry/core/bootstrap.scm`:
+
+`and`, `or`, `let`, `let*`, `letrec`, `letrec*`, `cond`, `case`, `when`, `unless`, `parameterize`, `let-values`, `let*-values`, `define-values`, `do`, `map`, `for-each`, `with-continuation-barrier`, `with-baffle`
+
+### Bootstrap macros that move to extensions
+
+These macros depend on extension primitives and move to the extension that provides those primitives (via `AddMacroSource`):
+
+| Macro | Depends on | Moves to |
+|-------|-----------|----------|
+| `guard`, `guard-aux` | `with-exception-handler`, `raise` | `wile-exceptions` |
+| `delay`, `delay-force` | `%make-lazy-promise` | `wile-promises` |
+| `define-record-type`, `define-record-type-impl` | `make-record-type`, `record-constructor`, `record-predicate`, `record-accessor`, `record-modifier` | `wile-records` |
+
+## Extension Modules
+
+Each extension is a separate Go module with a single dependency on `github.com/aalpar/wile`.
+
+### Extension inventory
+
+| Module | Current location | Primitives | Macros | Security class |
+|--------|-----------------|------------|--------|---------------|
+| `wile-io` | `internal/extensions/io/` | read, write, display, newline, ports, string/bytevector ports, current-input/output-port, binary I/O | none | safe |
+| `wile-exceptions` | `extensions/exceptions/` | raise, with-exception-handler, raise-continuable, error, error-object?, error-object-message, error-object-irritants, error-object-type | `guard`, `guard-aux` | safe |
+| `wile-records` | split from `internal/extensions/all/` | make-record-type, record-constructor, record-predicate, record-accessor, record-modifier, record?, record-type? | `define-record-type`, `define-record-type-impl` | safe |
+| `wile-promises` | split from `internal/extensions/all/` | %make-lazy-promise, promise?, force, make-promise | `delay`, `delay-force` | safe |
+| `wile-math` | `extensions/math/` | sqrt, sin, cos, tan, asin, acos, atan, exp, log, expt, floor, ceiling, truncate, round | none | safe |
+| `wile-files` | `extensions/files/` | open-input-file, open-output-file, delete-file, file-exists?, call-with-input-file, call-with-output-file, with-input-from-file, with-output-to-file | none | privileged |
+| `wile-eval` | `internal/extensions/eval/` | eval, load, interaction-environment, scheme-report-environment, null-environment, environment, syntax-expand, compile | none | privileged |
+| `wile-system` | `extensions/system/` | exit, emergency-exit, command-line, get-environment-variable, get-environment-variables | none | privileged |
+| `wile-threads` | `extensions/threads/` | SRFI-18 threads, mutexes, condition variables, thread time | none | context-dependent |
+| `wile-gointerop` | `extensions/gointerop/` | Go function bridge | none | privileged |
+
+### Decomposing `internal/extensions/all/`
+
+The current `all` extension is a grab bag that bundles:
+
+| Contents | Destination |
+|----------|-------------|
+| Records (make-record-type, etc.) | `wile-records` |
+| Promises (%make-lazy-promise, force, etc.) | `wile-promises` |
+| String mutation (string-copy!, string-fill!) | `registry/core/` (these are `(scheme base)` and use only core types) |
+
+After decomposition, `internal/extensions/all/` no longer exists.
+
+### Import graph
+
+```
+github.com/aalpar/wile                 (core — zero external deps)
+
+github.com/aalpar/wile-io              → wile
+github.com/aalpar/wile-exceptions      → wile
+github.com/aalpar/wile-records         → wile
+github.com/aalpar/wile-promises        → wile
+github.com/aalpar/wile-math            → wile
+github.com/aalpar/wile-files           → wile
+github.com/aalpar/wile-eval            → wile
+github.com/aalpar/wile-system          → wile
+github.com/aalpar/wile-threads         → wile
+github.com/aalpar/wile-gointerop       → wile
+
+github.com/aalpar/wile-scheme          → all of the above (CLI/REPL)
+```
+
+No extension depends on another extension. No circular dependencies. Each extension's only dependency is the core module.
+
+### Extension module structure
+
+Each extension module follows the same pattern:
+
+```
+wile-io/
+├── go.mod              # module github.com/aalpar/wile-io
+├── register.go         # var Extension = registry.NewExtension("io", AddToRegistry)
+├── prim_read_write.go  # primitive implementations
+├── prim_ports.go
+├── ...
+├── macros.scm          # bootstrap macros (if any), embedded via go:embed
+└── *_test.go
+```
+
+The embedder imports:
+
+```go
+import (
+    "github.com/aalpar/wile"
+    wileio "github.com/aalpar/wile-io"
+)
+
+eng, _ := wile.NewEngine(ctx,
+    wile.WithExtension(wileio.Extension),
+)
+```
+
+## R7RS Standard Library Files (.sld)
+
+The `lib/` directory contains `.sld` files that define standard R7RS libraries (e.g., `lib/scheme/base.sld`, `lib/scheme/file.sld`). These reference extension primitives via `(import ...)`.
+
+**Problem:** `lib/scheme/file.sld` re-exports filesystem primitives. If `wile-files` is a separate repo, where does `scheme/file.sld` live?
+
+**Solution:** Each extension module ships its own `.sld` files. The engine's `WithLibraryPaths()` searches all configured paths. The extension provides a helper:
+
+```go
+// In wile-files
+import "embed"
+
+//go:embed lib
+var LibDir embed.FS
+
+// LibraryPath returns the path to the embedded library files.
+func LibraryPath() string { ... }
+```
+
+Or the extension registers its library directly via the synthetic library mechanism (already exists in `engine.go:155-178` for extension primitives).
+
+**For standard R7RS libraries** that bundle primitives from multiple extensions (e.g., `(scheme base)` includes both core and io primitives), the `.sld` file lives with whoever bundles the full R7RS personality — the `r7rs` dialect package or a `wile-std` convenience module.
+
+## Convenience Bundles
+
+Individual extension repos provide maximum granularity. Convenience bundles provide common compositions:
+
+### Option A: `r7rs` package in core
+
+A package within `github.com/aalpar/wile` that re-exports extension configurations:
+
+```go
+// wile/r7rs/dialect.go
+package r7rs
+
+var Dialect = wile.Dialect{
+    // ... includes io, exceptions, records, promises, math
+}
+```
+
+**Problem:** This creates an import dependency from `wile` core to all extension modules, defeating the purpose of the split.
+
+### Option B: Separate `wile-r7rs` module
+
+```go
+// github.com/aalpar/wile-r7rs
+package r7rs
+
+import (
+    wileio "github.com/aalpar/wile-io"
+    wileexc "github.com/aalpar/wile-exceptions"
+    wilerec "github.com/aalpar/wile-records"
+    wileprom "github.com/aalpar/wile-promises"
+    // ...
+)
+
+var AllExtensions = []wile.EngineOption{
+    wile.WithExtension(wileio.Extension),
+    wile.WithExtension(wileexc.Extension),
+    wile.WithExtension(wilerec.Extension),
+    wile.WithExtension(wileprom.Extension),
+    // ...
+}
+
+var Dialect = wile.Dialect{ ... }
+```
+
+**This is the right approach.** The core repo stays dependency-free. The bundle repo depends on all extensions. Embedders who want full R7RS `go get github.com/aalpar/wile-r7rs` and get everything.
+
+### Option C: `wile-std` (standard library bundle)
+
+A bundle of the "safe" extensions — io, exceptions, records, promises, math — without the privileged ones (files, eval, system, gointerop, threads):
+
+```go
+// github.com/aalpar/wile-std
+var SafeExtensions = []wile.EngineOption{ ... }
+```
+
+This connects to `SANDBOXING_MODEL.md` Phase 1 (SafeExtensions convenience API), just as a separate module instead of in-core.
+
+## Go Workspace for Development
+
+```
+wile-workspace/
+├── go.work
+├── wile/
+├── wile-io/
+├── wile-exceptions/
+├── wile-records/
+├── wile-promises/
+├── wile-math/
+├── wile-files/
+├── wile-eval/
+├── wile-system/
+├── wile-threads/
+├── wile-gointerop/
+├── wile-r7rs/
+└── wile-scheme/
+```
+
+`go.work`:
+
+```
+go 1.24
+
+use (
+    ./wile
+    ./wile-io
+    ./wile-exceptions
+    ./wile-records
+    ./wile-promises
+    ./wile-math
+    ./wile-files
+    ./wile-eval
+    ./wile-system
+    ./wile-threads
+    ./wile-gointerop
+    ./wile-r7rs
+    ./wile-scheme
+)
+```
+
+Local changes to any module are immediately visible to all others via `go work`. Published releases use normal `go get` with version constraints.
+
+## Why ~148 Core Primitives Is the Floor
+
+It's tempting to shrink core further — do we really need `-` when `(+ a (* -1 b))` works? The answer is yes, and the reasons are structural, not just performance.
+
+**Three constraints that define the floor:**
+
+1. **Bootstrap dependency.** The bootstrap macros (`cond`, `case`, `parameterize`, `define-values`, `map`, `for-each`, etc.) reference specific primitives: `memv`, `cons`, `car`, `cdr`, `apply`, `call-with-values`, `dynamic-wind`, `null?`, `not`, `list`, `set!`. These primitives must be Go-level (`AddPrimitive`) because bootstrap macros run *before* any Scheme-defined functions exist. You can't define `memv` in Scheme and then use it in `cond`'s expansion — `cond` is being loaded at the same time.
+
+2. **Scheme-level load ordering.** Go primitives (`AddPrimitive`) are all available simultaneously after `Registry.Apply()` — no ordering issue. Scheme-defined functions (`AddMacroSource`) are evaluated sequentially and can only reference things defined before them. If `-` were a Scheme function provided by an extension, the extension's macro source must be evaluated before any code that uses `-`. This ordering is implicit (determined by `WithExtension()` call order) and invisible to Go's module system. A second dependency graph layered on top of `go.mod` is the complexity you'd be buying.
+
+3. **No embedder benefit.** Nobody wants Scheme-without-subtraction. The sandboxing use case is about *capabilities* (filesystem, eval, system), not *arithmetic*. Removing `append` or `list-ref` from core saves nothing meaningful — the embedder still needs them, they just import them from somewhere else.
+
+**What could theoretically leave core** (not used by bootstrap, not performance-critical):
+
+| Primitives | Count | Why you'd extract |
+|-----------|-------|-------------------|
+| CxR accessors (`caaar` through `cddddr`) | 28 | Pure convenience |
+| Hashtables | 10 | Non-R7RS (Wile extension) |
+| Boxes | 4 | Non-R7RS (Wile extension) |
+| Bytevectors (some) | ~5 | Scripts that don't do binary |
+
+But the savings are marginal (~47 primitives) and the cost is real: more repos, more version coordination, load-ordering problems for any that get Scheme-level replacements.
+
+**The goal is not to minimize core — it's to make the extension mechanism so clear that it's self-service.** Someone should be able to read the docs and build their own `guard`-equivalent without special knowledge. Whether `guard` itself lives in core or in an extension is a pragmatic choice. What matters is that the mechanism for low-level extension works tractably from the outside.
+
+## Initialization Ordering
+
+### The problem
+
+The engine initializes in a strict sequence:
+
+```
+1. Registry built       — AddPrimitive() from all extensions (Go-level)
+2. Environment created
+3. Registry applied     — Go primitives become env bindings (ForeignClosure)
+4. Syntax compilers     — RegisterSyntaxCompilers
+5. Expanders            — RegisterPrimitiveExpanders
+6. Bootstrap macros     — AddMacroSource strings evaluated sequentially
+7. Library system       — LibraryEnvFactory set, search paths configured
+8. User code runs
+```
+
+Steps 1-3 are order-independent: all Go primitives land in the environment before any Scheme runs. Step 6 is order-dependent: macro sources are evaluated sequentially and can reference results of earlier evaluations. The library system (step 7) isn't active yet during step 6.
+
+This creates a hard split between things that can be defined during bootstrap (step 6) and things that must wait for the library system (step 7+).
+
+### Four techniques for providing Scheme-level functionality
+
+| Technique | Bound as | When available | Ordering constraint |
+|-----------|----------|---------------|-------------------|
+| `AddPrimitive` (ForeignFunction) | Go closure in env | After step 3 — before any Scheme | None — all available simultaneously |
+| `AddMacroSource` (macro/define) | Scheme syntax transformer or closure | After its source is evaluated in step 6 | Must come after any macro/function it references |
+| Synthetic library (engine.go:155-178) | Available via `(import ...)` | On demand, after step 7 | Library system handles ordering |
+| R7RS library (.sld file) | Available via `(import ...)` | On demand, after step 7 | Library system handles ordering |
+
+The first technique has no ordering problem. The last two have ordering solved by the library system (load-on-demand, cycle detection, caching). The second technique — `AddMacroSource` — is the trouble zone.
+
+### The solution: two tiers
+
+**Tier 1 (Bootstrap): `AddMacroSource` — core only, no cross-extension dependencies.**
+
+Bootstrap macros are loaded during step 6. They depend ONLY on Go primitives (always available) and on earlier bootstrap macros (guaranteed by sequential evaluation within a single macro source string). No extension's bootstrap code depends on another extension's bootstrap code.
+
+These macros are required for the language to function at all — including for the library system to compile `(define-library ...)` and `(import ...)` forms. They are: `and`, `or`, `let`, `let*`, `letrec`, `letrec*`, `cond`, `case`, `when`, `unless`, `parameterize`, `let-values`, `let*-values`, `define-values`, `do`, `map`, `for-each`, `with-continuation-barrier`, `with-baffle`.
+
+**Tier 2 (Library): Extension Scheme code loaded via the library system.**
+
+Extension-specific macros and functions become library exports, loaded on demand via `(import ...)`. The library system handles dependency resolution automatically.
+
+Example — `guard` as a library export:
+
+```scheme
+;; Provided by wile-exceptions as part of its library definition
+(define-library (wile exceptions)
+  (export guard with-exception-handler raise raise-continuable
+          error error-object? error-object-message
+          error-object-irritants error-object-type)
+  (import (scheme base))   ;; for let, if, lambda, call/cc — all bootstrap
+  (begin
+    (define-syntax guard ...)
+    (define-syntax guard-aux ...)))
+```
+
+When user code writes `(import (wile exceptions))`, the library system loads and evaluates this definition. `guard` depends on `with-exception-handler` and `raise` (Go primitives from the same extension, already in the environment) and on `call/cc` and `let` (core bootstrap, already loaded). No ordering problem.
+
+**`(scheme base)` re-exports from extension libraries.** R7RS says `guard` is part of `(scheme base)`. So `(scheme base)` would `(import (wile exceptions))` and re-export `guard`. This is how R7RS is designed — `(scheme base)` is a composite library that bundles features from multiple sources. The library system handles the transitive dependency resolution.
+
+### How extensions provide both Go and Scheme code
+
+An extension module provides:
+
+1. **Go primitives** via `AddPrimitive` — available immediately after registry application (step 3)
+2. **A synthetic library** registered in the library system — provides Scheme-level macros/functions, loaded on demand after step 7
+
+The engine already creates synthetic libraries for extension primitives (`engine.go:155-178`). The extension just needs to also include macro sources in its library definition. The mechanism for this is:
+
+- Extension ships a `.sld` file (embedded via `go:embed`) that defines the library with both exported Go primitives and Scheme macros
+- Or the extension programmatically creates a `CompiledLibrary` that includes macro sources
+
+The specific API for attaching Scheme definitions to synthetic libraries needs design work (it doesn't exist yet — synthetic libraries currently only export Go primitives). This is a concrete deliverable of the module decomposition.
+
+### What this means for extension authors
+
+An extension author who wants to provide low-level Scheme functionality (macros, helper functions, derived forms) follows this pattern:
+
+1. Implement Go primitives normally via `AddPrimitive`
+2. Write Scheme macros/functions in a `.sld` file that `(import ...)` whatever bootstrap macros they need
+3. Ship the `.sld` file with the extension module (embedded via `go:embed`)
+4. Users access the functionality via `(import (extension-name))`
+
+The extension author doesn't need to know about bootstrap ordering, `AddMacroSource` internals, or the engine's initialization sequence. They write a standard R7RS library definition. The library system handles the rest.
+
+### Fallback: declared dependencies for global Scheme definitions
+
+For the rare case where an extension truly needs Scheme code available globally (not via `(import ...)`), the Extension interface supports an optional dependency declaration:
+
+```go
+// SchemeDependencies returns extension names whose Scheme-level definitions
+// must be loaded before this extension's AddMacroSource code.
+// Most extensions should use the library system instead of this mechanism.
+type SchemeDependencyDeclarer interface {
+    SchemeDependencies() []string
+}
+```
+
+The engine topologically sorts extensions with `AddMacroSource` code based on these declarations. This is the K8s PostStartHook pattern — explicit dependency declaration resolved at startup.
+
+This should be rarely used. The library system is the primary mechanism.
+
+## The Embedder Experience
+
+**Minimal (pure computation):**
+
+```go
+import "github.com/aalpar/wile"
+
+eng, _ := wile.NewEngine(ctx)
+result, _ := eng.Eval(ctx, "(+ 1 2 3)")
+// result is values.Int(6) — no I/O, no files, no eval
+```
+
+**Safe sandbox with I/O and exceptions:**
+
+```go
+import (
+    "github.com/aalpar/wile"
+    wileio "github.com/aalpar/wile-io"
+    wileexc "github.com/aalpar/wile-exceptions"
+)
+
+eng, _ := wile.NewEngine(ctx,
+    wile.WithExtension(wileio.Extension),
+    wile.WithExtension(wileexc.Extension),
+)
+```
+
+**Full R7RS:**
+
+```go
+import (
+    "github.com/aalpar/wile"
+    "github.com/aalpar/wile-r7rs"
+)
+
+eng, _ := wile.NewEngine(ctx,
+    wile.WithDialect(r7rs.Dialect),
+    wile.WithLibraryPaths("./lib"),
+)
+```
+
+**Custom DSL with Go interop:**
+
+```go
+import (
+    "github.com/aalpar/wile"
+    wilegio "github.com/aalpar/wile-gointerop"
+)
+
+eng, _ := wile.NewEngine(ctx,
+    wile.WithExtension(wilegio.Extension),
+)
+eng.RegisterFunc("process-data", myGoFunction)
+```
+
+## Phases
+
+### Phase 1: Decompose `internal/extensions/all/`
+
+Split the grab bag:
+- Records → new `internal/extensions/records/` (temporary, before extraction)
+- Promises → new `internal/extensions/promises/` (temporary, before extraction)
+- String mutation ops (`string-copy!`, `string-fill!`) → `registry/core/strings.go`
+
+Move bootstrap macros: `guard`/`guard-aux` to exceptions, `delay`/`delay-force` to promises, `define-record-type` to records. Each extension's `AddToRegistry` calls `r.AddMacroSource(...)` for its macros.
+
+**Prerequisite:** None. Internal refactor, no public API change.
+
+### Phase 2: Make `internal/extensions/` public
+
+Move internal extensions to public packages:
+- `internal/extensions/io/` → `extensions/io/` (or top-level `io/`)
+- `internal/extensions/eval/` → `extensions/eval/`
+- New `extensions/records/`, `extensions/promises/` from Phase 1
+
+After this phase, all extensions are importable by external code. This is the `EXTERNAL_EXTENSIONS_PLAN.md` work.
+
+**Prerequisite:** Phase 1.
+
+### Phase 3: Extract extension modules
+
+One extension at a time, extract to separate repos:
+
+1. Start with a leaf extension that has no dependents — `wile-math` or `wile-system`
+2. Create the repo, move code, update imports
+3. Set up CI and release tagging
+4. Update `wile-scheme` (CLI) to import from the new module
+5. Repeat for each extension
+
+Order (least dependencies first):
+1. `wile-math` — pure math, zero dependents
+2. `wile-system` — exit/env vars, zero dependents
+3. `wile-gointerop` — Go bridge, zero dependents
+4. `wile-threads` — SRFI-18, zero dependents
+5. `wile-files` — filesystem, zero dependents
+6. `wile-io` — ports/read/write
+7. `wile-exceptions` — raise/guard
+8. `wile-records` — record types
+9. `wile-promises` — lazy evaluation
+10. `wile-eval` — eval/load/environments
+
+**Prerequisite:** Phase 2.
+
+### Phase 4: Create convenience bundles
+
+- `wile-r7rs` — full R7RS dialect bundle (all extensions + standard library .sld files)
+- `wile-std` — safe extensions bundle (io + exceptions + records + promises + math)
+
+**Prerequisite:** Phase 3 (all extensions extracted).
+
+### Phase 5: Go workspace setup
+
+Create `wile-workspace` repo (or document the workspace pattern) with `go.work` linking all modules for development.
+
+**Prerequisite:** Phase 3.
+
+## Scope Boundaries
+
+**Covered by this plan:**
+- Core/extension boundary definition
+- `internal/extensions/all/` decomposition
+- Extension extraction to separate Go modules
+- Convenience bundles (`wile-r7rs`, `wile-std`)
+- Go workspace for multi-module development
+- Bootstrap macro migration
+
+**Not covered:**
+- Dialect system implementation (`DIALECT_SYSTEM.md`) — composable with but independent of module extraction
+- Authorization framework (`AUTHORIZATION_FRAMEWORK.md`) — lives in core
+- Sandboxing convenience API (`SANDBOXING_MODEL.md`) — moves to `wile-std` bundle
+- New value types — `values/` stays in core; new types added there
+- Parser extensions — `internal/tokenizer`, `internal/parser` stay in core
+
+## Dependencies on Other Plans
+
+| This plan | Depends on | Why |
+|-----------|-----------|-----|
+| Phase 1 (decompose all) | Nothing | Internal refactor |
+| Phase 2 (make public) | `EXTERNAL_EXTENSIONS_PLAN.md` | Same work, already scoped |
+| Phase 3 (extract modules) | Phase 2 | Can't extract until public |
+| Phase 4 (bundles) | `DIALECT_SYSTEM.md` Phase 3 | `wile-r7rs` needs the Dialect type |
+| Phase 4 (bundles) | `SANDBOXING_MODEL.md` Phase 1 | `wile-std` is SafeExtensions as a module |
+
+## Decision Log
+
+| Decision | Rationale |
+|----------|-----------|
+| Core includes all ~148 primitives in `registry/core/` | Bootstrap macros depend on them (can't be Scheme-defined — they run before the library system). Shrinking core further buys no real embedder benefit and creates Scheme-level load-ordering problems. The goal is a clear extension mechanism, not minimal core size. |
+| Bootstrap macros split by dependency | 16 macros depend only on core → stay as `AddMacroSource` (Tier 1). 5 macros depend on extension primitives → become library exports loaded via `(import ...)` (Tier 2). |
+| Two-tier Scheme initialization | Tier 1 (bootstrap `AddMacroSource`): core-only, no cross-extension deps. Tier 2 (library system): extension Scheme code loaded on demand via `(import ...)`). Library system handles ordering automatically. This avoids a parallel dependency graph. |
+| Library system is the primary mechanism for extension Scheme code | Extensions provide Go primitives via `AddPrimitive` and Scheme definitions via `.sld` library files. Users access both via `(import ...)`. Extension authors don't need to understand bootstrap internals — they write standard R7RS library definitions. |
+| `SchemeDependencies` as fallback only | K8s-style explicit dependency declaration for the rare case where global Scheme definitions (outside the library system) are needed. Most extensions should use the library system instead. |
+| String mutation ops move to core | `string-copy!` and `string-fill!` are `(scheme base)` and use only core types. They don't belong in a separate extension. |
+| Separate repos over monorepo subdirectories | Go modules in subdirectories of a monorepo share version tags, complicating independent releases. Separate repos have independent versioning, CI, and release cycles. |
+| `wile-r7rs` as a separate bundle module | Can't live in core — would create import dependency from core to all extensions. A separate module that depends on all extensions provides the "batteries included" experience without bloating core. |
+| Extension extraction order: leaves first | Extensions with zero dependents (math, system) are safest to extract first. Extensions that other code might reference (io, exceptions) go later to minimize mid-migration breakage. |
+| No extension depends on another extension | Each extension depends only on `wile` core. This keeps the dependency graph flat and prevents cascading version conflicts. If an extension needs functionality from another (e.g., eval needs io for `load`), it depends on the shared core interfaces, not the extension. |
+
+## Open Questions
+
+1. **I/O in core vs separate?** `display`, `read`, `write` are `(scheme base)`. An engine without I/O can't print. But for embedded use, the Go program is the I/O layer — results come back as `values.Value`. The engine can function without `display`. Leaning toward separate.
+
+2. **How many repos is too many?** 10 extension repos + 2 bundles + 1 CLI = 14 repos. This is manageable but requires CI/release tooling. Alternative: fewer, larger repos (e.g., merge records + promises + exceptions into `wile-std-extensions`). The tradeoff is granularity vs management overhead.
+
+3. **Versioning discipline?** Each extension pins a minimum `wile` core version. Breaking changes in core (e.g., `MachineContext` API) require coordinated releases. A compatibility matrix or CI that tests extensions against core HEAD would help.
+
+4. **Test migration?** Many tests in `registry/core/*_test.go` use `runSchemeCode` which creates a full environment with all extensions. These tests would need to use only core primitives, or be restructured to test with explicit extension composition.
+
+5. **Synthetic library API for Scheme definitions.** Synthetic libraries currently only export Go primitives (`engine.go:155-178`). To support Tier 2 (extension Scheme code loaded via library system), synthetic libraries need to also carry macro sources that are evaluated when the library is first loaded. The API for attaching Scheme definitions to synthetic libraries needs design work — this is a concrete deliverable.
+
+6. **Pragmatic core size.** The goal is a clear, self-service extension mechanism — not minimal core. Some things that *could* technically be extensions (e.g., `guard`, `define-record-type`) may stay in core for pragmatic reasons. What matters is that the mechanism works identically for things inside and outside core. If someone builds their own `guard`-equivalent as an extension, the same library-system path works — they write a `.sld` file, ship it with their module, users `(import ...)` it.

--- a/plans/SANDBOXING_MODEL.md
+++ b/plans/SANDBOXING_MODEL.md
@@ -1,0 +1,356 @@
+# Plan: Extension-Level Sandboxing Model
+
+**Status**: Proposed
+**Date**: 2026-02-20
+**Related**: `AUTHORIZATION_FRAMEWORK.md` (fine-grained layer), `docs/EXTENSIONS.md`
+
+## Motivation
+
+Embedders need to control what capabilities Scheme code has access to. The library system's `export` mechanism controls outward visibility (what importers see), not inward capability (what code inside a library can do). Sandboxing requires inward restriction.
+
+Wile already has the right architecture for coarse-grained sandboxing — extensions are opt-in via `WithExtension()` — but this isn't documented as a security boundary, there's no convenience API for common sandbox profiles, and the relationship between extension-level and fine-grained authorization isn't articulated.
+
+This plan documents the extension-level sandboxing model and the concrete work to make it usable.
+
+## Architecture: Two-Layer Sandboxing
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Layer 1: Extension-level (this plan)                        │
+│                                                             │
+│ Controls WHICH primitives exist in the engine.              │
+│ Mechanism: WithExtension() at Engine construction.          │
+│ Granularity: per-extension (io, files, eval, threads, etc.) │
+│ Enforcement: primitives not in registry don't exist.        │
+│ Propagation: LibraryEnvFactory inherits engine's registry.  │
+└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────┐
+│ Layer 2: Authorization (AUTHORIZATION_FRAMEWORK.md)         │
+│                                                             │
+│ Controls WHAT operations primitives can perform.            │
+│ Mechanism: Authorizer via context.Context.                  │
+│ Granularity: per-operation (read file X, delete file Y).    │
+│ Enforcement: Check() call inside each gated primitive.      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Layer 1 is coarse but zero-cost: if the filesystem extension isn't loaded, filesystem primitives don't exist — no runtime checks needed. Layer 2 adds fine-grained control within loaded extensions (e.g., allow reading `/data/` but deny writing).
+
+Most embedders need only Layer 1. Layer 2 is for cases where an extension must be partially available (e.g., filesystem read but not write).
+
+## Extension Security Classification
+
+Each extension falls into one of three categories:
+
+| Category | Extensions | Threat |
+|----------|-----------|--------|
+| **Safe** | core, io, exceptions, math, all | Pure computation + in-memory ports. No ambient authority. |
+| **Privileged** | files, eval, system, gointerop | Ambient authority: filesystem, process env, code loading, Go bridge. |
+| **Context-dependent** | threads | Resource exhaustion, concurrency bugs. Safe for trusted code. |
+
+### Detailed breakdown
+
+**Safe extensions** — no external side effects:
+
+| Extension | Package | What it provides |
+|-----------|---------|-----------------|
+| core | `registry/core` | Pairs, lists, arithmetic, control, vectors, strings, characters, bytevectors, syntax, parameters, prompts, boxes, hashtables, equality, predicates, special forms, bootstrap macros |
+| io | `internal/extensions/io` | `read`, `write`, `display`, `newline`, string/bytevector ports, `current-input-port`, `current-output-port`, `current-error-port`, port predicates, binary I/O. All in-memory or on caller-provided ports — no filesystem access. |
+| exceptions | `extensions/exceptions` | `raise`, `with-exception-handler`, `guard`, `error`, `error-object?` |
+| math | `extensions/math` | `sqrt`, `sin`, `cos`, trigonometric/transcendental functions |
+| all | `internal/extensions/all` | Records, promises, `string-copy!`, `string-fill!` |
+
+**Privileged extensions** — require trust or authorization:
+
+| Extension | Package | Capability granted |
+|-----------|---------|-------------------|
+| files | `extensions/files` | `open-input-file`, `open-output-file`, `delete-file`, `file-exists?`, `call-with-input-file`, `call-with-output-file`, `with-input-from-file`, `with-output-to-file` |
+| eval | `internal/extensions/eval` | `eval`, `load`, `interaction-environment`, `scheme-report-environment`, `null-environment`, `environment`, `syntax-expand`, `compile` |
+| system | `extensions/system` | `exit`, `emergency-exit`, `command-line`, `get-environment-variable`, `get-environment-variables` |
+| gointerop | `extensions/gointerop` | Go function bridge — arbitrary Go code execution |
+
+**Context-dependent:**
+
+| Extension | Package | Risk |
+|-----------|---------|------|
+| threads | `extensions/threads` | SRFI-18 threads, mutexes, condition variables. Resource exhaustion via unbounded thread creation. Safe for trusted code; risky for untrusted. |
+
+## How propagation works
+
+The `LibraryEnvFactory` in `engine.go:182-211` closes over the engine's registry. When a library is loaded via `(import ...)`, the factory creates a new environment and applies the *same* registry. This means:
+
+1. If files extension isn't loaded, no library can access the filesystem — even if a `.sld` file on disk contains `(import (scheme file))`.
+2. Extension libraries registered as synthetic R7RS libraries (e.g., `(wile math)`) only export primitives that exist in the engine's registry.
+3. Standard R7RS libraries loaded from `.sld` files get environments created by the factory, so they inherit the same restrictions.
+
+**The restriction is transitive and hermetic** — there's no way for Scheme code to escalate privileges within a single engine.
+
+## Concrete work items
+
+### Phase 1: Convenience API
+
+Add a `SafeExtensions()` function that returns the safe extension set:
+
+```go
+// SafeExtensions returns extensions suitable for sandboxed engines:
+// io, exceptions, math, and all. These provide R7RS (scheme base)
+// functionality without filesystem, eval, system, or Go interop access.
+func SafeExtensions() []EngineOption
+```
+
+Usage:
+
+```go
+eng, err := wile.NewEngine(ctx,
+    append(wile.SafeExtensions(),
+        wile.WithLibraryPaths("./lib"),
+    )...,
+)
+```
+
+**Location**: `options.go`
+
+**Open question**: Should this be a single `WithSafeExtensions()` option or a function returning a slice? The slice is more composable (`append(SafeExtensions(), WithExtension(threads.Extension))`), but a single option is simpler for the common case. Leaning toward the single option with the slice available as a package-level variable.
+
+### Phase 2: Document security boundaries
+
+Add a `docs/SANDBOXING.md` covering:
+
+- The two-layer model (extension-level + authorization)
+- Extension security classification table
+- Example: minimal sandbox, safe sandbox, full-featured sandbox
+- How library propagation works
+- What sandboxing does NOT cover (resource limits, CPU/memory, stack depth — separate concerns; `WithMaxCallDepth` exists for stack)
+- Relationship to `AUTHORIZATION_FRAMEWORK.md`
+
+### Phase 3: Verify isolation invariants
+
+Write integration tests that verify:
+
+1. An engine without files extension rejects `(open-input-file "x")` with an unbound-variable error (not a runtime error — the binding shouldn't exist at all).
+2. A library loaded by a restricted engine also lacks the restricted primitives.
+3. `(import (scheme file))` fails in a restricted engine (library exists on disk but its environment lacks the primitives, or the synthetic library isn't registered).
+4. `eval` in a restricted engine (without eval extension) is unbound.
+
+**Location**: `integration/sandbox_test.go` or `engine_sandbox_test.go`
+
+### Phase 4: Registry filtering
+
+Add methods to `Registry` that let embedders subtract primitives from a fully-populated registry. This enables fine-grained control within extensions without requiring every extension to be rebuilt from scratch.
+
+**The use case:** An embedder wants the full language minus mutation — no `set!`, `set-car!`, `set-cdr!`, `vector-set!`, `string-set!`, `list-set!`, `hashtable-set!`, `set-box!`. Or: include the io extension but remove `read` (output-only sandbox). Extension-level filtering (Phase 1) can't express this; you need per-primitive granularity.
+
+**API — two methods on `Registry`:**
+
+```go
+// Without returns a new Registry with the named primitives removed.
+// Names that don't match any registered primitive are silently ignored.
+// Compile-time bindings, init funcs, macro sources, and global values
+// are copied unchanged.
+func (p *Registry) Without(names ...string) *Registry
+
+// WithoutCategory returns a new Registry with all primitives in the
+// named categories removed. Categories are matched against PrimitiveSpec.Category.
+func (p *Registry) WithoutCategory(categories ...string) *Registry
+```
+
+**Usage:**
+
+```go
+// Immutable sandbox: full core, no mutation primitives
+reg := registry.NewRegistry()
+core.AddToRegistry(reg)
+io.AddToRegistry(reg)
+restricted := reg.Without(
+    "set!", "set-car!", "set-cdr!",
+    "vector-set!", "string-set!", "list-set!",
+    "hashtable-set!", "hashtable-delete!", "hashtable-clear!",
+    "set-box!",
+)
+eng, err := wile.NewEngine(ctx, wile.WithRegistry(restricted))
+```
+
+```go
+// Remove all hashtable primitives by category
+restricted := reg.WithoutCategory("hashtables")
+```
+
+**Implementation:** Both methods iterate `p.primitives`, skip matches, copy the rest into a new `Registry`. `Clone()` already exists and provides the pattern. Bindings, init funcs, macro sources, and global values are copied as-is — filtering only applies to primitives.
+
+**What about compile-time bindings?** `set!` is both a compile-time binding (in `specialforms.go`) and a runtime operation (compiled by the compiler). Removing the primitive from the registry doesn't remove the compile-time binding — the compiler would still recognize `set!` as a special form but would have no runtime implementation. This would produce a compile-time error, which is the correct behavior: "I know what `set!` means, but you can't use it here."
+
+However, if the goal is to make `set!` completely unbound (as if it never existed), the filter would also need to operate on compile-time bindings. This suggests a third method or an option:
+
+```go
+// WithoutBindings returns a new Registry with the named compile-time
+// bindings also removed. Use after Without() to fully erase a name.
+func (p *Registry) WithoutBindings(names ...string) *Registry
+```
+
+**Open question:** Is compile-error-on-`set!` sufficient, or does it need to be fully unbound? Compile error is arguably better — it tells the programmer "mutation is disallowed" rather than the confusing "undefined variable: set!". But this is a UX decision for the embedder.
+
+**What filtering does NOT cover:**
+- Bootstrap macros are registered as source strings, not as named primitives. You can't selectively remove `cond` or `let` via `Without()`. This is fine — derived forms are pure syntax transformations with no capability implications.
+- Syntax compilers and primitive expanders are registered via `machine.RegisterSyntaxCompilers` / `machine.RegisterPrimitiveExpanders`, outside the registry. These are core language constructs (`if`, `lambda`, `define`), not capabilities.
+
+**Location:** `registry/registry.go` (methods on `*Registry`)
+
+**Existing infrastructure:**
+- `Registry.Clone()` — deep copy pattern to follow
+- `PrimitiveSpec.Category` — already on every primitive (15 categories in core, plus extension categories like `"io"`, `"ports"`, `"eval"`, `"records"`, `"promises"`)
+- `PrimitivesByCategory()` — read-only grouping, exists but only for inspection
+
+### Phase 5: Library name in factory signature
+
+Pass the library name through `LibraryEnvFactory` so the factory knows which library it's creating an environment for. This is a low-cost signature change that enables per-library policies in the future and makes the loading path self-documenting.
+
+**Current signature** (`environment/top_level_environment.go:29`):
+
+```go
+type LibraryEnvFactory func(context.Context, *EnvironmentFrame) (*EnvironmentFrame, error)
+```
+
+**Proposed signature:**
+
+```go
+type LibraryEnvFactory func(context.Context, *EnvironmentFrame, machine.LibraryName) (*EnvironmentFrame, error)
+```
+
+**Note:** This introduces a dependency from `environment/` on `machine.LibraryName`. If that's undesirable (layering violation — `environment/` is lower than `machine/`), alternatives:
+- Move `LibraryName` to `environment/` or a shared package (e.g., `values/`)
+- Use `[]string` directly in the signature and convert at the call site
+- Define a minimal interface or type alias in `environment/`
+
+The `[]string` option is simplest and avoids the dependency entirely:
+
+```go
+type LibraryEnvFactory func(context.Context, *EnvironmentFrame, []string) (*EnvironmentFrame, error)
+```
+
+**Blast radius** — well-contained:
+
+| What | Where | Change |
+|------|-------|--------|
+| Type definition | `environment/top_level_environment.go:29` | Add `[]string` param |
+| Field + getter + setter | `environment/top_level_environment.go:80,236,241` | Follows from type |
+| Call site (only one) | `machine/library_loader.go:130` | Pass `expectedName.Parts` — already in scope |
+| Engine factory closure | `engine.go:182` | Add param to closure signature (ignore or log) |
+| Bootstrap factory | `internal/bootstrap/environment_tiny.go:148` | Add param to `NewLibraryEnvironmentFrame` |
+| CLI setup | `cmd/scheme/main.go:191` | Points to bootstrap factory |
+| Tests | `machine/library_test.go:309,745`, `machine/library_scheme_test.go:54` | Point to bootstrap factory |
+| Docs | `docs/EXTENSION_LIBRARIES.md`, `docs/dev/ENVIRONMENT_SYSTEM.md` | Text updates |
+
+Factories that don't need the name ignore the parameter. The engine factory could log it or pass it to a future policy callback.
+
+### Phase 6: Library load observability
+
+Add an optional observer that records library load events. This gives embedders visibility into which libraries were loaded, what they exported, and what bindings actually flowed into the importer.
+
+**Observer interface:**
+
+```go
+// LibraryImportEvent records what happened when a library was imported.
+type LibraryImportEvent struct {
+    Library     []string          // imported library name parts, e.g., ["scheme", "base"]
+    SourceFile  string            // path to .sld file (empty for synthetic libraries)
+    Exports     []string          // all names exported by the library
+    Imported    []string          // names that actually landed in the importer (after only/except/prefix/rename)
+    Importer    []string          // importing library name (nil for top-level import)
+}
+```
+
+**Integration points:**
+
+There are three sites that process `(import ...)`:
+
+| Site | File | Context |
+|------|------|---------|
+| `processLibraryImport` | `compile_time_continuation_library.go:300` | Inside `define-library` — has `lib *CompiledLibrary`, so importer name is `lib.Name` |
+| `CompileImport` | `compile_time_continuation_library.go:717` | Top-level `(import ...)` — importer is `nil` (script/REPL) |
+| `expandImportForm` | `expander_time_continuation.go:747` | Top-level during expansion — importer is `nil` (script/REPL) |
+
+The key insight: `processLibraryImport` already receives the importing library as `lib *CompiledLibrary`. The importer identity is in scope — it's just not passed further. The other two sites are top-level imports where `nil` is the correct importer identity (not a missing value).
+
+All three sites follow the same sequence:
+1. `LoadLibrary` → get `*CompiledLibrary` (library name, exports, source file)
+2. `ApplyToExports` → get post-modifier bindings (what actually lands)
+3. `CopyLibraryBindingsToEnvAtPhase` → install bindings
+
+The callback fires between steps 2 and 3, where all information converges.
+
+**Where the data lives now:**
+
+| Information | Available at | Currently stored? |
+|-------------|-------------|-------------------|
+| Library name | `LoadLibrary` / `CompiledLibrary.Name` | Yes — in `LibraryRegistry` |
+| Source file | `loadLibraryFromFile` / `CompiledLibrary.SourceFile` | Yes — in `CompiledLibrary` |
+| Export list | `CompiledLibrary.Exports` | Yes — in `CompiledLibrary` |
+| Post-modifier bindings | `ApplyToExports` return value | **No** — computed and consumed, not stored |
+| Importing library name | `processLibraryImport` `lib` param | **In scope but not propagated** |
+
+**Approach:** Add an optional `LibraryImportObserver` callback to `LibraryRegistry` or `TopLevelEnvironment`. Fire it at all three import sites, between `ApplyToExports` and `CopyLibraryBindingsToEnvAtPhase`. The observer is read-only — it observes but doesn't influence the import.
+
+```go
+type LibraryImportObserver func(LibraryImportEvent)
+```
+
+Embedders that don't set it pay nothing (nil check before firing).
+
+**Future extension path:** If the observer's return type changes from nothing to `error`, it becomes an enforcement hook — a callback that can reject an import. The call sites already have error handling around the import step. This is additive (change the callback signature), not a redesign. The plan does NOT include enforcement; it only includes observation. But the architecture doesn't prevent it.
+
+### Phase 7: Bootstrap factory alignment (optional)
+
+The bootstrap factory (`internal/bootstrap/environment_tiny.go:53-65`) hardcodes `allExtensions` and loads everything. This is the test/standalone path (used by `NewTopLevelEnvironmentFrameTiny` and `NewLibraryEnvironmentFrame`).
+
+For the engine path this doesn't matter — the engine uses its own factory. But the bootstrap factory creates an inconsistency: tests that use `NewLibraryEnvironmentFrame` directly get full capabilities regardless of any restriction the test intends.
+
+**Deferred** — only matters if tests need to verify sandboxed library behavior through the bootstrap path, which they shouldn't.
+
+## Scope boundaries
+
+**Covered by this plan:**
+- Extension-level capability control
+- Convenience API for sandbox profiles
+- Documentation of security boundaries
+- Integration tests for isolation
+- Registry filtering (`Without`, `WithoutCategory`) for per-primitive control
+- Library name in factory signature (forward-compatible for per-library policies)
+- Library load observability (what was loaded, what bindings landed where)
+
+**Covered by AUTHORIZATION_FRAMEWORK.md:**
+- Fine-grained per-operation authorization within loaded extensions
+- `Check(AccessRequest)` at runtime primitive call sites
+- `FilesystemRoot`, `ReadOnly`, `DenyAll` authorizers
+
+**Not covered (separate concerns):**
+- Resource limits: CPU time, memory, allocation rate — requires VM-level instrumentation
+- Stack depth limits: `WithMaxCallDepth` already exists
+- Network access: no network primitives exist yet; when added, they'd be a new privileged extension
+- Per-library policies (enforcement): Phase 4 passes the library name through the factory, which *enables* per-library policies. The actual policy mechanism (allowlist, callback, etc.) is future work — build when there's demand.
+- Information flow: a privileged library can pass capabilities (e.g., open file handle) to an unprivileged library via exported values. Preventing this requires an object-capability model, which is a fundamental architecture change.
+
+## Dependencies
+
+- Phase 1 (convenience API): None
+- Phase 2 (documentation): None
+- Phase 3 (integration tests): Phase 1
+- Phase 4 (registry filtering): None — operates on `Registry` type, independent of other phases
+- Phase 5 (factory signature): None (mechanical change)
+- Phase 6 (observability): Phase 5 (needs library name in factory for importer tracking)
+- Phase 7 (bootstrap alignment): Deferred
+- `AUTHORIZATION_FRAMEWORK.md` is independent and can proceed in parallel
+
+## Decision log
+
+| Decision | Rationale |
+|----------|-----------|
+| Extension-level as primary mechanism | Embedder is the security principal. Extensions are already opt-in. Zero-cost when extension not loaded. |
+| `export` is not a security mechanism | `export` controls outward visibility (namespace management), not inward capability. A library with full imports can do anything regardless of its export list. |
+| Safe = no ambient authority | Extensions classified as safe have no way to affect the outside world. io extension uses caller-provided ports or in-memory ports — no filesystem access. |
+| `[]string` over `LibraryName` in factory | Avoids `environment/` → `machine/` dependency. `LibraryName.Parts` is `[]string` internally; convert at call site. |
+| Observer as optional callback | Embedders that don't need observability pay nothing. No allocation, no interface dispatch on the hot path. Observer is read-only — observation now, enforcement later if needed (change return type to `error`). |
+| Post-modifier bindings not stored | Computed on demand by `ApplyToExports`. Storing them would mean every import set grows. Observer callback is fire-and-forget — cheaper than persistent storage. |
+| Importer identity is already in scope | `processLibraryImport` has `lib *CompiledLibrary` — the importing library name. Top-level sites (`CompileImport`, `expandImportForm`) correctly have `nil` importer. No new threading needed; just pass what's already available into the callback. |
+| Subtraction over composition for filtering | `Without()` starts from the full registry and removes. Alternative (export individual `add*` functions for embedders to compose) requires embedders to know the internal structure of core. Subtraction is simpler: start with everything, remove what you don't want. |
+| Compile-time binding removal separate from primitive removal | `Without()` removes runtime primitives. Compile-time bindings (`set!` as special form) stay — the compiler recognizes the form but the runtime rejects it. This produces a clear compile error ("mutation disallowed") rather than a confusing unbound-variable error. `WithoutBindings()` available for embedders who want full erasure. |
+| Per-library enforcement deferred | Phase 5 threads the library name through the factory. Phase 6 observes imports with importer identity. Enforcement (blocking imports) is a future callback return-type change, not a redesign. |


### PR DESCRIPTION
## Summary

Three interconnected design plans for Wile's extension architecture:

- **SANDBOXING_MODEL.md**: Two-layer sandboxing model (extension-level + authorization). Security classification of all extensions (safe/privileged/context-dependent). Registry filtering API (`Without`, `WithoutCategory`). Library load observability via import observer callback. Factory signature change to pass library name for per-library context.

- **DIALECT_SYSTEM.md**: De-globalize the forms registry (`internal/forms/form_spec.go`) to enable per-engine language personalities. Extract R7RS as the default dialect via a `Dialect` type and `WithDialect()` option. The single structural blocker is the package-level global `map[string]*FormSpec`.

- **MODULE_DECOMPOSITION.md**: Split extensions into separate Go modules (`wile-io`, `wile-files`, `wile-math`, etc.). Defines the core boundary (~148 primitives + 16 bootstrap macros that depend only on core). Two-tier initialization model: Tier 1 (bootstrap `AddMacroSource`) for core-only macros, Tier 2 (R7RS library system) for extension Scheme code. Go workspace pattern for multi-module development.

## Test plan

- [ ] Plans are documentation only — no code changes to test
- [ ] Verify plan files render correctly in GitHub markdown
- [ ] Cross-reference consistency between the three plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)