### PR TITLE
add EditPlan for bytecode instruction range manipulation

### DIFF
--- a/machine/edit_plan.go
+++ b/machine/edit_plan.go
@@ -1,0 +1,271 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"sort"
+
+	"github.com/aalpar/wile/values"
+)
+
+// EditPlan collects non-overlapping bytecode edits for a NativeTemplate.
+// Edits are applied in a single pass via Apply, which rewrites code,
+// sourceRefs, and branch offsets, then garbage-collects unreferenced
+// sideTable entries.
+type EditPlan struct {
+	tpl   *NativeTemplate
+	edits []edit
+}
+
+type edit struct {
+	start, end int           // [start, end) range in original code to replace
+	replace    []Instruction // replacement instructions (nil = pure deletion)
+	sourceRef  uint16        // source ref for all replacement instructions
+}
+
+// NewEditPlan creates a new edit plan for the given template.
+func NewEditPlan(tpl *NativeTemplate) *EditPlan {
+	return &EditPlan{tpl: tpl}
+}
+
+// AddLiteral adds a value to the template's literal pool, with deduplication.
+// Returns the index suitable for use in Instruction.Arg fields that reference
+// the literal pool (OpLoadLiteral, OpLoadGlobal, OpStoreGlobal).
+func (p *EditPlan) AddLiteral(v values.Value) int32 {
+	return int32(p.tpl.MaybeAppendLiteral(v))
+}
+
+// Replace marks the range [start, end) for replacement with instrs.
+// src is the source reference for all inserted instructions.
+func (p *EditPlan) Replace(start, end int, instrs []Instruction, src uint16) {
+	p.edits = append(p.edits, edit{
+		start:     start,
+		end:       end,
+		replace:   instrs,
+		sourceRef: src,
+	})
+}
+
+// Delete marks the range [start, end) for removal.
+func (p *EditPlan) Delete(start, end int) {
+	p.Replace(start, end, nil, 0)
+}
+
+// Insert inserts instrs before the instruction at position at.
+func (p *EditPlan) Insert(at int, instrs []Instruction, src uint16) {
+	p.Replace(at, at, instrs, src)
+}
+
+// HasEdits reports whether any edits have been added.
+func (p *EditPlan) HasEdits() bool {
+	return len(p.edits) > 0
+}
+
+// Apply rewrites the template according to all accumulated edits:
+//  1. Sorts and validates edits (panics on overlap)
+//  2. Builds a PC remap from old positions to new positions
+//  3. Fixes branch offsets for surviving original instructions
+//  4. Rebuilds code + sourceRefs, splicing in replacements
+//  5. Garbage-collects unreferenced sideTable entries, remaps OpComplex.Arg
+//
+// Returns the net change in instruction count (negative means code shrunk).
+func (p *EditPlan) Apply() int {
+	if len(p.edits) == 0 {
+		return 0
+	}
+
+	oldLen := len(p.tpl.code)
+
+	sort.Slice(p.edits, func(i, j int) bool {
+		return p.edits[i].start < p.edits[j].start
+	})
+	validateEdits(p.edits, oldLen)
+
+	remap := buildEditRemap(p.edits, oldLen)
+	fixSurvivingBranches(p.tpl.code, p.edits, remap)
+	p.tpl.code, p.tpl.sourceRefs = rewriteCode(p.tpl.code, p.tpl.sourceRefs, p.edits)
+	gcSideTable(p.tpl)
+
+	return len(p.tpl.code) - oldLen
+}
+
+// validateEdits panics if any edits overlap or fall outside [0, codeLen].
+func validateEdits(edits []edit, codeLen int) {
+	for i, e := range edits {
+		if e.start < 0 || e.end > codeLen || e.start > e.end {
+			panic("edit_plan: edit out of bounds")
+		}
+		if i > 0 && e.start < edits[i-1].end {
+			panic("edit_plan: overlapping edits")
+		}
+	}
+}
+
+// buildEditRemap constructs a mapping from old PC positions to new PC
+// positions after all edits are applied. The returned slice has length
+// codeLen+1, where remap[codeLen] is the new sentinel position (total
+// length of the rewritten code).
+//
+// Positions inside a deleted range [start, end) all map to the new
+// position of the replacement's start, so branches targeting any
+// instruction in a replaced range land at the replacement.
+func buildEditRemap(edits []edit, codeLen int) []int {
+	remap := make([]int, codeLen+1)
+	delta := 0
+	editIdx := 0
+	i := 0
+
+	for i <= codeLen {
+		if editIdx < len(edits) && i == edits[editIdx].start {
+			e := edits[editIdx]
+			newStart := i + delta
+			for j := e.start; j < e.end; j++ {
+				remap[j] = newStart
+			}
+			delta += len(e.replace) - (e.end - e.start)
+			if e.end > e.start {
+				i = e.end
+			} else {
+				// Pure insertion at position i: i itself is not consumed.
+				remap[i] = i + delta
+				i++
+			}
+			editIdx++
+		} else {
+			remap[i] = i + delta
+			i++
+		}
+	}
+
+	return remap
+}
+
+// isBranchOp returns true for opcodes whose Arg is a relative PC offset
+// that must be adjusted when instructions are removed or inserted.
+func isBranchOp(op OpCode) bool {
+	return op == OpBranch ||
+		op == OpBranchOnFalseValue ||
+		op == OpSaveContinuation
+}
+
+// fixSurvivingBranches adjusts branch offsets for original instructions
+// that survive (are not inside any edit range). Replacement instructions
+// are left as-is — the caller is responsible for their offsets.
+func fixSurvivingBranches(code []Instruction, edits []edit, remap []int) {
+	inEdit := make([]bool, len(code))
+	for _, e := range edits {
+		for j := e.start; j < e.end; j++ {
+			inEdit[j] = true
+		}
+	}
+
+	for i := range code {
+		if inEdit[i] {
+			continue
+		}
+		if !isBranchOp(code[i].Op) {
+			continue
+		}
+		absTarget := i + int(code[i].Arg)
+		code[i].Arg = int32(remap[absTarget] - remap[i])
+	}
+}
+
+// rewriteCode builds new code and sourceRefs arrays by copying surviving
+// segments and splicing in replacement instructions from each edit.
+func rewriteCode(code []Instruction, sourceRefs []uint16, edits []edit) ([]Instruction, []uint16) {
+	// Compute new length.
+	newLen := len(code)
+	for _, e := range edits {
+		newLen += len(e.replace) - (e.end - e.start)
+	}
+
+	newCode := make([]Instruction, 0, newLen)
+	newRefs := make([]uint16, 0, newLen)
+	prev := 0
+
+	for _, e := range edits {
+		// Copy surviving segment before this edit.
+		newCode = append(newCode, code[prev:e.start]...)
+		newRefs = append(newRefs, sourceRefs[prev:e.start]...)
+
+		// Splice in replacement.
+		newCode = append(newCode, e.replace...)
+		for range e.replace {
+			newRefs = append(newRefs, e.sourceRef)
+		}
+		prev = e.end
+	}
+
+	// Copy trailing segment after last edit.
+	newCode = append(newCode, code[prev:]...)
+	newRefs = append(newRefs, sourceRefs[prev:]...)
+
+	return newCode, newRefs
+}
+
+// gcSideTable removes unreferenced sideTable entries and remaps
+// OpComplex.Arg values to the compacted indices.
+func gcSideTable(tpl *NativeTemplate) {
+	if len(tpl.sideTable) == 0 {
+		return
+	}
+
+	// Mark which entries are still referenced.
+	referenced := make([]bool, len(tpl.sideTable))
+	for _, instr := range tpl.code {
+		if instr.Op == OpComplex {
+			referenced[instr.Arg] = true
+		}
+	}
+
+	// Check if GC is needed.
+	deadCount := 0
+	for _, ref := range referenced {
+		if !ref {
+			deadCount++
+		}
+	}
+	if deadCount == 0 {
+		return
+	}
+
+	// Build old index → new index mapping.
+	newIdx := make([]int32, len(tpl.sideTable))
+	w := int32(0)
+	for i, ref := range referenced {
+		if ref {
+			newIdx[i] = w
+			w++
+		}
+	}
+
+	// Remap OpComplex.Arg in code.
+	for i := range tpl.code {
+		if tpl.code[i].Op == OpComplex {
+			tpl.code[i].Arg = newIdx[tpl.code[i].Arg]
+		}
+	}
+
+	// Compact sideTable in place.
+	j := 0
+	for i, ref := range referenced {
+		if ref {
+			tpl.sideTable[j] = tpl.sideTable[i]
+			j++
+		}
+	}
+	tpl.sideTable = tpl.sideTable[:j]
+}

