### PR TITLE
refactor(values): convert numeric dispatch to tables with same-type hot paths

### DIFF
--- a/values/big_complex.go
+++ b/values/big_complex.go
@@ -252,82 +252,251 @@ func divideParts(a, b Number) Number {
 
 // Add returns the sum of this BigComplex and another number.
 //
-// R7RS §6.2.6: The + procedure returns the sum of its arguments.
-// R7RS §6.2.2 Exactness: exact + exact = exact, exact + inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
-func (p *BigComplex) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigComplex:
-		newReal := addParts(p.real, v.real)
-		newImag := addParts(p.imag, v.imag)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigInteger:
-		newReal := addParts(p.real, v)
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *BigComplex) Kind() NumericKind {
+	return KindBigComplex
+}
+
+var bigComplexAdd [numKinds]func(*BigComplex, Number) Number
+var bigComplexSubtract [numKinds]func(*BigComplex, Number) Number
+var bigComplexCompare [numKinds]func(*BigComplex, Number) int
+var bigComplexMultiply [numKinds]func(*BigComplex, Number) Number
+var bigComplexDivide [numKinds]func(*BigComplex, Number) Number
+
+func init() {
+	bigComplexAdd[KindInteger] = func(p *BigComplex, o Number) Number {
+		bi := NewBigIntegerFromInt64(o.(*Integer).Value)
+		newReal := addParts(p.real, bi)
 		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *BigFloat:
-		newReal := addParts(p.real, v)
+	}
+	bigComplexAdd[KindBigInteger] = func(p *BigComplex, o Number) Number {
+		newReal := addParts(p.real, o.(*BigInteger))
 		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *Integer:
-		bi := NewBigIntegerFromInt64(v.Value)
-		return p.Add(bi)
-	case *Float:
-		bf := NewBigFloatFromFloat64(v.Value)
-		return p.Add(bf)
-	case *Rational:
-		newReal := addParts(p.real, v)
+	}
+	bigComplexAdd[KindFloat] = func(p *BigComplex, o Number) Number {
+		bf := NewBigFloatFromFloat64(o.(*Float).Value)
+		newReal := addParts(p.real, bf)
 		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *Complex:
+	}
+	bigComplexAdd[KindBigFloat] = func(p *BigComplex, o Number) Number {
+		newReal := addParts(p.real, o.(*BigFloat))
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexAdd[KindRational] = func(p *BigComplex, o Number) Number {
+		newReal := addParts(p.real, o.(*Rational))
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexAdd[KindComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*Complex)
 		bc := NewBigComplexFromBigFloats(
 			NewBigFloatFromFloat64(real(v.Value)),
 			NewBigFloatFromFloat64(imag(v.Value)),
 		)
-		return p.Add(bc)
+		newReal := addParts(p.real, bc.real)
+		newImag := addParts(p.imag, bc.imag)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
 	}
-	panic(ErrNotANumber)
+	bigComplexAdd[KindBigComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigComplex)
+		newReal := addParts(p.real, v.real)
+		newImag := addParts(p.imag, v.imag)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+
+	bigComplexSubtract[KindInteger] = func(p *BigComplex, o Number) Number {
+		bi := NewBigIntegerFromInt64(o.(*Integer).Value)
+		newReal := subtractParts(p.real, bi)
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexSubtract[KindBigInteger] = func(p *BigComplex, o Number) Number {
+		newReal := subtractParts(p.real, o.(*BigInteger))
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexSubtract[KindFloat] = func(p *BigComplex, o Number) Number {
+		bf := NewBigFloatFromFloat64(o.(*Float).Value)
+		newReal := subtractParts(p.real, bf)
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexSubtract[KindBigFloat] = func(p *BigComplex, o Number) Number {
+		newReal := subtractParts(p.real, o.(*BigFloat))
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexSubtract[KindRational] = func(p *BigComplex, o Number) Number {
+		newReal := subtractParts(p.real, o.(*Rational))
+		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
+	}
+	bigComplexSubtract[KindComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*Complex)
+		bc := NewBigComplexFromBigFloats(
+			NewBigFloatFromFloat64(real(v.Value)),
+			NewBigFloatFromFloat64(imag(v.Value)),
+		)
+		newReal := subtractParts(p.real, bc.real)
+		newImag := subtractParts(p.imag, bc.imag)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexSubtract[KindBigComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigComplex)
+		newReal := subtractParts(p.real, v.real)
+		newImag := subtractParts(p.imag, v.imag)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+
+	bigComplexCompare[KindInteger] = func(p *BigComplex, o Number) int {
+		otherReal := NewBigIntegerFromInt64(o.(*Integer).Value)
+		return toBigFloat(p.real).Compare(otherReal)
+	}
+	bigComplexCompare[KindBigInteger] = func(p *BigComplex, o Number) int {
+		return toBigFloat(p.real).Compare(o.(*BigInteger))
+	}
+	bigComplexCompare[KindFloat] = func(p *BigComplex, o Number) int {
+		otherReal := NewBigFloatFromFloat64(o.(*Float).Value)
+		return toBigFloat(p.real).Compare(otherReal)
+	}
+	bigComplexCompare[KindBigFloat] = func(p *BigComplex, o Number) int {
+		return toBigFloat(p.real).Compare(o.(*BigFloat))
+	}
+	bigComplexCompare[KindRational] = func(p *BigComplex, o Number) int {
+		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(o.(*Rational).Rat())
+		otherReal := &BigFloat{value: bf}
+		return toBigFloat(p.real).Compare(otherReal)
+	}
+	bigComplexCompare[KindComplex] = func(p *BigComplex, o Number) int {
+		otherReal := NewBigFloatFromFloat64(real(o.(*Complex).Value))
+		return toBigFloat(p.real).Compare(otherReal)
+	}
+	bigComplexCompare[KindBigComplex] = func(p *BigComplex, o Number) int {
+		return toBigFloat(p.real).Compare(toBigFloat(o.(*BigComplex).real))
+	}
+
+	bigComplexMultiply[KindInteger] = func(p *BigComplex, o Number) Number {
+		bi := NewBigIntegerFromInt64(o.(*Integer).Value)
+		return p.Multiply(bi)
+	}
+	bigComplexMultiply[KindBigInteger] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigInteger)
+		newReal := multiplyParts(p.real, v)
+		newImag := multiplyParts(p.imag, v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexMultiply[KindFloat] = func(p *BigComplex, o Number) Number {
+		bf := NewBigFloatFromFloat64(o.(*Float).Value)
+		return p.Multiply(bf)
+	}
+	bigComplexMultiply[KindBigFloat] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigFloat)
+		newReal := multiplyParts(p.real, v)
+		newImag := multiplyParts(p.imag, v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexMultiply[KindRational] = func(p *BigComplex, o Number) Number {
+		v := o.(*Rational)
+		newReal := multiplyParts(p.real, v)
+		newImag := multiplyParts(p.imag, v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexMultiply[KindComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*Complex)
+		bc := NewBigComplexFromBigFloats(
+			NewBigFloatFromFloat64(real(v.Value)),
+			NewBigFloatFromFloat64(imag(v.Value)),
+		)
+		return p.Multiply(bc)
+	}
+	bigComplexMultiply[KindBigComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigComplex)
+		ac := multiplyParts(p.real, v.real)
+		bd := multiplyParts(p.imag, v.imag)
+		ad := multiplyParts(p.real, v.imag)
+		bc := multiplyParts(p.imag, v.real)
+		newReal := subtractParts(ac, bd)
+		newImag := addParts(ad, bc)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+
+	bigComplexDivide[KindInteger] = func(p *BigComplex, o Number) Number {
+		bi := NewBigIntegerFromInt64(o.(*Integer).Value)
+		newReal := divideParts(p.real, bi)
+		newImag := divideParts(p.imag, bi)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexDivide[KindBigInteger] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigInteger)
+		newReal := divideParts(p.real, v)
+		newImag := divideParts(p.imag, v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexDivide[KindFloat] = func(p *BigComplex, o Number) Number {
+		bf := NewBigFloatFromFloat64(o.(*Float).Value)
+		newReal := toBigFloat(p.real).Divide(bf)
+		newImag := toBigFloat(p.imag).Divide(bf)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexDivide[KindBigFloat] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigFloat)
+		newReal := toBigFloat(p.real).Divide(v)
+		newImag := toBigFloat(p.imag).Divide(v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexDivide[KindRational] = func(p *BigComplex, o Number) Number {
+		v := o.(*Rational)
+		newReal := divideParts(p.real, v)
+		newImag := divideParts(p.imag, v)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	bigComplexDivide[KindComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*Complex)
+		bc := NewBigComplexFromBigFloats(
+			NewBigFloatFromFloat64(real(v.Value)),
+			NewBigFloatFromFloat64(imag(v.Value)),
+		)
+		return p.Divide(bc)
+	}
+	bigComplexDivide[KindBigComplex] = func(p *BigComplex, o Number) Number {
+		v := o.(*BigComplex)
+		// (a+bi)/(c+di) = ((ac+bd) + (bc-ad)i) / (c²+d²)
+		ac := multiplyParts(p.real, v.real)
+		bd := multiplyParts(p.imag, v.imag)
+		bc := multiplyParts(p.imag, v.real)
+		ad := multiplyParts(p.real, v.imag)
+		cc := multiplyParts(v.real, v.real)
+		dd := multiplyParts(v.imag, v.imag)
+
+		numerReal := addParts(ac, bd)
+		numerImag := subtractParts(bc, ad)
+		denom := addParts(cc, dd)
+
+		newReal := toBigFloat(numerReal).Divide(toBigFloat(denom))
+		newImag := toBigFloat(numerImag).Divide(toBigFloat(denom))
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+}
+
+// R7RS §6.2.6: The + procedure returns the sum of its arguments.
+// R7RS §6.2.2 Exactness: exact + exact = exact, exact + inexact = inexact.
+// Inexactness is contagious per R7RS §6.2.2.
+func (p *BigComplex) Add(o Number) Number {
+	v, ok := o.(*BigComplex)
+	if ok {
+		newReal := addParts(p.real, v.real)
+		newImag := addParts(p.imag, v.imag)
+		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
+	}
+	return bigComplexAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of this BigComplex and another number.
 //
 // R7RS §6.2.6: The - procedure returns the difference of its arguments.
 // R7RS §6.2.2 Exactness: exact - exact = exact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *BigComplex) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigComplex:
+	v, ok := o.(*BigComplex)
+	if ok {
 		newReal := subtractParts(p.real, v.real)
 		newImag := subtractParts(p.imag, v.imag)
 		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigInteger:
-		newReal := subtractParts(p.real, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *BigFloat:
-		newReal := subtractParts(p.real, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *Integer:
-		bi := NewBigIntegerFromInt64(v.Value)
-		return p.Subtract(bi)
-	case *Float:
-		bf := NewBigFloatFromFloat64(v.Value)
-		return p.Subtract(bf)
-	case *Rational:
-		newReal := subtractParts(p.real, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), p.imag)
-	case *Complex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(v.Value)),
-			NewBigFloatFromFloat64(imag(v.Value)),
-		)
-		return p.Subtract(bc)
 	}
-	panic(ErrNotANumber)
+	return bigComplexSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of this BigComplex and another number.
@@ -342,8 +511,8 @@ func (p *BigComplex) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *BigComplex:
+	v, ok := o.(*BigComplex)
+	if ok {
 		// (a+bi)(c+di) = (ac-bd) + (ad+bc)i
 		ac := multiplyParts(p.real, v.real)
 		bd := multiplyParts(p.imag, v.imag)
@@ -352,32 +521,8 @@ func (p *BigComplex) Multiply(o Number) Number {
 		newReal := subtractParts(ac, bd)
 		newImag := addParts(ad, bc)
 		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigInteger:
-		newReal := multiplyParts(p.real, v)
-		newImag := multiplyParts(p.imag, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigFloat:
-		newReal := multiplyParts(p.real, v)
-		newImag := multiplyParts(p.imag, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *Integer:
-		bi := NewBigIntegerFromInt64(v.Value)
-		return p.Multiply(bi)
-	case *Float:
-		bf := NewBigFloatFromFloat64(v.Value)
-		return p.Multiply(bf)
-	case *Rational:
-		newReal := multiplyParts(p.real, v)
-		newImag := multiplyParts(p.imag, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *Complex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(v.Value)),
-			NewBigFloatFromFloat64(imag(v.Value)),
-		)
-		return p.Multiply(bc)
 	}
-	panic(ErrNotANumber)
+	return bigComplexMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this BigComplex and another number.
@@ -389,8 +534,8 @@ func (p *BigComplex) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *BigComplex:
+	v, ok := o.(*BigComplex)
+	if ok {
 		// (a+bi)/(c+di) = ((ac+bd) + (bc-ad)i) / (c²+d²)
 		ac := multiplyParts(p.real, v.real)
 		bd := multiplyParts(p.imag, v.imag)
@@ -403,37 +548,11 @@ func (p *BigComplex) Divide(o Number) Number {
 		numerImag := subtractParts(bc, ad)
 		denom := addParts(cc, dd)
 
-		// Division produces BigFloat results
 		newReal := toBigFloat(numerReal).Divide(toBigFloat(denom))
 		newImag := toBigFloat(numerImag).Divide(toBigFloat(denom))
 		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigInteger:
-		// Use exact division to preserve exactness when possible
-		newReal := divideParts(p.real, v)
-		newImag := divideParts(p.imag, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *BigFloat:
-		newReal := toBigFloat(p.real).Divide(v)
-		newImag := toBigFloat(p.imag).Divide(v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *Integer:
-		bi := NewBigIntegerFromInt64(v.Value)
-		return p.Divide(bi)
-	case *Float:
-		bf := NewBigFloatFromFloat64(v.Value)
-		return p.Divide(bf)
-	case *Rational:
-		newReal := divideParts(p.real, v)
-		newImag := divideParts(p.imag, v)
-		return maybeSimplify(promoteToBigComplexPart(newReal), promoteToBigComplexPart(newImag))
-	case *Complex:
-		bc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(v.Value)),
-			NewBigFloatFromFloat64(imag(v.Value)),
-		)
-		return p.Divide(bc)
 	}
-	panic(ErrNotANumber)
+	return bigComplexDivide[o.Kind()](p, o)
 }
 
 // Negate returns the negation of this BigComplex.
@@ -471,27 +590,11 @@ func (p *BigComplex) LessThan(o Number) bool {
 // R7RS §6.2.6: Numeric comparisons use mathematical value.
 // For complex numbers, we compare real parts only (matching Complex behavior).
 func (p *BigComplex) Compare(o Number) int {
-	var otherReal Number
-	switch v := o.(type) {
-	case *BigComplex:
-		otherReal = v.real
-	case *BigInteger:
-		otherReal = v
-	case *BigFloat:
-		otherReal = v
-	case *Integer:
-		otherReal = NewBigIntegerFromInt64(v.Value)
-	case *Float:
-		otherReal = NewBigFloatFromFloat64(v.Value)
-	case *Rational:
-		bf := new(big.Float).SetPrec(DefaultBigFloatPrecision).SetRat(v.Rat())
-		otherReal = &BigFloat{value: bf}
-	case *Complex:
-		otherReal = NewBigFloatFromFloat64(real(v.Value))
-	default:
-		panic(ErrNotANumber)
+	v, ok := o.(*BigComplex)
+	if ok {
+		return toBigFloat(p.real).Compare(toBigFloat(v.real))
 	}
-	return toBigFloat(p.real).Compare(otherReal)
+	return bigComplexCompare[o.Kind()](p, o)
 }
 
 // IsReal returns true if the imaginary part is zero.

--- a/values/big_float.go
+++ b/values/big_float.go
@@ -74,82 +74,226 @@ func (p *BigFloat) HashCode() uint64 {
 
 // Add returns the sum of this BigFloat and another number.
 //
-// R7RS §6.2.6: The + procedure returns the sum of its arguments.
-// R7RS §6.2.2 Exactness: inexact + inexact = inexact, exact + inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
-func (p *BigFloat) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Add(p.value, v.value)}
-	case *BigInteger:
-		vf := v.bigFloat()
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *BigFloat) Kind() NumericKind {
+	return KindBigFloat
+}
+
+var bigFloatAdd [numKinds]func(*BigFloat, Number) Number
+var bigFloatSubtract [numKinds]func(*BigFloat, Number) Number
+var bigFloatLessThan [numKinds]func(*BigFloat, Number) bool
+var bigFloatCompare [numKinds]func(*BigFloat, Number) int
+var bigFloatMultiply [numKinds]func(*BigFloat, Number) Number
+var bigFloatDivide [numKinds]func(*BigFloat, Number) Number
+
+func init() {
+	bigFloatAdd[KindInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Integer).bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
-	case *Integer:
-		vf := v.bigFloat()
+	}
+	bigFloatAdd[KindBigInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*BigInteger).bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
-	case *Float:
-		vf := v.bigFloat()
+	}
+	bigFloatAdd[KindFloat] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Float).bigFloat()
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
+	}
+	bigFloatAdd[KindBigFloat] = func(p *BigFloat, o Number) Number {
+		return &BigFloat{value: new(big.Float).Add(p.value, o.(*BigFloat).value)}
+	}
+	bigFloatAdd[KindRational] = func(p *BigFloat, o Number) Number {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
 		return &BigFloat{value: new(big.Float).Add(p.value, vf)}
-	case *Complex:
-		// Convert both to BigComplex to preserve BigFloat precision
+	}
+	bigFloatAdd[KindComplex] = func(p *BigFloat, o Number) Number {
+		v := o.(*Complex)
 		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
 		vc := NewBigComplexFromBigFloats(
 			NewBigFloatFromFloat64(real(v.Value)),
 			NewBigFloatFromFloat64(imag(v.Value)),
 		)
 		return bc.Add(vc)
-	case *BigComplex:
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		return bc.Add(v)
 	}
-	panic(ErrNotANumber)
-}
+	bigFloatAdd[KindBigComplex] = func(p *BigFloat, o Number) Number {
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		return bc.Add(o)
+	}
 
-// Subtract returns the difference of this BigFloat and another number.
-//
-// R7RS §6.2.6: The - procedure returns the difference of its arguments.
-// R7RS §6.2.2 Exactness: inexact - inexact = inexact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
-func (p *BigFloat) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Sub(p.value, v.value)}
-	case *BigInteger:
-		vf := v.bigFloat()
+	bigFloatSubtract[KindInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Integer).bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
-	case *Integer:
-		vf := v.bigFloat()
+	}
+	bigFloatSubtract[KindBigInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*BigInteger).bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
-	case *Float:
-		vf := v.bigFloat()
+	}
+	bigFloatSubtract[KindFloat] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Float).bigFloat()
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
+	}
+	bigFloatSubtract[KindBigFloat] = func(p *BigFloat, o Number) Number {
+		return &BigFloat{value: new(big.Float).Sub(p.value, o.(*BigFloat).value)}
+	}
+	bigFloatSubtract[KindRational] = func(p *BigFloat, o Number) Number {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
 		return &BigFloat{value: new(big.Float).Sub(p.value, vf)}
-	case *Complex:
-		// Convert both to BigComplex to preserve BigFloat precision
+	}
+	bigFloatSubtract[KindComplex] = func(p *BigFloat, o Number) Number {
+		v := o.(*Complex)
 		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
 		vc := NewBigComplexFromBigFloats(
 			NewBigFloatFromFloat64(real(v.Value)),
 			NewBigFloatFromFloat64(imag(v.Value)),
 		)
 		return bc.Subtract(vc)
-	case *BigComplex:
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		return bc.Subtract(v)
 	}
-	panic(ErrNotANumber)
+	bigFloatSubtract[KindBigComplex] = func(p *BigFloat, o Number) Number {
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		return bc.Subtract(o)
+	}
+
+	bigFloatLessThan[KindInteger] = func(p *BigFloat, o Number) bool {
+		return p.value.Cmp(o.(*Integer).bigFloat()) < 0
+	}
+	bigFloatLessThan[KindBigInteger] = func(p *BigFloat, o Number) bool {
+		return p.value.Cmp(o.(*BigInteger).bigFloat()) < 0
+	}
+	bigFloatLessThan[KindFloat] = func(p *BigFloat, o Number) bool {
+		return p.value.Cmp(o.(*Float).bigFloat()) < 0
+	}
+	bigFloatLessThan[KindBigFloat] = func(p *BigFloat, o Number) bool {
+		return p.value.Cmp(o.(*BigFloat).value) < 0
+	}
+	bigFloatLessThan[KindRational] = func(p *BigFloat, o Number) bool {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
+		return p.value.Cmp(vf) < 0
+	}
+	bigFloatLessThan[KindComplex] = func(p *BigFloat, o Number) bool {
+		f, _ := p.value.Float64()
+		return f < real(o.(*Complex).Value)
+	}
+	bigFloatLessThan[KindBigComplex] = func(p *BigFloat, o Number) bool {
+		return p.value.Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue()) < 0
+	}
+
+	bigFloatCompare[KindInteger] = func(p *BigFloat, o Number) int {
+		return p.value.Cmp(o.(*Integer).bigFloat())
+	}
+	bigFloatCompare[KindBigInteger] = func(p *BigFloat, o Number) int {
+		return p.value.Cmp(o.(*BigInteger).bigFloat())
+	}
+	bigFloatCompare[KindFloat] = func(p *BigFloat, o Number) int {
+		return p.value.Cmp(o.(*Float).bigFloat())
+	}
+	bigFloatCompare[KindBigFloat] = func(p *BigFloat, o Number) int {
+		return p.value.Cmp(o.(*BigFloat).value)
+	}
+	bigFloatCompare[KindRational] = func(p *BigFloat, o Number) int {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
+		return p.value.Cmp(vf)
+	}
+	bigFloatCompare[KindComplex] = func(p *BigFloat, o Number) int {
+		f, _ := p.value.Float64()
+		if f < real(o.(*Complex).Value) {
+			return -1
+		} else if f > real(o.(*Complex).Value) {
+			return 1
+		}
+		return 0
+	}
+	bigFloatCompare[KindBigComplex] = func(p *BigFloat, o Number) int {
+		return p.value.Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue())
+	}
+
+	bigFloatMultiply[KindInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Integer).bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
+	}
+	bigFloatMultiply[KindBigInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*BigInteger).bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
+	}
+	bigFloatMultiply[KindFloat] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Float).bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
+	}
+	bigFloatMultiply[KindBigFloat] = func(p *BigFloat, o Number) Number {
+		return &BigFloat{value: new(big.Float).Mul(p.value, o.(*BigFloat).value)}
+	}
+	bigFloatMultiply[KindRational] = func(p *BigFloat, o Number) Number {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
+		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
+	}
+	bigFloatMultiply[KindComplex] = func(p *BigFloat, o Number) Number {
+		v := o.(*Complex)
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		vc := NewBigComplexFromBigFloats(
+			NewBigFloatFromFloat64(real(v.Value)),
+			NewBigFloatFromFloat64(imag(v.Value)),
+		)
+		return bc.Multiply(vc)
+	}
+	bigFloatMultiply[KindBigComplex] = func(p *BigFloat, o Number) Number {
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		return bc.Multiply(o)
+	}
+
+	bigFloatDivide[KindInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Integer).bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
+	}
+	bigFloatDivide[KindBigInteger] = func(p *BigFloat, o Number) Number {
+		vf := o.(*BigInteger).bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
+	}
+	bigFloatDivide[KindFloat] = func(p *BigFloat, o Number) Number {
+		vf := o.(*Float).bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
+	}
+	bigFloatDivide[KindBigFloat] = func(p *BigFloat, o Number) Number {
+		return &BigFloat{value: new(big.Float).Quo(p.value, o.(*BigFloat).value)}
+	}
+	bigFloatDivide[KindRational] = func(p *BigFloat, o Number) Number {
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
+		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
+	}
+	bigFloatDivide[KindComplex] = func(p *BigFloat, o Number) Number {
+		v := o.(*Complex)
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		vc := NewBigComplexFromBigFloats(
+			NewBigFloatFromFloat64(real(v.Value)),
+			NewBigFloatFromFloat64(imag(v.Value)),
+		)
+		return bc.Divide(vc)
+	}
+	bigFloatDivide[KindBigComplex] = func(p *BigFloat, o Number) Number {
+		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
+		return bc.Divide(o)
+	}
+}
+
+// R7RS §6.2.6: The + procedure returns the sum of its arguments.
+// R7RS §6.2.2 Exactness: inexact + inexact = inexact, exact + inexact = inexact.
+// Inexactness is contagious per R7RS §6.2.2.
+func (p *BigFloat) Add(o Number) Number {
+	v, ok := o.(*BigFloat)
+	if ok {
+		return &BigFloat{value: new(big.Float).Add(p.value, v.value)}
+	}
+	return bigFloatAdd[o.Kind()](p, o)
+}
+
+// Subtract returns the difference of this BigFloat and another number.
+//
+// R7RS §6.2.6: The - procedure returns the difference of its arguments.
+// R7RS §6.2.2 Exactness: inexact - inexact = inexact, exact - inexact = inexact.
+func (p *BigFloat) Subtract(o Number) Number {
+	v, ok := o.(*BigFloat)
+	if ok {
+		return &BigFloat{value: new(big.Float).Sub(p.value, v.value)}
+	}
+	return bigFloatSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of this BigFloat and another number.
@@ -162,71 +306,23 @@ func (p *BigFloat) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *BigFloat:
+	v, ok := o.(*BigFloat)
+	if ok {
 		return &BigFloat{value: new(big.Float).Mul(p.value, v.value)}
-	case *BigInteger:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
-	case *Integer:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
-	case *Float:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
-		return &BigFloat{value: new(big.Float).Mul(p.value, vf)}
-	case *Complex:
-		// Convert both to BigComplex to preserve BigFloat precision
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		vc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(v.Value)),
-			NewBigFloatFromFloat64(imag(v.Value)),
-		)
-		return bc.Multiply(vc)
-	case *BigComplex:
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		return bc.Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return bigFloatMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this BigFloat and another number.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *BigFloat) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *BigFloat:
+	v, ok := o.(*BigFloat)
+	if ok {
 		return &BigFloat{value: new(big.Float).Quo(p.value, v.value)}
-	case *BigInteger:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
-	case *Integer:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
-	case *Float:
-		vf := v.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
-		return &BigFloat{value: new(big.Float).Quo(p.value, vf)}
-	case *Complex:
-		// Convert both to BigComplex to preserve BigFloat precision
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		vc := NewBigComplexFromBigFloats(
-			NewBigFloatFromFloat64(real(v.Value)),
-			NewBigFloatFromFloat64(imag(v.Value)),
-		)
-		return bc.Divide(vc)
-	case *BigComplex:
-		bc := NewBigComplex(p, NewBigFloatFromFloat64(0))
-		return bc.Divide(v)
 	}
