### PR TITLE
add Stack.Drain() to eliminate PopAll allocation in VM hot path

### DIFF
--- a/machine/counters.go
+++ b/machine/counters.go
@@ -28,7 +28,7 @@ type VMCounters struct {
 	ContinuationsSaved       uint64
 	ContinuationsRestored    uint64
 	StackPopAlls             uint64
-	StackElementsCopied      uint64
+	StackElementsDrained      uint64
 	ForeignCalls             uint64
 	SubContextsCreated       uint64
 	StackPoolReleases        uint64
@@ -78,7 +78,7 @@ func (c VMCounters) String() string {
 			"continuations_saved:          %d\n"+
 			"continuations_restored:       %d\n"+
 			"stack_pop_alls:               %d\n"+
-			"stack_elements_copied:        %d\n"+
+			"stack_elements_drained:        %d\n"+
 			"foreign_calls:                %d\n"+
 			"sub_contexts_created:         %d\n"+
 			"stack_pool_releases:          %d\n"+
@@ -101,7 +101,7 @@ func (c VMCounters) String() string {
 		c.ContinuationsSaved,
 		c.ContinuationsRestored,
 		c.StackPopAlls,
-		c.StackElementsCopied,
+		c.StackElementsDrained,
 		c.ForeignCalls,
 		c.SubContextsCreated,
 		c.StackPoolReleases,

--- a/machine/machine_context.go
+++ b/machine/machine_context.go
@@ -400,6 +400,11 @@ func (p *MachineContext) ApplyCaseLambda(clcls *CaseLambdaClosure, vs ...values.
 //   - *Parameter: R7RS parameter object (§4.2.6)
 //   - *ComposableContinuation: delimited continuation
 //
+// args may alias the evals backing array (when the caller uses Drain).
+// Dispatch targets must finish reading all args before calling Restore,
+// returnImmediate, or pushing to mc.evals — releaseStack nils elements
+// in the shared backing array, and Push overwrites them.
+//
 // Precondition: p.ctx must be set (always true for contexts created via
 // NewMachineContext or NewSubContext).
 func (p *MachineContext) ApplyCallable(callable values.Value, args ...values.Value) (*MachineContext, error) {
@@ -489,6 +494,10 @@ func (p *MachineContext) applyComposableContinuation(cc *ComposableContinuation,
 		return p, err
 	}
 
+	// Save before Restore/returnImmediate, which call releaseStack on old
+	// evals. args may alias the evals backing array (see ApplyCallable doc).
+	val := args[0]
+
 	// Reject cross-thread composable continuation invocation
 	if p.threadID != cc.threadID {
 		return p, values.WrapForeignErrorf(values.ErrCrossThreadContinuation,
@@ -518,7 +527,7 @@ func (p *MachineContext) applyComposableContinuation(cc *ComposableContinuation,
 		// Empty composable continuation: captured at a tail-call site with no
 		// saved frames above it (e.g., call/cc inside a sub-context where
 		// the call was in tail position). Applying it just returns the value.
-		p.SetValue(args[0])
+		p.SetValue(val)
 		return p.returnImmediate(), nil
 	}
 
@@ -527,7 +536,7 @@ func (p *MachineContext) applyComposableContinuation(cc *ComposableContinuation,
 
 	// Restore from the top of the segment (resume captured computation)
 	p.Restore(segment)
-	p.SetValue(args[0])
+	p.SetValue(val)
 	return p, nil
 }
 
@@ -625,11 +634,12 @@ func (p *MachineContext) Run() error {
 			mc.pc++
 
 		case OpApply:
-			vs := mc.evals.PopAll()
+			vs := mc.evals.Drain()
 			mc.counters.StackPopAlls++
-			mc.counters.StackElementsCopied += uint64(len(vs))
+			mc.counters.StackElementsDrained += uint64(len(vs))
 			mc.counters.RecordStackDepth(len(vs))
 			result, err := mc.ApplyCallable(mc.GetValue(), vs...)
+			clear(vs)
 			if err != nil {
 				return mc.WrapError(err, "")
 			}
@@ -770,11 +780,12 @@ func (p *MachineContext) Run() error {
 
 		case OpPullApply:
 			mc.SetValue(mc.evals.Pull())
-			vs := mc.evals.PopAll()
+			vs := mc.evals.Drain()
 			mc.counters.StackPopAlls++
-			mc.counters.StackElementsCopied += uint64(len(vs))
+			mc.counters.StackElementsDrained += uint64(len(vs))
 			mc.counters.RecordStackDepth(len(vs))
 			result, err := mc.ApplyCallable(mc.GetValue(), vs...)
+			clear(vs)
 			if err != nil {
 				return mc.WrapError(err, "")
 			}

--- a/machine/stack.go
+++ b/machine/stack.go
@@ -118,6 +118,21 @@ func (p *Stack) PopAll() []values.Value {
 	return result
 }
 
+// Drain returns the stack's contents and resets the stack to empty.
+// The returned slice shares the stack's backing array — the caller must
+// finish reading before any new Push operations (which overwrite the same
+// memory). Call clear(result) after reading to release GC references.
+// Use PopAll() when the returned slice must outlive subsequent stack operations.
+func (p *Stack) Drain() []values.Value {
+	n := len(*p)
+	if n == 0 {
+		return nil
+	}
+	result := ([]values.Value)(*p)[:n:n]
+	*p = (*p)[:0]
+	return result
+}
+
 // PeekK returns the kth value from the top of the stack without removing it.
 // `K` is zero-based, so PeekK(0) returns the top value. `K` is used for methods that need a numeric index.
 func (p Stack) PeekK(i int) values.Value {

--- a/machine/stack_test.go
+++ b/machine/stack_test.go
@@ -430,6 +430,62 @@ func TestStackPopAllThenPush(t *testing.T) {
 	qt.Assert(t, got[1], valuestest.SchemeEquals, values.NewInteger(2))
 }
 
+// TestStack_Drain verifies Drain returns correct elements and empties the stack.
+func TestStack_Drain(t *testing.T) {
+	s := NewStack()
+	s.Push(values.NewInteger(10))
+	s.Push(values.NewInteger(20))
+	s.Push(values.NewInteger(30))
+
+	vs := s.Drain()
+	qt.Assert(t, len(vs), qt.Equals, 3)
+	qt.Assert(t, cap(vs), qt.Equals, 3)
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(10))
+	qt.Assert(t, vs[1], valuestest.SchemeEquals, values.NewInteger(20))
+	qt.Assert(t, vs[2], valuestest.SchemeEquals, values.NewInteger(30))
+	qt.Assert(t, s.Len(), qt.Equals, 0)
+}
+
+// TestStack_Drain_Empty verifies Drain returns nil on empty stack.
+func TestStack_Drain_Empty(t *testing.T) {
+	s := NewStack()
+	vs := s.Drain()
+	qt.Assert(t, vs, qt.IsNil)
+}
+
+// TestStack_Drain_SharedMemory verifies the returned slice shares backing
+// memory with the stack — Push after Drain overwrites the same array.
+func TestStack_Drain_SharedMemory(t *testing.T) {
+	s := NewStack()
+	s.Push(values.NewInteger(1))
+	s.Push(values.NewInteger(2))
+
+	vs := s.Drain()
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(1))
+
+	// Push reuses the backing array — vs[0] is now overwritten.
+	s.Push(values.NewInteger(99))
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(99))
+}
+
+// TestStack_Drain_AfterPull verifies Drain works correctly after Pull,
+// matching the OpPullApply pattern.
+func TestStack_Drain_AfterPull(t *testing.T) {
+	s := NewStack()
+	s.Push(values.NewInteger(1)) // will be Pull'd (procedure)
+	s.Push(values.NewInteger(2)) // arg 1
+	s.Push(values.NewInteger(3)) // arg 2
+
+	pulled := s.Pull()
+	qt.Assert(t, pulled, valuestest.SchemeEquals, values.NewInteger(1))
+
+	vs := s.Drain()
+	qt.Assert(t, len(vs), qt.Equals, 2)
+	qt.Assert(t, vs[0], valuestest.SchemeEquals, values.NewInteger(2))
+	qt.Assert(t, vs[1], valuestest.SchemeEquals, values.NewInteger(3))
+	qt.Assert(t, s.Len(), qt.Equals, 0)
+}
+
 // TestStackPeekKPanics tests that Stack.PeekK panics on invalid indices
 func TestStackPeekKPanics(t *testing.T) {
 	s := NewStack(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
@@ -454,4 +510,46 @@ func TestStackPeekKPanics(t *testing.T) {
 	qt.Assert(t, func() {
 		empty.PeekK(0)
 	}, qt.PanicMatches, ".*stack underflow.*")
+}
+
+func BenchmarkStack_PopAll(b *testing.B) {
+	depths := []int{1, 3, 5, 8}
+	vals := make([]values.Value, 8)
+	for i := range vals {
+		vals[i] = values.NewInteger(int64(i))
+	}
+	for _, depth := range depths {
+		b.Run(
+			"depth="+qt.Format(depth),
+			func(b *testing.B) {
+				s := NewStack()
+				for range b.N {
+					s.PushAll(vals[:depth])
+					vs := s.PopAll()
+					_ = vs
+				}
+			},
+		)
+	}
+}
+
+func BenchmarkStack_Drain(b *testing.B) {
+	depths := []int{1, 3, 5, 8}
+	vals := make([]values.Value, 8)
+	for i := range vals {
+		vals[i] = values.NewInteger(int64(i))
+	}
+	for _, depth := range depths {
+		b.Run(
+			"depth="+qt.Format(depth),
+			func(b *testing.B) {
+				s := NewStack()
+				for range b.N {
+					s.PushAll(vals[:depth])
+					vs := s.Drain()
+					clear(vs)
+				}
+			},
+		)
+	}
 }

--- a/registry/core/prim_prompt_test.go
+++ b/registry/core/prim_prompt_test.go
@@ -140,6 +140,25 @@ func TestPrompt_ComposableContinuation(t *testing.T) {
 				        result))))`,
 			expected: values.NewInteger(21),
 		},
+		{
+			// Regression: OpApply uses Drain which returns a slice aliasing
+			// the evals backing array. When applyComposableContinuation calls
+			// Restore, releaseStack nils elements in that shared array. The
+			// argument value (42) must be saved to a local before Restore;
+			// otherwise it reads as nil/0 and the result would be 1 not 43.
+			name: "composable continuation preserves argument through Restore",
+			code: `(let ((tag (make-continuation-prompt-tag 'test)))
+				(let ((k #f))
+				  (call-with-continuation-prompt
+				    (lambda ()
+				      (+ 1 (call-with-composable-continuation
+				              (lambda (c) (set! k c) 0)
+				              tag)))
+				    tag
+				    #f)
+				  (k 42)))`,
+			expected: values.NewInteger(43),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
## Summary

- Add `Stack.Drain()` — returns a zero-copy view of the stack's backing array, resets stack to empty. Cap pinned to length to prevent caller `append` into shared memory.
- Replace `PopAll()` with `Drain()` + `clear(vs)` in `OpApply` and `OpPullApply` — the two call sites that fire on every non-tail closure application.
- Save composable continuation arg to a local before `Restore` (which calls `releaseStack`, nilling the shared backing array). Document the aliasing invariant on `ApplyCallable`.

## Benchmark

| Depth | PopAll | Drain | Speedup | Allocs |
|-------|--------|-------|---------|--------|
| 1 | 6.96 ns | 4.22 ns | 1.6x | 0→0 |
| 3 | 28.7 ns | 4.85 ns | **5.9x** | 1→0 |
| 5 | 36.0 ns | 5.32 ns | **6.8x** | 1→0 |
| 8 | 45.0 ns | 5.31 ns | **8.5x** | 1→0 |

## Test plan

- [x] `go test ./machine/... -run TestStack_Drain` — new unit tests pass
- [x] `go test ./...` — full suite green (including composable continuation tests)
- [x] `make lint` — no issues
- [x] Microbenchmarks show zero allocations for Drain at all depths

🤖 Generated with [Claude Code](https://claude.com/claude-code)