--- a/machine/edit_plan_test.go
+++ b/machine/edit_plan_test.go
@@ -1,0 +1,450 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"testing"
+
+	"github.com/aalpar/wile/values"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// --- EditPlan Core ---
+
+func TestEditPlan_EmptyPlan(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{{Op: OpLoadVoid}, {Op: OpPush}}
+	tpl.sourceRefs = []uint16{1, 2}
+
+	plan := NewEditPlan(tpl)
+	delta := plan.Apply()
+
+	qt.Assert(t, delta, qt.Equals, 0)
+	qt.Assert(t, len(tpl.code), qt.Equals, 2)
+}
+
+func TestEditPlan_HasEdits(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{{Op: OpLoadVoid}}
+	tpl.sourceRefs = []uint16{0}
+
+	plan := NewEditPlan(tpl)
+	qt.Assert(t, plan.HasEdits(), qt.IsFalse)
+
+	plan.Delete(0, 1)
+	qt.Assert(t, plan.HasEdits(), qt.IsTrue)
+}
+
+// --- Delete ---
+
+func TestEditPlan_SingleDelete(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpStoreGlobal, Arg: 0},
+		{Op: OpLoadVoid}, // delete this
+		{Op: OpLoadLiteral, Arg: 1},
+		{Op: OpPush},
+	}
+	tpl.sourceRefs = []uint16{1, 2, 3, 4}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 2)
+	delta := plan.Apply()
+
+	qt.Assert(t, delta, qt.Equals, -1)
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpStoreGlobal, OpLoadLiteral, OpPush})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{1, 3, 4})
+}
+
+func TestEditPlan_DeleteRange(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpStoreGlobal, Arg: 0}, // 0: keep
+		{Op: OpLoadVoid},            // 1: delete
+		{Op: OpPush},                // 2: delete
+		{Op: OpLoadLiteral, Arg: 1}, // 3: delete
+		{Op: OpApply},               // 4: keep
+	}
+	tpl.sourceRefs = []uint16{1, 2, 3, 4, 5}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 4)
+	plan.Apply()
+
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpStoreGlobal, OpApply})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{1, 5})
+}
+
+func TestEditPlan_MultipleDeletes(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpLoadLiteral, Arg: 0}, // 0: keep
+		{Op: OpLoadVoid},            // 1: delete
+		{Op: OpPush},                // 2: keep
+		{Op: OpLoadVoid},            // 3: delete
+		{Op: OpApply},               // 4: keep
+	}
+	tpl.sourceRefs = []uint16{1, 2, 3, 4, 5}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 2)
+	plan.Delete(3, 4)
+	plan.Apply()
+
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpLoadLiteral, OpPush, OpApply})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{1, 3, 5})
+}
+
+// --- Replace ---
+
+func TestEditPlan_SingleReplace(t *testing.T) {
+	// Simulates constant folding: replace a call sequence with a single LoadLiteral.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpSaveContinuation, Arg: 8}, // 0
+		{Op: OpLoadGlobal, Arg: 0},       // 1
+		{Op: OpPush},                     // 2
+		{Op: OpLoadLiteral, Arg: 1},      // 3
+		{Op: OpPush},                     // 4
+		{Op: OpLoadLiteral, Arg: 2},      // 5
+		{Op: OpPush},                     // 6
+		{Op: OpPull},                     // 7
+		{Op: OpApply},                    // 8
+		{Op: OpPush},                     // 9: after the call
+	}
+	tpl.sourceRefs = []uint16{10, 10, 10, 10, 10, 10, 10, 10, 10, 11}
+	tpl.literals = MultipleValues{values.NewSymbol("+"), values.NewInteger(3), values.NewInteger(4)}
+
+	plan := NewEditPlan(tpl)
+	litIdx := plan.AddLiteral(values.NewInteger(7))
+	plan.Replace(0, 9, []Instruction{
+		{Op: OpLoadLiteral, Arg: litIdx},
+	}, 10)
+	plan.Apply()
+
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpLoadLiteral, OpPush})
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, litIdx)
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{10, 11})
+}
+
+func TestEditPlan_ReplaceWithLarger(t *testing.T) {
+	// Replace one instruction with three.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpLoadVoid}, // 0: replace with 3 instrs
+		{Op: OpPush},     // 1: keep
+	}
+	tpl.sourceRefs = []uint16{1, 2}
+
+	plan := NewEditPlan(tpl)
+	plan.Replace(0, 1, []Instruction{
+		{Op: OpLoadLiteral, Arg: 0},
+		{Op: OpPush},
+		{Op: OpPop},
+	}, 5)
+	plan.Apply()
+
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpLoadLiteral, OpPush, OpPop, OpPush})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{5, 5, 5, 2})
+}
+
+// --- Insert ---
+
+func TestEditPlan_Insert(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpLoadVoid}, // 0
+		{Op: OpPush},     // 1
+	}
+	tpl.sourceRefs = []uint16{1, 2}
+
+	plan := NewEditPlan(tpl)
+	plan.Insert(1, []Instruction{
+		{Op: OpLoadLiteral, Arg: 0},
+	}, 3)
+	plan.Apply()
+
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpLoadVoid, OpLoadLiteral, OpPush})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{1, 3, 2})
+}
+
+// --- Branch Fixup ---
+
+func TestEditPlan_BranchShrinks(t *testing.T) {
+	// Branch spans a deleted range; offset must shrink.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpBranch, Arg: 4},      // 0: target = 4
+		{Op: OpStoreGlobal, Arg: 0}, // 1
+		{Op: OpLoadVoid},            // 2: delete
+		{Op: OpLoadLiteral, Arg: 1}, // 3
+		{Op: OpApply},               // 4
+	}
+	tpl.sourceRefs = make([]uint16, 5)
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(2, 3)
+	plan.Apply()
+
+	// After: [0] Branch +3  [1] StoreGlobal  [2] LoadLiteral  [3] Apply
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, int32(3))
+}
+
+func TestEditPlan_BranchGrows(t *testing.T) {
+	// Branch spans an insertion; offset must grow.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpBranch, Arg: 2}, // 0: target = 2
+		{Op: OpPush},           // 1
+		{Op: OpApply},          // 2
+	}
+	tpl.sourceRefs = make([]uint16, 3)
+
+	plan := NewEditPlan(tpl)
+	plan.Insert(1, []Instruction{
+		{Op: OpLoadVoid},
+		{Op: OpLoadVoid},
+	}, 0)
+	plan.Apply()
+
+	// After: [0] Branch +4  [1] LoadVoid  [2] LoadVoid  [3] Push  [4] Apply
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, int32(4))
+}
+
+func TestEditPlan_BranchAcrossReplace(t *testing.T) {
+	// Branch at 0 targets 6. Replace [2,5) with 1 instruction.
+	// Net: delete 3, insert 1 => shrink by 2.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpBranch, Arg: 6}, // 0: target = 6
+		{Op: OpPush},           // 1
+		{Op: OpLoadVoid},       // 2: replaced
+		{Op: OpLoadVoid},       // 3: replaced
+		{Op: OpLoadVoid},       // 4: replaced
+		{Op: OpPush},           // 5
+		{Op: OpApply},          // 6
+	}
+	tpl.sourceRefs = make([]uint16, 7)
+
+	plan := NewEditPlan(tpl)
+	plan.Replace(2, 5, []Instruction{
+		{Op: OpLoadLiteral, Arg: 0},
+	}, 0)
+	plan.Apply()
+
+	// After: [0] Branch +4  [1] Push  [2] LoadLiteral  [3] Push  [4] Apply
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, int32(4))
+}
+
+func TestEditPlan_SaveContinuationSentinel(t *testing.T) {
+	// SaveContinuation targeting past the end (sentinel).
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpSaveContinuation, Arg: 4}, // 0: target = 4 (sentinel)
+		{Op: OpLoadVoid},                 // 1: delete
+		{Op: OpLoadLiteral, Arg: 0},      // 2
+		{Op: OpApply},                    // 3
+	}
+	tpl.sourceRefs = make([]uint16, 4)
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 2)
+	plan.Apply()
+
+	// After: [0] SaveContinuation +3  [1] LoadLiteral  [2] Apply
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, int32(3))
+}
+
+func TestEditPlan_BranchBeforeReplace_NotSpanning(t *testing.T) {
+	// Branch whose target is before the edit — should be unchanged.
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpPush},            // 0
+		{Op: OpBranch, Arg: -1}, // 1: target = 0 (backward)
+		{Op: OpLoadVoid},        // 2: delete
+		{Op: OpApply},           // 3
+	}
+	tpl.sourceRefs = make([]uint16, 4)
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(2, 3)
+	plan.Apply()
+
+	// After: [0] Push  [1] Branch -1  [2] Apply
+	qt.Assert(t, tpl.code[1].Arg, qt.Equals, int32(-1))
+}
+
+// --- AddLiteral ---
+
+func TestEditPlan_AddLiteral_New(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{{Op: OpLoadVoid}}
+	tpl.sourceRefs = []uint16{0}
+	tpl.literals = MultipleValues{values.NewInteger(1)}
+
+	plan := NewEditPlan(tpl)
+	idx := plan.AddLiteral(values.NewInteger(42))
+
+	qt.Assert(t, idx, qt.Equals, int32(1))
+	qt.Assert(t, len(tpl.literals), qt.Equals, 2)
+}
+
+func TestEditPlan_AddLiteral_Dedup(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{{Op: OpLoadVoid}}
+	tpl.sourceRefs = []uint16{0}
+	tpl.literals = MultipleValues{values.NewInteger(42)}
+
+	plan := NewEditPlan(tpl)
+	idx := plan.AddLiteral(values.NewInteger(42))
+
+	qt.Assert(t, idx, qt.Equals, int32(0))
+	qt.Assert(t, len(tpl.literals), qt.Equals, 1)
+}
+
+// --- SideTable GC ---
+
+func TestEditPlan_SideTableGC(t *testing.T) {
+	op0 := &OperationForeignFunctionCall{Function: func(_ *MachineContext) error { return nil }}
+	op1 := &OperationForeignFunctionCall{Function: func(_ *MachineContext) error { return nil }}
+	op2 := &OperationForeignFunctionCall{Function: func(_ *MachineContext) error { return nil }}
+
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpComplex, Arg: 0}, // 0: references op0
+		{Op: OpComplex, Arg: 1}, // 1: references op1 — will be deleted
+		{Op: OpComplex, Arg: 2}, // 2: references op2
+	}
+	tpl.sourceRefs = []uint16{0, 0, 0}
+	tpl.sideTable = []InlinedOperation{op0, op1, op2}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 2) // remove the instruction referencing op1
+	plan.Apply()
+
+	// op1 should be GC'd; op0 stays at 0, op2 remapped to 1.
+	qt.Assert(t, len(tpl.sideTable), qt.Equals, 2)
+	qt.Assert(t, tpl.code[0].Arg, qt.Equals, int32(0))
+	qt.Assert(t, tpl.code[1].Arg, qt.Equals, int32(1))
+	qt.Assert(t, tpl.sideTable[0], qt.Equals, InlinedOperation(op0))
+	qt.Assert(t, tpl.sideTable[1], qt.Equals, InlinedOperation(op2))
+}
+
+func TestEditPlan_SideTableGC_NoneUnreferenced(t *testing.T) {
+	op0 := &OperationForeignFunctionCall{Function: func(_ *MachineContext) error { return nil }}
+
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpComplex, Arg: 0},
+		{Op: OpLoadVoid}, // delete this (doesn't reference sideTable)
+		{Op: OpLoadLiteral, Arg: 0},
+	}
+	tpl.sourceRefs = []uint16{0, 0, 0}
+	tpl.sideTable = []InlinedOperation{op0}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(1, 2)
+	plan.Apply()
+
+	qt.Assert(t, len(tpl.sideTable), qt.Equals, 1) // no GC needed
+}
+
+// --- Validation ---
+
+func TestEditPlan_OverlappingEdits_Panics(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpLoadVoid},
+		{Op: OpPush},
+		{Op: OpApply},
+	}
+	tpl.sourceRefs = make([]uint16, 3)
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(0, 2)
+	plan.Delete(1, 3) // overlaps with first
+
+	qt.Assert(t, func() { plan.Apply() }, qt.PanicMatches, "edit_plan: overlapping edits")
+}
+
+func TestEditPlan_OutOfBounds_Panics(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{{Op: OpLoadVoid}}
+	tpl.sourceRefs = []uint16{0}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(0, 5) // end > len(code)
+
+	qt.Assert(t, func() { plan.Apply() }, qt.PanicMatches, "edit_plan: edit out of bounds")
+}
+
+// --- Compound: Delete + Replace + Insert in one plan ---
+
+func TestEditPlan_MixedEdits(t *testing.T) {
+	tpl := NewEmptyNativeTemplate()
+	tpl.code = []Instruction{
+		{Op: OpLoadVoid},            // 0: delete
+		{Op: OpPush},                // 1: keep
+		{Op: OpLoadLiteral, Arg: 0}, // 2: replace with 2 instrs
+		{Op: OpApply},               // 3: keep
+	}
+	tpl.sourceRefs = []uint16{1, 2, 3, 4}
+
+	plan := NewEditPlan(tpl)
+	plan.Delete(0, 1)
+	plan.Replace(2, 3, []Instruction{
+		{Op: OpLoadGlobal, Arg: 0},
+		{Op: OpPop},
+	}, 7)
+	delta := plan.Apply()
+
+	// New: [Push, LoadGlobal, Pop, Apply]
+	qt.Assert(t, delta, qt.Equals, 0) // -1 + 1 = 0 net
+	qt.Assert(t, opcodes(tpl), qt.DeepEquals, []OpCode{OpPush, OpLoadGlobal, OpPop, OpApply})
+	qt.Assert(t, tpl.sourceRefs, qt.DeepEquals, []uint16{2, 7, 7, 4})
+}
+
+// --- buildEditRemap ---
+
+func TestBuildEditRemap_SingleDelete(t *testing.T) {
+	edits := []edit{{start: 2, end: 4}}
+	remap := buildEditRemap(edits, 6)
+
+	// old: 0 1 [2 3] 4 5  sentinel
+	// new: 0 1  2 2  2 3  4
+	qt.Assert(t, remap, qt.DeepEquals, []int{0, 1, 2, 2, 2, 3, 4})
+}
+
+func TestBuildEditRemap_SingleInsert(t *testing.T) {
+	edits := []edit{{start: 1, end: 1, replace: []Instruction{{Op: OpLoadVoid}, {Op: OpLoadVoid}}}}
+	remap := buildEditRemap(edits, 3)
+
+	// old: 0 1 2  sentinel
+	// Insert 2 instrs at position 1. After: 0 [new new] 1 2
+	// remap[0] = 0, remap[1] = 3 (shifted by 2), remap[2] = 4, remap[3] = 5
+	qt.Assert(t, remap, qt.DeepEquals, []int{0, 3, 4, 5})
+}
+
+func TestBuildEditRemap_Replace(t *testing.T) {
+	// Replace [1,3) with 1 instruction.
+	edits := []edit{{start: 1, end: 3, replace: []Instruction{{Op: OpLoadVoid}}}}
+	remap := buildEditRemap(edits, 5)
+
+	// old: 0 [1 2] 3 4  sentinel
+	// new: 0 [1]   2 3  4
+	// remap[0]=0, remap[1]=1 (replacement start), remap[2]=1, remap[3]=2, remap[4]=3, remap[5]=4
+	qt.Assert(t, remap, qt.DeepEquals, []int{0, 1, 1, 2, 3, 4})
+}