-	panic(ErrNotANumber)
+	return bigFloatDivide[o.Kind()](p, o)
 }
 
 // Negate returns the negation of this BigFloat.
@@ -241,7 +337,11 @@ func (p *BigFloat) IsZero() bool {
 
 // LessThan returns true if this BigFloat is less than another number.
 func (p *BigFloat) LessThan(o Number) bool {
-	return p.Compare(o) < 0
+	v, ok := o.(*BigFloat)
+	if ok {
+		return p.value.Cmp(v.value) < 0
+	}
+	return bigFloatLessThan[o.Kind()](p, o)
 }
 
 // IsNegative returns true if this BigFloat is negative.
@@ -314,33 +414,11 @@ func (p *BigFloat) Sign() int {
 
 // Compare compares this BigFloat with another number.
 func (p *BigFloat) Compare(o Number) int {
-	switch v := o.(type) {
-	case *BigFloat:
+	v, ok := o.(*BigFloat)
+	if ok {
 		return p.value.Cmp(v.value)
-	case *BigInteger:
-		vf := v.bigFloat()
-		return p.value.Cmp(vf)
-	case *Integer:
-		vf := v.bigFloat()
-		return p.value.Cmp(vf)
-	case *Float:
-		vf := v.bigFloat()
-		return p.value.Cmp(vf)
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
-		return p.value.Cmp(vf)
-	case *Complex:
-		f, _ := p.value.Float64()
-		if f < real(v.Value) {
-			return -1
-		} else if f > real(v.Value) {
-			return 1
-		}
-		return 0
-	case *BigComplex:
-		return p.value.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
-	panic(ErrNotANumber)
+	return bigFloatCompare[o.Kind()](p, o)
 }
 
 // SchemeString returns the Scheme representation of this BigFloat.

--- a/values/big_integer.go
+++ b/values/big_integer.go
@@ -125,86 +125,224 @@ func (p *BigInteger) toBigComplex() *BigComplex {
 
 // Add returns the sum of this BigInteger and another number.
 //
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *BigInteger) Kind() NumericKind {
+	return KindBigInteger
+}
+
+var bigIntegerAdd [numKinds]func(*BigInteger, Number) Number
+var bigIntegerSubtract [numKinds]func(*BigInteger, Number) Number
+var bigIntegerLessThan [numKinds]func(*BigInteger, Number) bool
+var bigIntegerCompare [numKinds]func(*BigInteger, Number) int
+var bigIntegerMultiply [numKinds]func(*BigInteger, Number) Number
+var bigIntegerDivide [numKinds]func(*BigInteger, Number) Number
+
+func init() {
+	bigIntegerAdd[KindInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, o.(*Integer).bigInt())}
+	}
+	bigIntegerAdd[KindBigInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, o.(*BigInteger).value)}
+	}
+	bigIntegerAdd[KindFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		other := o.(*Float).bigFloat()
+		result := new(big.Float).Add(self, other)
+		return NewBigFloat(result)
+	}
+	bigIntegerAdd[KindBigFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Add(self, o.(*BigFloat).value)}
+	}
+	bigIntegerAdd[KindRational] = func(p *BigInteger, o Number) Number {
+		pRat := p.bigRat()
+		return NewRationalFromRat(new(big.Rat).Add(pRat, o.(*Rational).Rat()))
+	}
+	bigIntegerAdd[KindComplex] = func(p *BigInteger, o Number) Number {
+		f := p.float64Val()
+		return NewComplex(complex(f, 0) + o.(*Complex).Datum())
+	}
+	bigIntegerAdd[KindBigComplex] = func(p *BigInteger, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Add(o)
+	}
+
+	bigIntegerSubtract[KindInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, o.(*Integer).bigInt())}
+	}
+	bigIntegerSubtract[KindBigInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, o.(*BigInteger).value)}
+	}
+	bigIntegerSubtract[KindFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		other := o.(*Float).bigFloat()
+		result := new(big.Float).Sub(self, other)
+		return NewBigFloat(result)
+	}
+	bigIntegerSubtract[KindBigFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Sub(self, o.(*BigFloat).value)}
+	}
+	bigIntegerSubtract[KindRational] = func(p *BigInteger, o Number) Number {
+		pRat := p.bigRat()
+		return NewRationalFromRat(new(big.Rat).Sub(pRat, o.(*Rational).Rat()))
+	}
+	bigIntegerSubtract[KindComplex] = func(p *BigInteger, o Number) Number {
+		f := p.float64Val()
+		return NewComplex(complex(f, 0) - o.(*Complex).Datum())
+	}
+	bigIntegerSubtract[KindBigComplex] = func(p *BigInteger, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Subtract(o)
+	}
+
+	bigIntegerLessThan[KindInteger] = func(p *BigInteger, o Number) bool {
+		return p.value.Cmp(o.(*Integer).bigInt()) < 0
+	}
+	bigIntegerLessThan[KindBigInteger] = func(p *BigInteger, o Number) bool {
+		return p.value.Cmp(o.(*BigInteger).value) < 0
+	}
+	bigIntegerLessThan[KindFloat] = func(p *BigInteger, o Number) bool {
+		return p.bigFloat().Cmp(o.(*Float).bigFloat()) < 0
+	}
+	bigIntegerLessThan[KindBigFloat] = func(p *BigInteger, o Number) bool {
+		return p.bigFloat().Cmp(o.(*BigFloat).BigFloatValue()) < 0
+	}
+	bigIntegerLessThan[KindRational] = func(p *BigInteger, o Number) bool {
+		return p.bigRat().Cmp(o.(*Rational).Rat()) < 0
+	}
+	bigIntegerLessThan[KindComplex] = func(p *BigInteger, o Number) bool {
+		self := p.bigFloat()
+		realPart := NewFloat(real(o.(*Complex).Value)).bigFloat()
+		return self.Cmp(realPart) < 0
+	}
+	bigIntegerLessThan[KindBigComplex] = func(p *BigInteger, o Number) bool {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue()) < 0
+	}
+
+	bigIntegerCompare[KindInteger] = func(p *BigInteger, o Number) int {
+		return p.value.Cmp(o.(*Integer).bigInt())
+	}
+	bigIntegerCompare[KindBigInteger] = func(p *BigInteger, o Number) int {
+		return p.value.Cmp(o.(*BigInteger).value)
+	}
+	bigIntegerCompare[KindFloat] = func(p *BigInteger, o Number) int {
+		// Convert both to BigFloat to preserve precision.
+		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
+		self := p.bigFloat()
+		other := o.(*Float).bigFloat()
+		return self.Cmp(other)
+	}
+	bigIntegerCompare[KindBigFloat] = func(p *BigInteger, o Number) int {
+		return p.bigFloat().Cmp(o.(*BigFloat).BigFloatValue())
+	}
+	bigIntegerCompare[KindRational] = func(p *BigInteger, o Number) int {
+		return p.bigRat().Cmp(o.(*Rational).Rat())
+	}
+	bigIntegerCompare[KindComplex] = func(p *BigInteger, o Number) int {
+		// Compare real parts at BigFloat precision.
+		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
+		self := p.bigFloat()
+		realPart := NewFloat(real(o.(*Complex).Value)).bigFloat()
+		return self.Cmp(realPart)
+	}
+	bigIntegerCompare[KindBigComplex] = func(p *BigInteger, o Number) int {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue())
+	}
+
+	bigIntegerMultiply[KindInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, o.(*Integer).bigInt())}
+	}
+	bigIntegerMultiply[KindBigInteger] = func(p *BigInteger, o Number) Number {
+		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, o.(*BigInteger).value)}
+	}
+	bigIntegerMultiply[KindFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		other := o.(*Float).bigFloat()
+		result := new(big.Float).Mul(self, other)
+		return NewBigFloat(result)
+	}
+	bigIntegerMultiply[KindBigFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(self, o.(*BigFloat).value)}
+	}
+	bigIntegerMultiply[KindRational] = func(p *BigInteger, o Number) Number {
+		pRat := p.bigRat()
+		return NewRationalFromRat(new(big.Rat).Mul(pRat, o.(*Rational).Rat()))
+	}
+	bigIntegerMultiply[KindComplex] = func(p *BigInteger, o Number) Number {
+		f := p.float64Val()
+		return NewComplex(complex(f, 0) * o.(*Complex).Datum())
+	}
+	bigIntegerMultiply[KindBigComplex] = func(p *BigInteger, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Multiply(o)
+	}
+
+	bigIntegerDivide[KindInteger] = func(p *BigInteger, o Number) Number {
+		v := o.(*Integer)
+		divisor := v.bigInt()
+		quo, rem := new(big.Int).QuoRem(p.value, divisor, new(big.Int))
+		if rem.Sign() == 0 {
+			return &BigInteger{value: quo}
+		}
+		return NewRationalFromBigInt(p.value, divisor)
+	}
+	bigIntegerDivide[KindBigInteger] = func(p *BigInteger, o Number) Number {
+		v := o.(*BigInteger)
+		quo, rem := new(big.Int).QuoRem(p.value, v.value, new(big.Int))
+		if rem.Sign() == 0 {
+			return &BigInteger{value: quo}
+		}
+		return NewRationalFromBigInt(p.value, v.value)
+	}
+	bigIntegerDivide[KindFloat] = func(p *BigInteger, o Number) Number {
+		v := o.(*Float)
+		self := p.bigFloat()
+		other := v.bigFloat()
+		result := new(big.Float).Quo(self, other)
+		return NewBigFloat(result)
+	}
+	bigIntegerDivide[KindBigFloat] = func(p *BigInteger, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(self, o.(*BigFloat).value)}
+	}
+	bigIntegerDivide[KindRational] = func(p *BigInteger, o Number) Number {
+		pRat := p.bigRat()
+		return NewRationalFromRat(new(big.Rat).Quo(pRat, o.(*Rational).Rat()))
+	}
+	bigIntegerDivide[KindComplex] = func(p *BigInteger, o Number) Number {
+		f := p.float64Val()
+		return NewComplex(complex(f, 0) / o.(*Complex).Datum())
+	}
+	bigIntegerDivide[KindBigComplex] = func(p *BigInteger, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Divide(o)
+	}
+}
+
 // R7RS §6.2.6: The + procedure returns the sum of its arguments.
 // R7RS §6.2.2 Exactness: exact + exact = exact (BigInteger),
 // exact + inexact = inexact (Float/Complex).
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
+// Inexactness is contagious per R7RS §6.2.2.
 func (p *BigInteger) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigInteger:
