### PR TITLE
perf: fix escape analysis artifacts in numeric fold helpers

### DIFF
--- a/registry/helpers/numeric.go
+++ b/registry/helpers/numeric.go
@@ -60,12 +60,16 @@ func NumericFoldVariadic(
 		mc.SetValue(binOp(nbr, v))
 		return nil
 	}
+	// acc is a separate variable so that nbr (used on the 2-arg fast path
+	// above) stays on the stack. The closure below captures acc by reference,
+	// which forces it to the heap — but only on the 3+-arg path.
+	acc := nbr
 	v, err := rest.ForEach(mc.Context(), func(_ context.Context, _ int, _ bool, o values.Value) error {
 		v, ok := o.(values.Number)
 		if !ok {
 			return values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected a number but got %T", name, o)
 		}
-		nbr = binOp(nbr, v)
+		acc = binOp(acc, v)
 		return nil
 	})
 	if err != nil {
@@ -74,7 +78,7 @@ func NumericFoldVariadic(
 	if !values.IsEmptyList(v) {
 		return values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %s", name, v.SchemeString())
 	}
-	mc.SetValue(nbr)
+	mc.SetValue(acc)
 	return nil
 }
 
@@ -105,16 +109,20 @@ func NumericFoldWithFirst(
 	if !ok {
 		return values.WrapForeignErrorf(values.ErrNotANumber, "%s: expected a number but got %T", name, o2)
 	}
-	acc := binOp(nbr0, nbr2)
+	result := binOp(nbr0, nbr2)
 	if values.IsEmptyList(pr.Cdr()) {
-		mc.SetValue(acc)
+		mc.SetValue(result)
 		return nil
 	}
 	rest, ok := pr.Cdr().(values.Tuple)
 	if !ok {
-		mc.SetValue(acc)
+		mc.SetValue(result)
 		return nil
 	}
+	// acc is a separate variable so that result (used on the 2-arg fast path
+	// above) stays on the stack. The closure below captures acc by reference,
+	// which forces it to the heap — but only on the 3+-arg path.
+	acc := result
 	v, err := rest.ForEach(mc.Context(), func(_ context.Context, _ int, _ bool, o values.Value) error {
 		v, ok := o.(values.Number)
 		if !ok {


### PR DESCRIPTION
## Summary

- Go's escape analysis is whole-function, not path-sensitive. Variables in `NumericFoldVariadic` and `NumericFoldWithFirst` escaped to the heap because `ForEach` closures later in the function captured them by reference — even on the 2-arg fast path that returned before the closure was created.
- Split the accumulator into two variables: one for the 2-arg fast path (stays on stack) and a separate `acc` assigned only on the 3+-arg path where the closure actually runs.
- Confirmed fix with `go build -gcflags='-m=2'`: fast-path variables no longer escape.

## Results

- **fib(10):** 83.5 → 78.4 µs/op (-6.1%), 1143 → 879 allocs/op (-23.1%)
- **Gabriel geo-mean:** -2.9% incremental
- **Best:** sumfp -8.6%, sum -7.5%, sieve -6.1%, fib -5.8%, ackermann -5.5%

## Test plan

- [x] All 29 test packages pass
- [x] Lint clean
- [x] Gabriel benchmarks run (3 runs averaged)
- [x] ZebraPuzzle: 10.97s (down from 18.36s original master, -40.2% total)