--- a/machine/peephole.go
+++ b/machine/peephole.go
@@ -29,19 +29,13 @@ package machine
 func (p *NativeTemplate) Optimize() {
 	n := len(p.code)
 	if n == 0 {
-		return
-	}
-
-	dead := make([]bool, n)
-	count := markDeadLoadVoid(p.code, dead)
-	if count == 0 {
 		p.optimizeSubTemplates()
 		return
 	}
 
-	pcRemap := buildPCRemap(dead)
-	fixBranchOffsets(p.code, dead, pcRemap)
-	p.code, p.sourceRefs = compact(p.code, p.sourceRefs, dead)
+	plan := NewEditPlan(p)
+	markDeadLoadVoidEdits(p.code, plan)
+	plan.Apply()
 
 	p.optimizeSubTemplates()
 }
@@ -66,77 +60,12 @@ func isLoadOp(op OpCode) bool {
 		op == OpLoadLocal
 }
 
-// isBranchOp returns true for opcodes whose Arg is a relative PC offset
-// that must be adjusted when instructions are removed.
-func isBranchOp(op OpCode) bool {
-	return op == OpBranch ||
-		op == OpBranchOnFalseValue ||
-		op == OpSaveContinuation
-}
-
-// markDeadLoadVoid scans code[0..len-2] and marks LoadVoid instructions
-// that are immediately followed by a load-family opcode. Returns the
-// number of dead instructions found.
-func markDeadLoadVoid(code []Instruction, dead []bool) int {
-	count := 0
+// markDeadLoadVoidEdits scans code[0..len-2] and adds Delete edits for
+// LoadVoid instructions immediately followed by a load-family opcode.
+func markDeadLoadVoidEdits(code []Instruction, plan *EditPlan) {
 	for i := 0; i < len(code)-1; i++ {
 		if code[i].Op == OpLoadVoid && isLoadOp(code[i+1].Op) {
-			dead[i] = true
-			count++
+			plan.Delete(i, i+1)
 		}
 	}
-	return count
-}
-
-// buildPCRemap constructs a mapping from old PC positions to new PC
-// positions after dead instructions are removed. The returned slice
-// has length len(dead)+1 so that pcRemap[len(dead)] gives the total
-// count of surviving instructions (used for targets at code end).
-//
-// Dead positions map to the same new index as the next surviving
-// instruction, so a branch targeting a dead position correctly lands
-// on the first survivor after it.
-func buildPCRemap(dead []bool) []int {
-	remap := make([]int, len(dead)+1)
-	removed := 0
-	for i, d := range dead {
-		remap[i] = i - removed
-		if d {
-			removed++
-		}
-	}
-	remap[len(dead)] = len(dead) - removed
-	return remap
-}
-
-// fixBranchOffsets adjusts the relative offset (Arg) of surviving branch
-// instructions so they target the same logical instruction after dead
-// entries are removed.
-func fixBranchOffsets(code []Instruction, dead []bool, pcRemap []int) {
-	for i := range code {
-		if dead[i] {
-			continue
-		}
-		if !isBranchOp(code[i].Op) {
-			continue
-		}
-		absTarget := i + int(code[i].Arg)
-		code[i].Arg = int32(pcRemap[absTarget] - pcRemap[i])
-	}
-}
-
-// compact removes dead entries from code and sourceRefs using an in-place
-// write cursor. Both slices are compacted in lockstep to maintain the
-// 1:1 correspondence between instructions and source references.
-func compact(code []Instruction, sourceRefs []uint16, dead []bool) ([]Instruction, []uint16) {
-	w := 0
-	for i := range code {
-		if dead[i] {
-			continue
-		}
-		code[w] = code[i]
-		sourceRefs[w] = sourceRefs[i]
-		w++
-	}
-	return code[:w], sourceRefs[:w]
 }

--- a/machine/peephole_test.go
+++ b/machine/peephole_test.go
@@ -418,26 +418,3 @@ func TestIsBranchOp(t *testing.T) {
 		qt.Assert(t, isBranchOp(op), qt.IsFalse, qt.Commentf("%s", op))
 	}
 }