+	v, ok := o.(*BigInteger)
+	if ok {
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, v.value)}
-	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Add, p.value, v.bigInt())}
-	case *Float:
-		// Promote to BigFloat for precision-preserving arithmetic.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		// Return BigFloat (inexact) to preserve exactness contagion per R7RS §6.2.2.
-		self := p.bigFloat()
-		other := v.bigFloat()
-		result := new(big.Float).Add(self, other)
-		return NewBigFloat(result)
-	case *Rational:
-		// Convert BigInteger to Rational and add
-		pRat := p.bigRat()
-		return NewRationalFromRat(new(big.Rat).Add(pRat, v.Rat()))
-	case *Complex:
-		// For Complex, we must use float64 (Complex type uses float64 parts).
-		// This loses precision for large BigIntegers, but Complex itself is inexact.
-		f := p.float64Val()
-		return NewComplex(complex(f, 0) + v.Datum())
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Add(self, v.value)}
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Add(v)
 	}
-	panic(ErrNotANumber)
+	return bigIntegerAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of this BigInteger and another number.
 //
 // R7RS §6.2.6: The - procedure returns the difference of its arguments.
 // R7RS §6.2.2 Exactness: exact - exact = exact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *BigInteger) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *BigInteger:
+	v, ok := o.(*BigInteger)
+	if ok {
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, v.value)}
-	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Sub, p.value, v.bigInt())}
-	case *Float:
-		// Promote to BigFloat for precision-preserving arithmetic.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		// Return BigFloat (inexact) to preserve exactness contagion per R7RS §6.2.2.
-		self := p.bigFloat()
-		other := v.bigFloat()
-		result := new(big.Float).Sub(self, other)
-		return NewBigFloat(result)
-	case *Rational:
-		pRat := p.bigRat()
-		return NewRationalFromRat(new(big.Rat).Sub(pRat, v.Rat()))
-	case *Complex:
-		// For Complex, we must use float64 (Complex type uses float64 parts).
-		// This loses precision for large BigIntegers, but Complex itself is inexact.
-		f := p.float64Val()
-		return NewComplex(complex(f, 0) - v.Datum())
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Subtract(v)
 	}
-	panic(ErrNotANumber)
+	return bigIntegerSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of this BigInteger and another number.
@@ -223,35 +361,11 @@ func (p *BigInteger) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *BigInteger:
+	v, ok := o.(*BigInteger)
+	if ok {
 		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, v.value)}
-	case *Integer:
-		return &BigInteger{value: newBigIntFromOp((*big.Int).Mul, p.value, v.bigInt())}
-	case *Float:
-		// Promote to BigFloat for precision-preserving arithmetic.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		// Return BigFloat (inexact) to preserve exactness contagion per R7RS §6.2.2.
-		self := p.bigFloat()
-		other := v.bigFloat()
-		result := new(big.Float).Mul(self, other)
-		return NewBigFloat(result)
-	case *Rational:
-		pRat := p.bigRat()
-		return NewRationalFromRat(new(big.Rat).Mul(pRat, v.Rat()))
-	case *Complex:
-		// For Complex, we must use float64 (Complex type uses float64 parts).
-		// This loses precision for large BigIntegers, but Complex itself is inexact.
-		f := p.float64Val()
-		return NewComplex(complex(f, 0) * v.Datum())
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return bigIntegerMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this BigInteger and another number.
@@ -267,46 +381,15 @@ func (p *BigInteger) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *BigInteger:
-		// Check if division is exact
+	v, ok := o.(*BigInteger)
+	if ok {
 		quo, rem := new(big.Int).QuoRem(p.value, v.value, new(big.Int))
 		if rem.Sign() == 0 {
 			return &BigInteger{value: quo}
 		}
 		return NewRationalFromBigInt(p.value, v.value)
-	case *Integer:
-		// Check if division is exact
-		divisor := v.bigInt()
-		quo, rem := new(big.Int).QuoRem(p.value, divisor, new(big.Int))
-		if rem.Sign() == 0 {
-			return &BigInteger{value: quo}
-		}
-		return NewRationalFromBigInt(p.value, divisor)
-	case *Float:
-		// Promote to BigFloat for precision-preserving arithmetic.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		// Return BigFloat (inexact) to preserve exactness contagion per R7RS §6.2.2.
-		self := p.bigFloat()
-		other := v.bigFloat()
-		result := new(big.Float).Quo(self, other)
-		return NewBigFloat(result)
-	case *Rational:
-		pRat := p.bigRat()
-		return NewRationalFromRat(new(big.Rat).Quo(pRat, v.Rat()))
-	case *Complex:
-		// For Complex, we must use float64 (Complex type uses float64 parts).
-		// This loses precision for large BigIntegers, but Complex itself is inexact.
-		f := p.float64Val()
-		return NewComplex(complex(f, 0) / v.Datum())
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Divide(v)
 	}
-	panic(ErrNotANumber)
+	return bigIntegerDivide[o.Kind()](p, o)
 }
 
 // Negate returns the negation of this BigInteger.
@@ -324,7 +407,11 @@ func (p *BigInteger) IsZero() bool {
 // R7RS §6.2.6: The < procedure returns #t if its arguments are monotonically
 // increasing. Comparison across numeric types uses mathematical value.
 func (p *BigInteger) LessThan(o Number) bool {
-	return p.Compare(o) < 0
+	v, ok := o.(*BigInteger)
+	if ok {
+		return p.value.Cmp(v.value) < 0
+	}
+	return bigIntegerLessThan[o.Kind()](p, o)
 }
 
 // IsNegative returns true if this BigInteger is negative.
@@ -412,35 +499,11 @@ func (p *BigInteger) Sign() int {
 // R7RS §6.2.6: Numeric comparisons use mathematical value regardless of
 // exactness. Returns -1, 0, or 1 for less than, equal, or greater than.
 func (p *BigInteger) Compare(o Number) int {
-	switch v := o.(type) {
-	case *BigInteger:
+	v, ok := o.(*BigInteger)
+	if ok {
 		return p.value.Cmp(v.value)
-	case *Integer:
-		return p.value.Cmp(v.bigInt())
-	case *Float:
-		// Convert both to BigFloat to preserve precision.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		// Pattern matches Float.Compare() and Integer.Compare() with BigFloat.
-		self := p.bigFloat()
-		other := v.bigFloat()
-		return self.Cmp(other)
-	case *BigFloat:
-		self := p.bigFloat()
-		return self.Cmp(v.BigFloatValue())
-	case *Rational:
-		pRat := p.bigRat()
-		return pRat.Cmp(v.Rat())
-	case *Complex:
-		// Compare real parts at BigFloat precision.
-		// Don't convert BigInteger to float64 (loses precision for >53-bit integers).
-		self := p.bigFloat()
-		realPart := NewFloat(real(v.Value)).bigFloat()
-		return self.Cmp(realPart)
-	case *BigComplex:
-		self := p.bigFloat()
-		return self.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
-	panic(ErrNotANumber)
+	return bigIntegerCompare[o.Kind()](p, o)
 }
 
 // SchemeString returns the Scheme representation of this BigInteger.

--- a/values/complex.go
+++ b/values/complex.go
@@ -68,7 +68,196 @@ func (p *Complex) toBigComplex() *BigComplex {
 	)
 }
 
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *Complex) Kind() NumericKind {
+	return KindComplex
+}
+
+var complexAdd [numKinds]func(*Complex, Number) Number
+var complexSubtract [numKinds]func(*Complex, Number) Number
+var complexLessThan [numKinds]func(*Complex, Number) bool
+var complexCompare [numKinds]func(*Complex, Number) int
+var complexMultiply [numKinds]func(*Complex, Number) Number
+var complexDivide [numKinds]func(*Complex, Number) Number
+
+func init() {
+	complexAdd[KindInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value + o.(*Integer).toComplex())
+	}
+	complexAdd[KindBigInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value + complex(o.(*BigInteger).float64Val(), 0))
+	}
+	complexAdd[KindFloat] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value + o.(*Float).toComplex())
+	}
+	complexAdd[KindBigFloat] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Add(o)
+	}
+	complexAdd[KindRational] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value + o.(*Rational).toComplex())
+	}
+	complexAdd[KindComplex] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value + o.(*Complex).Value)
+	}
+	complexAdd[KindBigComplex] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Add(o)
+	}
+
+	complexSubtract[KindInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value - o.(*Integer).toComplex())
+	}
+	complexSubtract[KindBigInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value - complex(o.(*BigInteger).float64Val(), 0))
+	}
+	complexSubtract[KindFloat] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value - o.(*Float).toComplex())
+	}
+	complexSubtract[KindBigFloat] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Subtract(o)
+	}
+	complexSubtract[KindRational] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value - o.(*Rational).toComplex())
+	}
+	complexSubtract[KindComplex] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value - o.(*Complex).Value)
+	}
+	complexSubtract[KindBigComplex] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Subtract(o)
+	}
+
+	complexLessThan[KindInteger] = func(p *Complex, o Number) bool {
+		return real(p.Value) < float64(o.(*Integer).Value)
+	}
+	complexLessThan[KindBigInteger] = func(p *Complex, o Number) bool {
+		return real(p.Value) < o.(*BigInteger).float64Val()
+	}
+	complexLessThan[KindFloat] = func(p *Complex, o Number) bool {
+		return real(p.Value) < o.(*Float).Value
+	}
+	complexLessThan[KindBigFloat] = func(p *Complex, o Number) bool {
+		self := NewBigFloatFromFloat64(real(p.Value))
+		return self.Compare(o.(*BigFloat)) < 0
+	}
+	complexLessThan[KindRational] = func(p *Complex, o Number) bool {
+		return real(p.Value) < o.(*Rational).Float64()
+	}
+	complexLessThan[KindComplex] = func(p *Complex, o Number) bool {
+		return real(p.Value) < real(o.(*Complex).Value)
+	}
+	complexLessThan[KindBigComplex] = func(p *Complex, o Number) bool {
+		return NewBigFloatFromFloat64(real(p.Value)).Compare(o.(*BigComplex).Real()) < 0
+	}
+
+	complexCompare[KindInteger] = func(p *Complex, o Number) int {
+		r := real(p.Value)
+		vf := float64(o.(*Integer).Value)
+		if r < vf {
+			return -1
+		} else if r > vf {
+			return 1
+		}
+		return 0
+	}
+	complexCompare[KindBigInteger] = func(p *Complex, o Number) int {
+		r := real(p.Value)
+		vf := o.(*BigInteger).float64Val()
+		if r < vf {
+			return -1
+		} else if r > vf {
+			return 1
+		}
+		return 0
+	}
+	complexCompare[KindFloat] = func(p *Complex, o Number) int {
+		r := real(p.Value)
+		if r < o.(*Float).Value {
+			return -1
+		} else if r > o.(*Float).Value {
+			return 1
+		}
+		return 0
+	}
+	complexCompare[KindBigFloat] = func(p *Complex, o Number) int {
+		return NewBigFloatFromFloat64(real(p.Value)).Compare(o)
+	}
+	complexCompare[KindRational] = func(p *Complex, o Number) int {
+		r := real(p.Value)
+		vf := o.(*Rational).Float64()
+		if r < vf {
+			return -1
+		} else if r > vf {
+			return 1
+		}
+		return 0
+	}
+	complexCompare[KindComplex] = func(p *Complex, o Number) int {
+		r1, r2 := real(p.Value), real(o.(*Complex).Value)
+		if r1 < r2 {
+			return -1
+		} else if r1 > r2 {
+			return 1
+		}
+		return 0
+	}
+	complexCompare[KindBigComplex] = func(p *Complex, o Number) int {
+		return NewBigFloatFromFloat64(real(p.Value)).Compare(o.(*BigComplex).Real())
+	}
+
+	complexMultiply[KindInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value * o.(*Integer).toComplex())
+	}
+	complexMultiply[KindBigInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value * complex(o.(*BigInteger).float64Val(), 0))
+	}
+	complexMultiply[KindFloat] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value * o.(*Float).toComplex())
+	}
+	complexMultiply[KindBigFloat] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Multiply(o)
+	}
+	complexMultiply[KindRational] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value * o.(*Rational).toComplex())
+	}
+	complexMultiply[KindComplex] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value * o.(*Complex).Value)
+	}
+	complexMultiply[KindBigComplex] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Multiply(o)
+	}
+
+	complexDivide[KindInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value / o.(*Integer).toComplex())
+	}
+	complexDivide[KindBigInteger] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value / complex(o.(*BigInteger).float64Val(), 0))
+	}
+	complexDivide[KindFloat] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value / o.(*Float).toComplex())
+	}
+	complexDivide[KindBigFloat] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Divide(o)
+	}
+	complexDivide[KindRational] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value / o.(*Rational).toComplex())
+	}
+	complexDivide[KindComplex] = func(p *Complex, o Number) Number {
+		return NewComplex(p.Value / o.(*Complex).Value)
+	}
+	complexDivide[KindBigComplex] = func(p *Complex, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Divide(o)
+	}
+}
+
 // Add returns the sum of this complex number and another number.