-
-func TestBuildPCRemap(t *testing.T) {
-	dead := []bool{false, false, true, false, false}
-	remap := buildPCRemap(dead)
-	// old:   0 1 2(dead) 3 4   sentinel
-	// remap: 0 1 2       2 3   4
-	// Dead position 2 maps forward to 2, same as next survivor (position 3).
-	qt.Assert(t, remap, qt.DeepEquals, []int{0, 1, 2, 2, 3, 4})
-}
-
-func TestBuildPCRemap_NoDead(t *testing.T) {
-	dead := []bool{false, false, false}
-	remap := buildPCRemap(dead)
-	qt.Assert(t, remap, qt.DeepEquals, []int{0, 1, 2, 3})
-}
-
-func TestBuildPCRemap_AllDead(t *testing.T) {
-	dead := []bool{true, true, true}
-	remap := buildPCRemap(dead)
-	// All dead: every position maps to 0 (the next survivor's position,
-	// which is the sentinel). Sentinel itself is also 0.
-	qt.Assert(t, remap, qt.DeepEquals, []int{0, 0, 0, 0})
-}


### PR DESCRIPTION
## Summary

- Adds `EditPlan` type in `machine/edit_plan.go` for collecting non-overlapping bytecode edits (replace, delete, insert) and applying them in a single pass with automatic branch offset fixup, sourceRef rewriting, and sideTable garbage collection
- `AddLiteral` method for adding constants to the literal pool with deduplication, returning indices for use in replacement instructions
- Refactors peephole optimizer to use EditPlan internally, removing standalone `buildPCRemap`/`fixBranchOffsets`/`compact` helpers

## Test plan

- [x] 22 new EditPlan tests covering deletions, replacements, insertions, branch fixup across all edit types, sideTable GC, literal dedup, validation, and compound edits
- [x] All 15 existing peephole behavioral tests pass against the refactored implementation
- [x] Full test suite passes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)