+// Zero short-circuit: 0+x=x preserves exactness per R7RS §6.2.2.
 func (p *Complex) Add(o Number) Number {
 	if o.IsZero() {
 		return p
@@ -76,81 +265,35 @@ func (p *Complex) Add(o Number) Number {
 	if p.IsZero() {
 		return o
 	}
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		return NewComplex(p.Value + v.Value)
-	case *Float:
-		return NewComplex(p.Value + v.toComplex())
-	case *Integer:
-		return NewComplex(p.Value + v.toComplex())
-	case *BigInteger:
-		return NewComplex(p.Value + complex(v.float64Val(), 0))
-	case *BigFloat:
-		bc := p.toBigComplex()
-		return bc.Add(v)
-	case *Rational:
-		return NewComplex(p.Value + v.toComplex())
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Add(v)
 	}
-	panic(ErrNotANumber)
+	return complexAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of this complex number and another number.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Complex) Subtract(o Number) Number {
 	if o.IsZero() {
 		return p
 	}
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		return NewComplex(p.Value - v.Value)
-	case *Float:
-		return NewComplex(p.Value - v.toComplex())
-	case *Integer:
-		return NewComplex(p.Value - v.toComplex())
-	case *BigInteger:
-		return NewComplex(p.Value - complex(v.float64Val(), 0))
-	case *BigFloat:
-		bc := p.toBigComplex()
-		return bc.Subtract(v)
-	case *Rational:
-		return NewComplex(p.Value - v.toComplex())
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Subtract(v)
 	}
-	panic(ErrNotANumber)
+	return complexSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of this complex number and another number.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Complex) Multiply(o Number) Number {
 	if o.IsZero() {
 		return o
 	}
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		return NewComplex(p.Value * v.Value)
-	case *Float:
-		return NewComplex(p.Value * v.toComplex())
-	case *Integer:
-		return NewComplex(p.Value * v.toComplex())
-	case *BigInteger:
-		return NewComplex(p.Value * complex(v.float64Val(), 0))
-	case *BigFloat:
-		bc := p.toBigComplex()
-		return bc.Multiply(v)
-	case *Rational:
-		return NewComplex(p.Value * v.toComplex())
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return complexMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this complex number and another number.
@@ -158,25 +301,11 @@ func (p *Complex) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		return NewComplex(p.Value / v.Value)
-	case *Float:
-		return NewComplex(p.Value / v.toComplex())
-	case *Integer:
-		return NewComplex(p.Value / v.toComplex())
-	case *BigInteger:
-		return NewComplex(p.Value / complex(v.float64Val(), 0))
-	case *BigFloat:
-		bc := p.toBigComplex()
-		return bc.Divide(v)
-	case *Rational:
-		return NewComplex(p.Value / v.toComplex())
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Divide(v)
 	}
-	panic(ErrNotANumber)
+	return complexDivide[o.Kind()](p, o)
 }
 
 // IsZero returns true if this complex number is zero.
@@ -186,24 +315,11 @@ func (p *Complex) IsZero() bool {
 
 // LessThan compares the real parts of the complex numbers.
 func (p *Complex) LessThan(o Number) bool {
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		return real(p.Value) < real(v.Value)
-	case *Float:
-		return real(p.Value) < v.Value
-	case *Integer:
-		return real(p.Value) < float64(v.Value)
-	case *BigInteger:
-		return real(p.Value) < v.float64Val()
-	case *BigFloat:
-		self := NewBigFloatFromFloat64(real(p.Value))
-		return self.Compare(v) < 0
-	case *Rational:
-		return real(p.Value) < v.Float64()
-	case *BigComplex:
-		return NewBigFloatFromFloat64(real(p.Value)).Compare(v.Real()) < 0
 	}
-	panic(ErrNotANumber)
+	return complexLessThan[o.Kind()](p, o)
 }
 
 // Negate returns the negation of this complex number.
@@ -256,8 +372,8 @@ func (p *Complex) ImagPart() Number {
 // R7RS §6.2.6: Complex comparison compares real parts only.
 // Returns -1 if p < o, 0 if p == o, 1 if p > o.
 func (p *Complex) Compare(o Number) int {
-	switch v := o.(type) {
-	case *Complex:
+	v, ok := o.(*Complex)
+	if ok {
 		r1, r2 := real(p.Value), real(v.Value)
 		if r1 < r2 {
 			return -1
@@ -265,48 +381,8 @@ func (p *Complex) Compare(o Number) int {
 			return 1
 		}
 		return 0
-	case *Float:
-		r := real(p.Value)
-		if r < v.Value {
-			return -1
-		} else if r > v.Value {
-			return 1
-		}
-		return 0
-	case *Integer:
-		r := real(p.Value)
-		vf := float64(v.Value)
-		if r < vf {
-			return -1
-		} else if r > vf {
-			return 1
-		}
-		return 0
-	case *BigInteger:
-		r := real(p.Value)
-		vf := v.float64Val()
-		if r < vf {
-			return -1
-		} else if r > vf {
-			return 1
-		}
-		return 0
-	case *BigFloat:
-		self := NewBigFloatFromFloat64(real(p.Value))
-		return self.Compare(v)
-	case *Rational:
-		r := real(p.Value)
-		vf := v.Float64()
-		if r < vf {
-			return -1
-		} else if r > vf {
-			return 1
-		}
-		return 0
-	case *BigComplex:
-		return NewBigFloatFromFloat64(real(p.Value)).Compare(v.Real())
 	}
-	panic(ErrNotANumber)
+	return complexCompare[o.Kind()](p, o)
 }
 
 // IsExact returns false since Complex is always inexact.

--- a/values/float.go
+++ b/values/float.go
@@ -73,64 +73,196 @@ func (p *Float) toBigComplex() *BigComplex {
 
 // Add returns the sum of two numbers.
 //
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *Float) Kind() NumericKind {
+	return KindFloat
+}
+
+var floatAdd [numKinds]func(*Float, Number) Number
+var floatSubtract [numKinds]func(*Float, Number) Number
+var floatLessThan [numKinds]func(*Float, Number) bool
+var floatCompare [numKinds]func(*Float, Number) int
+var floatMultiply [numKinds]func(*Float, Number) Number
+var floatDivide [numKinds]func(*Float, Number) Number
+
+func init() {
+	floatAdd[KindInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value + float64(o.(*Integer).Value))
+	}
+	floatAdd[KindBigInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value + float64FromBigInt(o.(*BigInteger).value))
+	}
+	floatAdd[KindFloat] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value + o.(*Float).Value)
+	}
+	floatAdd[KindBigFloat] = func(p *Float, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Add(self, o.(*BigFloat).value)}
+	}
+	floatAdd[KindRational] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value + o.(*Rational).Float64())
+	}
+	floatAdd[KindComplex] = func(p *Float, o Number) Number {
+		return NewComplex(p.toComplex() + o.(*Complex).Value)
+	}
+	floatAdd[KindBigComplex] = func(p *Float, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Add(o)
+	}
+
+	floatSubtract[KindInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value - float64(o.(*Integer).Value))
+	}
+	floatSubtract[KindBigInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value - float64FromBigInt(o.(*BigInteger).value))
+	}
+	floatSubtract[KindFloat] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value - o.(*Float).Value)
+	}
+	floatSubtract[KindBigFloat] = func(p *Float, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Sub(self, o.(*BigFloat).value)}
+	}
+	floatSubtract[KindRational] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value - o.(*Rational).Float64())
+	}
+	floatSubtract[KindComplex] = func(p *Float, o Number) Number {
+		return NewComplex(p.toComplex() - o.(*Complex).Value)
+	}
+	floatSubtract[KindBigComplex] = func(p *Float, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Subtract(o)
+	}
+
+	floatLessThan[KindInteger] = func(p *Float, o Number) bool {
+		return p.Value < float64(o.(*Integer).Value)
+	}
+	floatLessThan[KindBigInteger] = func(p *Float, o Number) bool {
+		self := p.bigFloat()
+		other := new(big.Float).SetInt(o.(*BigInteger).BigInt())
+		return self.Cmp(other) < 0
+	}
+	floatLessThan[KindFloat] = func(p *Float, o Number) bool {
+		return p.Value < o.(*Float).Value
+	}
+	floatLessThan[KindBigFloat] = func(p *Float, o Number) bool {
+		return p.bigFloat().Cmp(o.(*BigFloat).BigFloatValue()) < 0
+	}
+	floatLessThan[KindRational] = func(p *Float, o Number) bool {
+		return p.Value < o.(*Rational).Float64()
+	}
+	floatLessThan[KindComplex] = func(p *Float, o Number) bool {
+		return p.Value < real(o.(*Complex).Value)
+	}
+	floatLessThan[KindBigComplex] = func(p *Float, o Number) bool {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue()) < 0
+	}
+
+	floatCompare[KindInteger] = func(p *Float, o Number) int {
+		pf := p.bigFloat()
+		vf := new(big.Float).SetInt64(o.(*Integer).Value)
+		return pf.Cmp(vf)
+	}
+	floatCompare[KindBigInteger] = func(p *Float, o Number) int {
+		pf := p.bigFloat()
+		vf := new(big.Float).SetInt(o.(*BigInteger).value)
+		return pf.Cmp(vf)
+	}
+	floatCompare[KindFloat] = func(p *Float, o Number) int {
+		pf := p.bigFloat()
+		vf := new(big.Float).SetFloat64(o.(*Float).Value)
+		return pf.Cmp(vf)
+	}
+	floatCompare[KindBigFloat] = func(p *Float, o Number) int {
+		return p.bigFloat().Cmp(o.(*BigFloat).value)
+	}
+	floatCompare[KindRational] = func(p *Float, o Number) int {
+		pf := p.bigFloat()
+		vf := new(big.Float).SetRat(o.(*Rational).Rat())
+		return pf.Cmp(vf)
+	}
+	floatCompare[KindComplex] = func(p *Float, o Number) int {
+		r := real(o.(*Complex).Value)
+		if p.Value < r {
+			return -1
+		} else if p.Value > r {
+			return 1
+		}
+		return 0
+	}
+	floatCompare[KindBigComplex] = func(p *Float, o Number) int {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue())
+	}
+
+	floatMultiply[KindInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value * float64(o.(*Integer).Value))
+	}
+	floatMultiply[KindBigInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value * float64FromBigInt(o.(*BigInteger).value))
+	}
+	floatMultiply[KindFloat] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value * o.(*Float).Value)
+	}
+	floatMultiply[KindBigFloat] = func(p *Float, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(self, o.(*BigFloat).value)}
+	}
+	floatMultiply[KindRational] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value * o.(*Rational).Float64())
+	}
+	floatMultiply[KindComplex] = func(p *Float, o Number) Number {
+		return NewComplex(p.toComplex() * o.(*Complex).Value)
+	}
+	floatMultiply[KindBigComplex] = func(p *Float, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Multiply(o)
+	}
+
+	floatDivide[KindInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value / float64(o.(*Integer).Value))
+	}
+	floatDivide[KindBigInteger] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value / float64FromBigInt(o.(*BigInteger).value))
+	}
+	floatDivide[KindFloat] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value / o.(*Float).Value)
+	}
+	floatDivide[KindBigFloat] = func(p *Float, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(self, o.(*BigFloat).value)}
+	}
+	floatDivide[KindRational] = func(p *Float, o Number) Number {
+		return NewFloat(p.Value / o.(*Rational).Float64())
+	}
+	floatDivide[KindComplex] = func(p *Float, o Number) Number {
+		return NewComplex(p.toComplex() / o.(*Complex).Value)
+	}
+	floatDivide[KindBigComplex] = func(p *Float, o Number) Number {
+		bc := p.toBigComplex()
+		return bc.Divide(o)
+	}
+}
+
 // R7RS §6.2.6: The + procedure returns the sum of its arguments.
 // R7RS §6.2.2 Exactness: inexact + inexact = inexact, exact + inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Float) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Integer:
-		return NewFloat(p.Value + float64(v.Value))
-	case *BigInteger:
-		return NewFloat(p.Value + float64FromBigInt(v.value))
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
 		return NewFloat(p.Value + v.Value)
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Add(self, v.value)}
-	case *Rational:
-		return NewFloat(p.Value + v.Float64())
-	case *Complex:
-		return NewComplex(p.toComplex() + v.Value)
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Add(v)
 	}
-	panic(ErrNotANumber)
+	return floatAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of two numbers.
 //
 // R7RS §6.2.6: The - procedure returns the difference of its arguments.
 // R7RS §6.2.2 Exactness: inexact - inexact = inexact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Float) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Integer:
-		return NewFloat(p.Value - float64(v.Value))
-	case *BigInteger:
-		return NewFloat(p.Value - float64FromBigInt(v.value))
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
 		return NewFloat(p.Value - v.Value)
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
-	case *Rational:
-		return NewFloat(p.Value - v.Float64())
-	case *Complex:
-		return NewComplex(p.toComplex() - v.Value)
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Subtract(v)
 	}
-	panic(ErrNotANumber)
+	return floatSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of two numbers.
@@ -146,25 +278,11 @@ func (p *Float) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *Integer:
-		return NewFloat(p.Value * float64(v.Value))
-	case *BigInteger:
-		return NewFloat(p.Value * float64FromBigInt(v.value))
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
 		return NewFloat(p.Value * v.Value)
-	case *Rational:
-		return NewFloat(p.Value * v.Float64())
-	case *Complex:
-		return NewComplex(p.toComplex() * v.Value)
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return floatMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this float and another number.
@@ -172,25 +290,11 @@ func (p *Float) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *Integer:
-		return NewFloat(p.Value / float64(v.Value))
-	case *BigInteger:
-		return NewFloat(p.Value / float64FromBigInt(v.value))
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
 		return NewFloat(p.Value / v.Value)
-	case *Rational:
-		return NewFloat(p.Value / v.Float64())
-	case *Complex:
-		return NewComplex(p.toComplex() / v.Value)
-	case *BigComplex:
-		bc := p.toBigComplex()
-		return bc.Divide(v)
 	}
-	panic(ErrNotANumber)
+	return floatDivide[o.Kind()](p, o)
 }
 
 // IsZero returns true if this float is zero.
@@ -200,27 +304,11 @@ func (p *Float) IsZero() bool {
 
 // LessThan returns true if this float is less than another number.
 func (p *Float) LessThan(o Number) bool {
-	switch v := o.(type) {
-	case *Integer:
-		return p.Value < float64(v.Value)
-	case *BigInteger:
-		self := p.bigFloat()
-		other := new(big.Float).SetInt(v.BigInt())
-		return self.Cmp(other) < 0
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
 		return p.Value < v.Value
-	case *BigFloat:
-		self := p.bigFloat()
-		return self.Cmp(v.BigFloatValue()) < 0
-	case *Rational:
-		return p.Value < v.Float64()
-	case *Complex:
-		return p.Value < real(v.Value)
-	case *BigComplex:
-		self := p.bigFloat()
-		return self.Cmp(toBigFloat(v.Real()).BigFloatValue()) < 0
 	}
-	panic(ErrNotANumber)
+	return floatLessThan[o.Kind()](p, o)
 }
 
 // Abs returns the absolute value of this float.
@@ -277,34 +365,13 @@ func (p *Float) Negate() Number {
 // R7RS §6.2.6: Numeric comparisons use mathematical value regardless of exactness.
 // Returns -1 if p < o, 0 if p == o, 1 if p > o.
 func (p *Float) Compare(o Number) int {
-	pf := p.bigFloat()
-	switch v := o.(type) {
-	case *BigFloat:
-		return pf.Cmp(v.value)
-	case *BigInteger:
-		vf := new(big.Float).SetInt(v.value)
-		return pf.Cmp(vf)
-	case *Integer:
-		vf := new(big.Float).SetInt64(v.Value)
-		return pf.Cmp(vf)
-	case *Float:
+	v, ok := o.(*Float)
+	if ok {
+		pf := p.bigFloat()
 		vf := new(big.Float).SetFloat64(v.Value)
 		return pf.Cmp(vf)
-	case *Rational:
-		vf := new(big.Float).SetRat(v.Rat())
-		return pf.Cmp(vf)
-	case *Complex:
-		r := real(v.Value)
-		if p.Value < r {
-			return -1
-		} else if p.Value > r {
-			return 1
-		}
-		return 0
-	case *BigComplex:
-		return pf.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
-	panic(ErrNotANumber)
+	return floatCompare[o.Kind()](p, o)
 }
 
 // IsExact returns false since Float is always inexact.

--- a/values/integer.go
+++ b/values/integer.go
@@ -165,65 +165,207 @@ func negateInt64(v int64) Number {
 // Add returns the sum of this integer and another number.
 //
 // R7RS §6.2.6: The + procedure returns the sum of its arguments.
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *Integer) Kind() NumericKind {
+	return KindInteger
+}
+
+var integerAdd [numKinds]func(*Integer, Number) Number
+var integerSubtract [numKinds]func(*Integer, Number) Number
+var integerLessThan [numKinds]func(*Integer, Number) bool
+var integerCompare [numKinds]func(*Integer, Number) int
+var integerMultiply [numKinds]func(*Integer, Number) Number
+var integerDivide [numKinds]func(*Integer, Number) Number
+
+func init() {
+	integerAdd[KindInteger] = func(p *Integer, o Number) Number {
+		return addInt64(p.Value, o.(*Integer).Value)
+	}
+	integerAdd[KindBigInteger] = func(p *Integer, o Number) Number {
+		v := o.(*BigInteger)
+		result := newBigIntFromOp((*big.Int).Add, p.bigInt(), v.value)
+		return &BigInteger{value: result}
+	}
+	integerAdd[KindFloat] = func(p *Integer, o Number) Number {
+		return NewFloat(float64(p.Value) + o.(*Float).Value)
+	}
+	integerAdd[KindBigFloat] = func(p *Integer, o Number) Number {
+		return &BigFloat{value: new(big.Float).Add(p.bigFloat(), o.(*BigFloat).value)}
+	}
+	integerAdd[KindRational] = func(p *Integer, o Number) Number {
+		result := new(big.Rat).Add(p.bigRat(), o.(*Rational).Rat())
+		return &Rational{value: result}
+	}
+	integerAdd[KindComplex] = func(p *Integer, o Number) Number {
+		return NewComplex(p.toComplex() + o.(*Complex).Value)
+	}
+	integerAdd[KindBigComplex] = func(p *Integer, o Number) Number {
+		return p.toBigComplex().Add(o)
+	}
+
+	integerSubtract[KindInteger] = func(p *Integer, o Number) Number {
+		return subInt64(p.Value, o.(*Integer).Value)
+	}
+	integerSubtract[KindBigInteger] = func(p *Integer, o Number) Number {
+		result := newBigIntFromOp((*big.Int).Sub, p.bigInt(), o.(*BigInteger).value)
+		return &BigInteger{value: result}
+	}
+	integerSubtract[KindFloat] = func(p *Integer, o Number) Number {
+		return NewFloat(float64(p.Value) - o.(*Float).Value)
+	}
+	integerSubtract[KindBigFloat] = func(p *Integer, o Number) Number {
+		return &BigFloat{value: new(big.Float).Sub(p.bigFloat(), o.(*BigFloat).value)}
+	}
+	integerSubtract[KindRational] = func(p *Integer, o Number) Number {
+		result := new(big.Rat).Sub(p.bigRat(), o.(*Rational).Rat())
+		return &Rational{value: result}
+	}
+	integerSubtract[KindComplex] = func(p *Integer, o Number) Number {
+		return NewComplex(p.toComplex() - o.(*Complex).Value)
+	}
+	integerSubtract[KindBigComplex] = func(p *Integer, o Number) Number {
+		return p.toBigComplex().Subtract(o)
+	}
+
+	integerLessThan[KindInteger] = func(p *Integer, o Number) bool {
+		return p.Value < o.(*Integer).Value
+	}
+	integerLessThan[KindBigInteger] = func(p *Integer, o Number) bool {
+		return p.bigInt().Cmp(o.(*BigInteger).BigInt()) < 0
+	}
+	integerLessThan[KindFloat] = func(p *Integer, o Number) bool {
+		return float64(p.Value) < o.(*Float).Value
+	}
+	integerLessThan[KindBigFloat] = func(p *Integer, o Number) bool {
+		return p.bigFloat().Cmp(o.(*BigFloat).BigFloatValue()) < 0
+	}
+	integerLessThan[KindRational] = func(p *Integer, o Number) bool {
+		return p.bigRat().Cmp(o.(*Rational).Rat()) < 0
+	}
+	integerLessThan[KindComplex] = func(p *Integer, o Number) bool {
+		return float64(p.Value) < real(o.(*Complex).Value)
+	}
+	integerLessThan[KindBigComplex] = func(p *Integer, o Number) bool {
+		return toBigFloat(NewBigIntegerFromInt64(p.Value)).Compare(o.(*BigComplex).Real()) < 0
+	}
+
+	integerCompare[KindInteger] = func(p *Integer, o Number) int {
+		v := o.(*Integer)
+		if p.Value < v.Value {
+			return -1
+		} else if p.Value > v.Value {
+			return 1
+		}
+		return 0
+	}
+	integerCompare[KindBigInteger] = func(p *Integer, o Number) int {
+		return p.bigInt().Cmp(o.(*BigInteger).value)
+	}
+	integerCompare[KindFloat] = func(p *Integer, o Number) int {
+		pf := float64(p.Value)
+		v := o.(*Float)
+		if pf < v.Value {
+			return -1
+		} else if pf > v.Value {
+			return 1
+		}
+		return 0
+	}
+	integerCompare[KindBigFloat] = func(p *Integer, o Number) int {
+		return p.bigFloat().Cmp(o.(*BigFloat).BigFloatValue())
+	}
+	integerCompare[KindRational] = func(p *Integer, o Number) int {
+		return p.bigRat().Cmp(o.(*Rational).Rat())
+	}
+	integerCompare[KindComplex] = func(p *Integer, o Number) int {
+		pf := float64(p.Value)
+		r := real(o.(*Complex).Value)
+		if pf < r {
+			return -1
+		} else if pf > r {
+			return 1
+		}
+		return 0
+	}
+	integerCompare[KindBigComplex] = func(p *Integer, o Number) int {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue())
+	}
+
+	integerMultiply[KindInteger] = func(p *Integer, o Number) Number {
+		return mulInt64(p.Value, o.(*Integer).Value)
+	}
+	integerMultiply[KindBigInteger] = func(p *Integer, o Number) Number {
+		v := o.(*BigInteger)
+		result := newBigIntFromOp((*big.Int).Mul, p.bigInt(), v.value)
+		return &BigInteger{value: result}
+	}
+	integerMultiply[KindFloat] = func(p *Integer, o Number) Number {
+		return NewFloat(float64(p.Value) * o.(*Float).Value)
+	}
+	integerMultiply[KindBigFloat] = func(p *Integer, o Number) Number {
+		return &BigFloat{value: new(big.Float).Mul(p.bigFloat(), o.(*BigFloat).value)}
+	}
+	integerMultiply[KindRational] = func(p *Integer, o Number) Number {
+		result := new(big.Rat).Mul(p.bigRat(), o.(*Rational).Rat())
+		return &Rational{value: result}
+	}
+	integerMultiply[KindComplex] = func(p *Integer, o Number) Number {
+		return NewComplex(p.toComplex() * o.(*Complex).Value)
+	}
+	integerMultiply[KindBigComplex] = func(p *Integer, o Number) Number {
+		return p.toBigComplex().Multiply(o)
+	}
+
+	integerDivide[KindInteger] = func(p *Integer, o Number) Number {
+		v := o.(*Integer)
+		result := NewRational(p.Value, v.Value)
+		if result.IsInteger() {
+			return NewInteger(result.NumInt64())
+		}
+		return result
+	}
+	integerDivide[KindBigInteger] = func(p *Integer, o Number) Number {
+		return NewRationalFromBigInt(p.bigInt(), o.(*BigInteger).value)
+	}
+	integerDivide[KindFloat] = func(p *Integer, o Number) Number {
+		return NewFloat(float64(p.Value) / o.(*Float).Value)
+	}
+	integerDivide[KindBigFloat] = func(p *Integer, o Number) Number {
+		return &BigFloat{value: new(big.Float).Quo(p.bigFloat(), o.(*BigFloat).value)}
+	}
+	integerDivide[KindRational] = func(p *Integer, o Number) Number {
+		result := new(big.Rat).Quo(p.bigRat(), o.(*Rational).Rat())
+		return &Rational{value: result}
+	}
+	integerDivide[KindComplex] = func(p *Integer, o Number) Number {
+		return NewComplex(p.toComplex() / o.(*Complex).Value)
+	}
+	integerDivide[KindBigComplex] = func(p *Integer, o Number) Number {
+		return p.toBigComplex().Divide(o)
+	}
+}
+
 // R7RS §6.2.2 Exactness: exact + exact = exact, exact + inexact = inexact.
 // When adding Integer + BigInteger, result is BigInteger (exact).
 // When adding Integer + Float/Complex, result is Float/Complex (inexact).
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Integer) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		return addInt64(p.Value, v.Value)
-	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Add, p.bigInt(), v.value)
-		return &BigInteger{value: result}
-	case *Float:
-		return NewFloat(float64(p.Value) + v.Value)
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Add(p.bigFloat(), v.value)}
-	case *Rational:
-		result := new(big.Rat).Add(p.bigRat(), v.Rat())
-		return &Rational{value: result}
-	case *Complex:
-		return NewComplex(p.toComplex() + v.Value)
-	case *BigComplex:
-		return p.toBigComplex().Add(v)
 	}
-	panic(ErrNotANumber)
+	return integerAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of this integer and another number.
 //
 // R7RS §6.2.6: The - procedure returns the difference of its arguments.
 // R7RS §6.2.2 Exactness: exact - exact = exact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Integer) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		return subInt64(p.Value, v.Value)
-	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Sub, p.bigInt(), v.value)
-		return &BigInteger{value: result}
-	case *Float:
-		return NewFloat(float64(p.Value) - v.Value)
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Sub(p.bigFloat(), v.value)}
-	case *Rational:
-		result := new(big.Rat).Sub(p.bigRat(), v.Rat())
-		return &Rational{value: result}
-	case *Complex:
-		return NewComplex(p.toComplex() - v.Value)
-	case *BigComplex:
-		return p.toBigComplex().Subtract(v)
 	}
-	panic(ErrNotANumber)
+	return integerSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of this integer and another number.
@@ -233,8 +375,6 @@ func (p *Integer) Subtract(o Number) Number {
 // Exception: Exact zero dominates—(* 0 x) may return exact 0 even when
 // x is inexact. Zero is an exact value when the result is mathematically
 // unambiguous. This implementation follows Chez Scheme's behavior.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Integer) Multiply(o Number) Number {
 	if o.IsZero() {
 		return multiplyResultForZero(o, p)
@@ -242,25 +382,11 @@ func (p *Integer) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		return mulInt64(p.Value, v.Value)
-	case *BigInteger:
-		result := newBigIntFromOp((*big.Int).Mul, p.bigInt(), v.value)
-		return &BigInteger{value: result}
-	case *Float:
-		return NewFloat(float64(p.Value) * v.Value)
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Mul(p.bigFloat(), v.value)}
-	case *Rational:
-		result := new(big.Rat).Mul(p.bigRat(), v.Rat())
-		return &Rational{value: result}
-	case *Complex:
-		return NewComplex(p.toComplex() * v.Value)
-	case *BigComplex:
-		return p.toBigComplex().Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return integerMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of this integer and another number.
@@ -272,34 +398,19 @@ func (p *Integer) Multiply(o Number) Number {
 //
 // R7RS §6.2.2 Exactness: exact / exact = exact (Integer or Rational),
 // exact / inexact = inexact (Float or Complex).
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Integer) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		result := NewRational(p.Value, v.Value)
 		if result.IsInteger() {
 			return NewInteger(result.NumInt64())
 		}
 		return result
-	case *BigInteger:
-		return NewRationalFromBigInt(p.bigInt(), v.value)
-	case *Float:
-		return NewFloat(float64(p.Value) / v.Value)
-	case *BigFloat:
-		return &BigFloat{value: new(big.Float).Quo(p.bigFloat(), v.value)}
-	case *Rational:
-		result := new(big.Rat).Quo(p.bigRat(), v.Rat())
-		return &Rational{value: result}
-	case *Complex:
-		return NewComplex(p.toComplex() / v.Value)
-	case *BigComplex:
-		return p.toBigComplex().Divide(v)
 	}
-	panic(ErrNotANumber)
+	return integerDivide[o.Kind()](p, o)
 }
 
 // IsZero returns true if this integer is zero.
@@ -312,23 +423,11 @@ func (p *Integer) IsZero() bool {
 // R7RS §6.2.6: The < procedure returns #t if its arguments are monotonically
 // increasing. Comparison across numeric types uses mathematical value.
 func (p *Integer) LessThan(o Number) bool {
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		return p.Value < v.Value
-	case *BigInteger:
-		return p.bigInt().Cmp(v.BigInt()) < 0
-	case *Float:
-		return float64(p.Value) < v.Value
-	case *BigFloat:
-		return p.bigFloat().Cmp(v.BigFloatValue()) < 0
-	case *Rational:
-		return p.bigRat().Cmp(v.Rat()) < 0
-	case *Complex:
-		return float64(p.Value) < real(v.Value)
-	case *BigComplex:
-		return toBigFloat(NewBigIntegerFromInt64(p.Value)).Compare(v.Real()) < 0
 	}
-	panic(ErrNotANumber)
+	return integerLessThan[o.Kind()](p, o)
 }
 
 func (p *Integer) Abs() Number {
@@ -389,41 +488,16 @@ func (p *Integer) Sign() int {
 // R7RS §6.2.6: Numeric comparisons use mathematical value regardless of exactness.
 // Returns -1 if p < o, 0 if p == o, 1 if p > o.
 func (p *Integer) Compare(o Number) int {
-	switch v := o.(type) {
-	case *Integer:
+	v, ok := o.(*Integer)
+	if ok {
 		if p.Value < v.Value {
 			return -1
 		} else if p.Value > v.Value {
 			return 1
 		}
 		return 0
-	case *BigInteger:
-		return p.bigInt().Cmp(v.value)
-	case *Float:
-		pf := float64(p.Value)
-		if pf < v.Value {
-			return -1
-		} else if pf > v.Value {
-			return 1
-		}
-		return 0
-	case *BigFloat:
-		return p.bigFloat().Cmp(v.BigFloatValue())
-	case *Rational:
-		return p.bigRat().Cmp(v.Rat())
-	case *Complex:
-		pf := float64(p.Value)
-		r := real(v.Value)
-		if pf < r {
-			return -1
-		} else if pf > r {
-			return 1
-		}
-		return 0
-	case *BigComplex:
-		return p.bigFloat().Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
-	panic(ErrNotANumber)
+	return integerCompare[o.Kind()](p, o)
 }
 
 // IsExact returns true since Integer is always exact.

--- a/values/numeric_dispatch_test.go
+++ b/values/numeric_dispatch_test.go
@@ -1,0 +1,73 @@
+package values
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestAllDispatchEntriesPopulated verifies that every dispatch table
+// has all numKinds entries populated (no nil function pointers).
+// This catches the case where a new numeric type is added without
+// updating all dispatch tables.
+func TestAllDispatchEntriesPopulated(t *testing.T) {
+	tables := []struct {
+		name  string
+		table any // [numKinds]func(...)
+	}{
+		{"integerAdd", integerAdd},
+		{"bigIntegerAdd", bigIntegerAdd},
+		{"floatAdd", floatAdd},
+		{"bigFloatAdd", bigFloatAdd},
+		{"rationalAdd", rationalAdd},
+		{"complexAdd", complexAdd},
+		{"bigComplexAdd", bigComplexAdd},
+		{"integerSubtract", integerSubtract},
+		{"bigIntegerSubtract", bigIntegerSubtract},
+		{"floatSubtract", floatSubtract},
+		{"bigFloatSubtract", bigFloatSubtract},
+		{"rationalSubtract", rationalSubtract},
+		{"complexSubtract", complexSubtract},
+		{"bigComplexSubtract", bigComplexSubtract},
+		{"integerLessThan", integerLessThan},
+		{"bigIntegerLessThan", bigIntegerLessThan},
+		{"floatLessThan", floatLessThan},
+		{"bigFloatLessThan", bigFloatLessThan},
+		{"rationalLessThan", rationalLessThan},
+		{"complexLessThan", complexLessThan},
+		{"integerCompare", integerCompare},
+		{"bigIntegerCompare", bigIntegerCompare},
+		{"floatCompare", floatCompare},
+		{"bigFloatCompare", bigFloatCompare},
+		{"rationalCompare", rationalCompare},
+		{"complexCompare", complexCompare},
+		{"bigComplexCompare", bigComplexCompare},
+		{"integerMultiply", integerMultiply},
+		{"bigIntegerMultiply", bigIntegerMultiply},
+		{"floatMultiply", floatMultiply},
+		{"bigFloatMultiply", bigFloatMultiply},
+		{"rationalMultiply", rationalMultiply},
+		{"complexMultiply", complexMultiply},
+		{"bigComplexMultiply", bigComplexMultiply},
+		{"integerDivide", integerDivide},
+		{"bigIntegerDivide", bigIntegerDivide},
+		{"floatDivide", floatDivide},
+		{"bigFloatDivide", bigFloatDivide},
+		{"rationalDivide", rationalDivide},
+		{"complexDivide", complexDivide},
+		{"bigComplexDivide", bigComplexDivide},
+	}
+
+	for _, tt := range tables {
+		t.Run(tt.name, func(t *testing.T) {
+			v := reflect.ValueOf(tt.table)
+			if v.Kind() != reflect.Array {
+				t.Fatalf("expected array, got %s", v.Kind())
+			}
+			for i := 0; i < v.Len(); i++ {
+				if v.Index(i).IsNil() {
+					t.Errorf("%s[%d] is nil", tt.name, i)
+				}
+			}
+		})
+	}
+}

--- a/values/numeric_kind.go
+++ b/values/numeric_kind.go
@@ -1,0 +1,18 @@
+package values
+
+// NumericKind identifies a concrete numeric type for dispatch table indexing.
+//
+// Used by the receiver-centric dispatch tables in each numeric type file
+// to replace 7-way type switches with O(1) array lookups.
+type NumericKind uint8
+
+const (
+	KindInteger NumericKind = iota
+	KindBigInteger
+	KindFloat
+	KindBigFloat
+	KindRational
+	KindComplex
+	KindBigComplex
+	numKinds // unexported sentinel for array sizing
+)

--- a/values/rational.go
+++ b/values/rational.go
@@ -107,76 +107,222 @@ func (p *Rational) IsInteger() bool {
 
 // Add returns the sum of two numbers.
 //
-// R7RS §6.2.6: The + procedure returns the sum of its arguments.
-// R7RS §6.2.2 Exactness: exact + exact = exact, exact + inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
-func (p *Rational) Add(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For addition, 0 + x = x,
-	// so the result's exactness MUST match the other operand.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Rational:
-		result := new(big.Rat).Add(p.value, v.value)
-		return &Rational{value: result}
-	case *Integer:
-		other := v.bigRat()
+// Kind returns the numeric kind for dispatch table indexing.
+func (p *Rational) Kind() NumericKind {
+	return KindRational
+}
+
+var rationalAdd [numKinds]func(*Rational, Number) Number
+var rationalSubtract [numKinds]func(*Rational, Number) Number
+var rationalLessThan [numKinds]func(*Rational, Number) bool
+var rationalCompare [numKinds]func(*Rational, Number) int
+var rationalMultiply [numKinds]func(*Rational, Number) Number
+var rationalDivide [numKinds]func(*Rational, Number) Number
+
+func init() {
+	rationalAdd[KindInteger] = func(p *Rational, o Number) Number {
+		other := o.(*Integer).bigRat()
 		result := new(big.Rat).Add(p.value, other)
 		return &Rational{value: result}
-	case *BigInteger:
-		other := v.bigRat()
+	}
+	rationalAdd[KindBigInteger] = func(p *Rational, o Number) Number {
+		other := o.(*BigInteger).bigRat()
 		result := new(big.Rat).Add(p.value, other)
 		return &Rational{value: result}
-	case *Float:
-		return NewFloat(p.Float64() + v.Value)
-	case *BigFloat:
+	}
+	rationalAdd[KindFloat] = func(p *Rational, o Number) Number {
+		return NewFloat(p.Float64() + o.(*Float).Value)
+	}
+	rationalAdd[KindBigFloat] = func(p *Rational, o Number) Number {
 		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Add(self, v.value)}
-	case *Complex:
-		return NewComplex(p.toComplex() + v.Value)
-	case *BigComplex:
+		return &BigFloat{value: new(big.Float).Add(self, o.(*BigFloat).value)}
+	}
+	rationalAdd[KindRational] = func(p *Rational, o Number) Number {
+		result := new(big.Rat).Add(p.value, o.(*Rational).value)
+		return &Rational{value: result}
+	}
+	rationalAdd[KindComplex] = func(p *Rational, o Number) Number {
+		return NewComplex(p.toComplex() + o.(*Complex).Value)
+	}
+	rationalAdd[KindBigComplex] = func(p *Rational, o Number) Number {
 		bf := p.bigFloat()
 		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
-		return bc.Add(v)
+		return bc.Add(o)
 	}
-	panic(ErrNotANumber)
+
+	rationalSubtract[KindInteger] = func(p *Rational, o Number) Number {
+		other := o.(*Integer).bigRat()
+		result := new(big.Rat).Sub(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalSubtract[KindBigInteger] = func(p *Rational, o Number) Number {
+		other := o.(*BigInteger).bigRat()
+		result := new(big.Rat).Sub(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalSubtract[KindFloat] = func(p *Rational, o Number) Number {
+		return NewFloat(p.Float64() - o.(*Float).Value)
+	}
+	rationalSubtract[KindBigFloat] = func(p *Rational, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Sub(self, o.(*BigFloat).value)}
+	}
+	rationalSubtract[KindRational] = func(p *Rational, o Number) Number {
+		result := new(big.Rat).Sub(p.value, o.(*Rational).value)
+		return &Rational{value: result}
+	}
+	rationalSubtract[KindComplex] = func(p *Rational, o Number) Number {
+		return NewComplex(p.toComplex() - o.(*Complex).Value)
+	}
+	rationalSubtract[KindBigComplex] = func(p *Rational, o Number) Number {
+		bf := p.bigFloat()
+		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
+		return bc.Subtract(o)
+	}
+
+	rationalLessThan[KindInteger] = func(p *Rational, o Number) bool {
+		return p.value.Cmp(o.(*Integer).bigRat()) < 0
+	}
+	rationalLessThan[KindBigInteger] = func(p *Rational, o Number) bool {
+		return p.value.Cmp(o.(*BigInteger).bigRat()) < 0
+	}
+	rationalLessThan[KindFloat] = func(p *Rational, o Number) bool {
+		return p.Float64() < o.(*Float).Value
+	}
+	rationalLessThan[KindBigFloat] = func(p *Rational, o Number) bool {
+		self := new(big.Float).SetRat(p.value)
+		return self.Cmp(o.(*BigFloat).BigFloatValue()) < 0
+	}
+	rationalLessThan[KindRational] = func(p *Rational, o Number) bool {
+		return p.value.Cmp(o.(*Rational).value) < 0
+	}
+	rationalLessThan[KindComplex] = func(p *Rational, o Number) bool {
+		return p.Float64() < real(o.(*Complex).Value)
+	}
+	rationalLessThan[KindBigComplex] = func(p *Rational, o Number) bool {
+		return p.bigFloat().Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue()) < 0
+	}
+
+	rationalCompare[KindInteger] = func(p *Rational, o Number) int {
+		return p.value.Cmp(o.(*Integer).bigRat())
+	}
+	rationalCompare[KindBigInteger] = func(p *Rational, o Number) int {
+		return p.value.Cmp(o.(*BigInteger).bigRat())
+	}
+	rationalCompare[KindFloat] = func(p *Rational, o Number) int {
+		pf := p.Float64()
+		v := o.(*Float)
+		if pf < v.Value {
+			return -1
+		} else if pf > v.Value {
+			return 1
+		}
+		return 0
+	}
+	rationalCompare[KindBigFloat] = func(p *Rational, o Number) int {
+		self := new(big.Float).SetRat(p.value)
+		return self.Cmp(o.(*BigFloat).BigFloatValue())
+	}
+	rationalCompare[KindRational] = func(p *Rational, o Number) int {
+		return p.value.Cmp(o.(*Rational).value)
+	}
+	rationalCompare[KindComplex] = func(p *Rational, o Number) int {
+		pf := p.Float64()
+		r := real(o.(*Complex).Value)
+		if pf < r {
+			return -1
+		} else if pf > r {
+			return 1
+		}
+		return 0
+	}
+	rationalCompare[KindBigComplex] = func(p *Rational, o Number) int {
+		self := p.bigFloat()
+		return self.Cmp(toBigFloat(o.(*BigComplex).Real()).BigFloatValue())
+	}
+
+	rationalMultiply[KindInteger] = func(p *Rational, o Number) Number {
+		other := o.(*Integer).bigRat()
+		result := new(big.Rat).Mul(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalMultiply[KindBigInteger] = func(p *Rational, o Number) Number {
+		other := o.(*BigInteger).bigRat()
+		result := new(big.Rat).Mul(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalMultiply[KindFloat] = func(p *Rational, o Number) Number {
+		return NewFloat(p.Float64() * o.(*Float).Value)
+	}
+	rationalMultiply[KindBigFloat] = func(p *Rational, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Mul(self, o.(*BigFloat).value)}
+	}
+	rationalMultiply[KindRational] = func(p *Rational, o Number) Number {
+		result := new(big.Rat).Mul(p.value, o.(*Rational).value)
+		return &Rational{value: result}
+	}
+	rationalMultiply[KindComplex] = func(p *Rational, o Number) Number {
+		return NewComplex(p.toComplex() * o.(*Complex).Value)
+	}
+	rationalMultiply[KindBigComplex] = func(p *Rational, o Number) Number {
+		bf := p.bigFloat()
+		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
+		return bc.Multiply(o)
+	}
+
+	rationalDivide[KindInteger] = func(p *Rational, o Number) Number {
+		other := o.(*Integer).bigRat()
+		result := new(big.Rat).Quo(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalDivide[KindBigInteger] = func(p *Rational, o Number) Number {
+		other := o.(*BigInteger).bigRat()
+		result := new(big.Rat).Quo(p.value, other)
+		return &Rational{value: result}
+	}
+	rationalDivide[KindFloat] = func(p *Rational, o Number) Number {
+		return NewFloat(p.Float64() / o.(*Float).Value)
+	}
+	rationalDivide[KindBigFloat] = func(p *Rational, o Number) Number {
+		self := p.bigFloat()
+		return &BigFloat{value: new(big.Float).Quo(self, o.(*BigFloat).value)}
+	}
+	rationalDivide[KindRational] = func(p *Rational, o Number) Number {
+		result := new(big.Rat).Quo(p.value, o.(*Rational).value)
+		return &Rational{value: result}
+	}
+	rationalDivide[KindComplex] = func(p *Rational, o Number) Number {
+		return NewComplex(p.toComplex() / o.(*Complex).Value)
+	}
+	rationalDivide[KindBigComplex] = func(p *Rational, o Number) Number {
+		bf := p.bigFloat()
+		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
+		return bc.Divide(o)
+	}
+}
+
+// R7RS §6.2.6: The + procedure returns the sum of its arguments.
+// R7RS §6.2.2 Exactness: exact + exact = exact, exact + inexact = inexact.
+// Inexactness is contagious per R7RS §6.2.2.
+func (p *Rational) Add(o Number) Number {
+	v, ok := o.(*Rational)
+	if ok {
+		return &Rational{value: new(big.Rat).Add(p.value, v.value)}
+	}
+	return rationalAdd[o.Kind()](p, o)
 }
 
 // Subtract returns the difference of two numbers.
 //
 // R7RS §6.2.6: The - procedure returns the difference of its arguments.
 // R7RS §6.2.2 Exactness: exact - exact = exact, exact - inexact = inexact.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Rational) Subtract(o Number) Number {
-	// R7RS §6.2.2: Inexactness is contagious. For subtraction, x - 0 = x,
-	// so the result's exactness MUST match the minuend.
-	// No zero short-circuit allowed (unlike multiplication).
-	switch v := o.(type) {
-	case *Rational:
-		result := new(big.Rat).Sub(p.value, v.value)
-		return &Rational{value: result}
-	case *Integer:
-		other := v.bigRat()
-		result := new(big.Rat).Sub(p.value, other)
-		return &Rational{value: result}
-	case *BigInteger:
-		other := v.bigRat()
-		result := new(big.Rat).Sub(p.value, other)
-		return &Rational{value: result}
-	case *Float:
-		return NewFloat(p.Float64() - v.Value)
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Sub(self, v.value)}
-	case *Complex:
-		return NewComplex(p.toComplex() - v.Value)
-	case *BigComplex:
-		bf := p.bigFloat()
-		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
-		return bc.Subtract(v)
+	v, ok := o.(*Rational)
+	if ok {
+		return &Rational{value: new(big.Rat).Sub(p.value, v.value)}
 	}
-	panic(ErrNotANumber)
+	return rationalSubtract[o.Kind()](p, o)
 }
 
 // Multiply returns the product of two numbers.
@@ -189,65 +335,25 @@ func (p *Rational) Multiply(o Number) Number {
 	if p.IsZero() && o.IsFinite() {
 		return multiplyResultForZero(p, o)
 	}
-	switch v := o.(type) {
-	case *Rational:
+	v, ok := o.(*Rational)
+	if ok {
 		result := new(big.Rat).Mul(p.value, v.value)
 		return &Rational{value: result}
-	case *Integer:
-		other := v.bigRat()
-		result := new(big.Rat).Mul(p.value, other)
-		return &Rational{value: result}
-	case *BigInteger:
-		other := v.bigRat()
-		result := new(big.Rat).Mul(p.value, other)
-		return &Rational{value: result}
-	case *Float:
-		return NewFloat(p.Float64() * v.Value)
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Mul(self, v.value)}
-	case *Complex:
-		return NewComplex(p.toComplex() * v.Value)
-	case *BigComplex:
-		bf := p.bigFloat()
-		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
-		return bc.Multiply(v)
 	}
-	panic(ErrNotANumber)
+	return rationalMultiply[o.Kind()](p, o)
 }
 
 // Divide returns the quotient of two numbers.
-//
-//nolint:dupl // Type dispatch pattern repeated across numeric tower
 func (p *Rational) Divide(o Number) Number {
 	if o.IsZero() {
 		panic(ErrDivisionByZero)
 	}
-	switch v := o.(type) {
-	case *Rational:
+	v, ok := o.(*Rational)
+	if ok {
 		result := new(big.Rat).Quo(p.value, v.value)
 		return &Rational{value: result}
-	case *Integer:
-		other := v.bigRat()
-		result := new(big.Rat).Quo(p.value, other)
-		return &Rational{value: result}
-	case *BigInteger:
-		other := v.bigRat()
-		result := new(big.Rat).Quo(p.value, other)
-		return &Rational{value: result}
-	case *Float:
-		return NewFloat(p.Float64() / v.Value)
-	case *BigFloat:
-		self := p.bigFloat()
-		return &BigFloat{value: new(big.Float).Quo(self, v.value)}
-	case *Complex:
-		return NewComplex(p.toComplex() / v.Value)
-	case *BigComplex:
-		bf := p.bigFloat()
-		bc := NewBigComplex(&BigFloat{value: bf}, NewBigFloatFromFloat64(0))
-		return bc.Divide(v)
 	}
-	panic(ErrNotANumber)
+	return rationalDivide[o.Kind()](p, o)
 }
 
 // IsZero returns true if the rational equals zero.
@@ -257,27 +363,11 @@ func (p *Rational) IsZero() bool {
 
 // LessThan returns true if this rational is less than another number.
 func (p *Rational) LessThan(o Number) bool {
-	switch v := o.(type) {
-	case *Rational:
+	v, ok := o.(*Rational)
+	if ok {
 		return p.value.Cmp(v.value) < 0
-	case *Integer:
-		other := v.bigRat()
-		return p.value.Cmp(other) < 0
-	case *BigInteger:
-		other := v.bigRat()
-		return p.value.Cmp(other) < 0
-	case *Float:
-		return p.Float64() < v.Value
-	case *BigFloat:
-		self := new(big.Float).SetRat(p.value)
-		return self.Cmp(v.BigFloatValue()) < 0
-	case *Complex:
-		return p.Float64() < real(v.Value)
-	case *BigComplex:
-		self := p.bigFloat()
-		return self.Cmp(toBigFloat(v.Real()).BigFloatValue()) < 0
 	}
-	panic(ErrNotANumber)
+	return rationalLessThan[o.Kind()](p, o)
 }
 
 // Negate returns the negation of this rational.
@@ -328,40 +418,11 @@ func (p *Rational) Sign() int {
 // R7RS §6.2.6: Numeric comparisons use mathematical value regardless of exactness.
 // Returns -1 if p < o, 0 if p == o, 1 if p > o.
 func (p *Rational) Compare(o Number) int {
-	switch v := o.(type) {
-	case *Rational:
+	v, ok := o.(*Rational)
+	if ok {
 		return p.value.Cmp(v.value)
-	case *Integer:
-		other := v.bigRat()
-		return p.value.Cmp(other)
-	case *BigInteger:
-		other := v.bigRat()
-		return p.value.Cmp(other)
-	case *Float:
-		pf := p.Float64()
-		if pf < v.Value {
-			return -1
-		} else if pf > v.Value {
-			return 1
-		}
-		return 0
-	case *BigFloat:
-		self := new(big.Float).SetRat(p.value)
-		return self.Cmp(v.BigFloatValue())
-	case *Complex:
-		pf := p.Float64()
-		r := real(v.Value)
-		if pf < r {
-			return -1
-		} else if pf > r {
-			return 1
-		}
-		return 0
-	case *BigComplex:
-		self := p.bigFloat()
-		return self.Cmp(toBigFloat(v.Real()).BigFloatValue())
 	}
-	panic(ErrNotANumber)
+	return rationalCompare[o.Kind()](p, o)
 }
 
 // IsExact returns true since Rational is always exact.

--- a/values/values.go
+++ b/values/values.go
@@ -298,6 +298,7 @@ type ByteVectorExtractor interface {
 // with-exception-handler.
 type Number interface {
 	Value
+	Kind() NumericKind
 	Add(Number) Number
 	Subtract(Number) Number
 	Multiply(Number) Number


### PR DESCRIPTION
## Summary

- Replace 7-way type switches in Add, Subtract, LessThan, Compare, Multiply, and Divide across all 7 numeric types with 1D dispatch tables indexed by `o.Kind()`
- Each method gets a same-type type assertion hot path before the table fallback, recovering inlining for the common case (Integer+Integer: 1.9ns → 1.6ns)
- 42 dispatch tables total (7 types × 6 operations), completeness test validates no nil entries
- All `//nolint:dupl` annotations removed

## Test plan

- [x] `go test ./values/...` — all pass
- [x] `go test ./...` — full suite passes
- [x] `make lint` — 0 issues
- [x] Gabriel benchmarks — most within noise, same-type hot path faster than original type switch
- [x] Dispatch table completeness test covers all 42 tables