### PR TITLE
refactor: consolidate repeated patterns into shared helpers

### DIFF
--- a/internal/extensions/all/prim_all.go
+++ b/internal/extensions/all/prim_all.go
@@ -51,20 +51,16 @@ func PrimMakeRecordType(mc *machine.MachineContext) error {
 }
 
 // PrimIsRecordType implements the (record-type? obj) primitive.
-func PrimIsRecordType(mc *machine.MachineContext) error {
-	obj := mc.Arg(0)
-	_, ok := obj.(*values.RecordType)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+var PrimIsRecordType = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(*values.RecordType)
+	return ok
+})
 
 // PrimIsRecord implements the (record? obj) primitive.
-func PrimIsRecord(mc *machine.MachineContext) error {
-	obj := mc.Arg(0)
-	_, ok := obj.(*values.Record)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+var PrimIsRecord = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(*values.Record)
+	return ok
+})
 
 // PrimRecordType implements the (record-type record) primitive.
 // Returns the record type of a record instance.
@@ -262,12 +258,10 @@ func newRecordModifierClosure(env *environment.EnvironmentFrame, rt *values.Reco
 // =============================================================================
 
 // PrimPromiseQ tests if an object is a promise.
-func PrimPromiseQ(mc *machine.MachineContext) error {
-	o := mc.Arg(0)
+var PrimPromiseQ = helpers.MakeTypePredicate(func(o values.Value) bool {
 	_, ok := o.(*values.Promise)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+	return ok
+})
 
 // PrimMakePromise implements the (make-promise) primitive.
 // Creates a promise from a value, wrapping it if not already a promise.

--- a/internal/extensions/all/prim_characters.go
+++ b/internal/extensions/all/prim_characters.go
@@ -60,87 +60,17 @@ func PrimCharCiGeVariadic(mc *machine.MachineContext) error {
 	})
 }
 
-// PrimCharAlphabeticQ tests if a character is alphabetic.
-func PrimCharAlphabeticQ(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-alphabetic?")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.BoolToBoolean(unicode.IsLetter(ch.Value)))
-	return nil
-}
+// Character classification predicates — all use MakeCharPredicate factory.
+var PrimCharAlphabeticQ = helpers.MakeCharPredicate("char-alphabetic?", unicode.IsLetter)
+var PrimCharNumericQ = helpers.MakeCharPredicate("char-numeric?", unicode.IsDigit)
+var PrimCharWhitespaceQ = helpers.MakeCharPredicate("char-whitespace?", unicode.IsSpace)
+var PrimCharUpperCaseQ = helpers.MakeCharPredicate("char-upper-case?", unicode.IsUpper)
+var PrimCharLowerCaseQ = helpers.MakeCharPredicate("char-lower-case?", unicode.IsLower)
 
-// PrimCharNumericQ tests if a character is numeric.
-func PrimCharNumericQ(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-numeric?")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.BoolToBoolean(unicode.IsDigit(ch.Value)))
-	return nil
-}
-
-// PrimCharWhitespaceQ tests if a character is whitespace.
-func PrimCharWhitespaceQ(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-whitespace?")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.BoolToBoolean(unicode.IsSpace(ch.Value)))
-	return nil
-}
-
-// PrimCharUpperCaseQ tests if a character is uppercase.
-func PrimCharUpperCaseQ(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-upper-case?")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.BoolToBoolean(unicode.IsUpper(ch.Value)))
-	return nil
-}
-
-// PrimCharLowerCaseQ tests if a character is lowercase.
-func PrimCharLowerCaseQ(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-lower-case?")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.BoolToBoolean(unicode.IsLower(ch.Value)))
-	return nil
-}
-
-// PrimCharUpcase returns the uppercase version of a character.
-func PrimCharUpcase(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-upcase")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewCharacter(unicode.ToUpper(ch.Value)))
-	return nil
-}
-
-// PrimCharDowncase returns the lowercase version of a character.
-func PrimCharDowncase(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-downcase")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewCharacter(unicode.ToLower(ch.Value)))
-	return nil
-}
-
-// PrimCharFoldcase returns the case-folded version of a character.
-// R7RS §6.6: Returns the simple Unicode case-folded version of the character.
-// Simple case folding maps each character to exactly one character.
-func PrimCharFoldcase(mc *machine.MachineContext) error {
-	ch, err := helpers.RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, "char-foldcase")
-	if err != nil {
-		return err
-	}
-	mc.SetValue(values.NewCharacter(simpleCaseFold(ch.Value)))
-	return nil
-}
+// Character case transformation — all use MakeCharTransform factory.
+var PrimCharUpcase = helpers.MakeCharTransform("char-upcase", unicode.ToUpper)
+var PrimCharDowncase = helpers.MakeCharTransform("char-downcase", unicode.ToLower)
+var PrimCharFoldcase = helpers.MakeCharTransform("char-foldcase", simpleCaseFold)
 
 // simpleCaseFold performs Unicode simple case folding on a rune.
 // Simple case folding maps each character to exactly one character.

--- a/internal/extensions/all/prim_strings.go
+++ b/internal/extensions/all/prim_strings.go
@@ -165,49 +165,24 @@ func PrimStringMap(mc *machine.MachineContext) error {
 		return values.WrapForeignErrorf(values.ErrWrongNumberOfArguments, "string-map: expected at least one string")
 	}
 
-	// Collect all strings into a slice
-	var strs []*values.String
-	current := stringsVal
-	for !values.IsEmptyList(current) {
-		tuple, ok := current.(values.Tuple)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAList, "string-map: improper argument list")
-		}
-		s, err := helpers.RequireType[*values.String](tuple.Car(), values.ErrNotAString, "string-map")
-		if err != nil {
-			return err
-		}
-		strs = append(strs, s)
-		current = tuple.Cdr()
+	strs, runeSlices, minLen, err := helpers.CollectStrings(stringsVal, "string-map")
+	if err != nil {
+		return err
 	}
-
 	if len(strs) == 0 {
 		return values.WrapForeignErrorf(values.ErrWrongNumberOfArguments, "string-map: expected at least one string")
 	}
 
-	// Convert all strings to rune slices and find minimum length
-	runeSlices := make([][]rune, len(strs))
-	minLen := -1
-	for i, s := range strs {
-		runeSlices[i] = s.Runes()
-		if minLen < 0 || len(runeSlices[i]) < minLen {
-			minLen = len(runeSlices[i])
-		}
-	}
-
-	// Apply proc to each position
 	result := make([]rune, minLen)
 	sub := mc.NewSubContext()
 	defer machine.ReleaseSubContext(sub)
 
-	for i := 0; i < minLen; i++ {
-		// Collect one character from each string
+	for i := range minLen {
 		args := make(values.Vector, len(strs))
 		for j := range strs {
 			args[j] = values.NewCharacter(runeSlices[j][i])
 		}
 
-		// Apply proc to collected arguments
 		_, err := sub.Apply(mcls, args...)
 		if err != nil {
 			return err
@@ -217,7 +192,6 @@ func PrimStringMap(mc *machine.MachineContext) error {
 			return err
 		}
 
-		// Get the result character
 		resultVal := sub.GetValue()
 		char, ok := resultVal.(*values.Character)
 		if !ok {
@@ -226,7 +200,6 @@ func PrimStringMap(mc *machine.MachineContext) error {
 		result[i] = char.Value
 	}
 
-	// R7RS §6.7: string-map returns a newly allocated mutable string
 	mc.SetValue(values.NewMutableString(string(result)))
 	return nil
 }
@@ -246,48 +219,23 @@ func PrimStringForEach(mc *machine.MachineContext) error {
 		return values.WrapForeignErrorf(values.ErrWrongNumberOfArguments, "string-for-each: expected at least one string")
 	}
 
-	// Collect all strings into a slice
-	var strs []*values.String
-	current := stringsVal
-	for !values.IsEmptyList(current) {
-		tuple, ok := current.(values.Tuple)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAList, "string-for-each: improper argument list")
-		}
-		s, err := helpers.RequireType[*values.String](tuple.Car(), values.ErrNotAString, "string-for-each")
-		if err != nil {
-			return err
-		}
-		strs = append(strs, s)
-		current = tuple.Cdr()
+	strs, runeSlices, minLen, err := helpers.CollectStrings(stringsVal, "string-for-each")
+	if err != nil {
+		return err
 	}
-
 	if len(strs) == 0 {
 		return values.WrapForeignErrorf(values.ErrWrongNumberOfArguments, "string-for-each: expected at least one string")
 	}
 
-	// Convert all strings to rune slices and find minimum length
-	runeSlices := make([][]rune, len(strs))
-	minLen := -1
-	for i, s := range strs {
-		runeSlices[i] = s.Runes()
-		if minLen < 0 || len(runeSlices[i]) < minLen {
-			minLen = len(runeSlices[i])
-		}
-	}
-
-	// Apply proc to each position
 	sub := mc.NewSubContext()
 	defer machine.ReleaseSubContext(sub)
 
-	for i := 0; i < minLen; i++ {
-		// Collect one character from each string
+	for i := range minLen {
 		args := make(values.Vector, len(strs))
 		for j := range strs {
 			args[j] = values.NewCharacter(runeSlices[j][i])
 		}
 
-		// Apply proc to collected arguments
 		_, err := sub.Apply(mcls, args...)
 		if err != nil {
 			return err

--- a/internal/extensions/io/prim_ports.go
+++ b/internal/extensions/io/prim_ports.go
@@ -22,35 +22,19 @@ import (
 	"github.com/aalpar/wile/values"
 )
 
-// PrimPortQ implements the port? primitive.
-// Returns #t if the argument is a port (input or output), #f otherwise.
-//
-// R7RS §6.13.1: Returns #t if obj is a port, otherwise returns #f.
-func PrimPortQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(values.Port)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
-
-// PrimInputPortQ implements the (input-port?) primitive.
-// Returns #t if argument is input port.
-//
-// R7RS §6.13.1: Returns #t if obj is an input port, otherwise returns #f.
-func PrimInputPortQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(values.InputPort)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
-
-// PrimOutputPortQ implements the output-port? primitive.
-// Returns #t if the argument is an output port, #f otherwise.
-//
-// R7RS §6.13.1: Returns #t if obj is an output port, otherwise returns #f.
-func PrimOutputPortQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(values.OutputPort)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+// Port type predicates — R7RS §6.13.1.
+var PrimPortQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(values.Port)
+	return ok
+})
+var PrimInputPortQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(values.InputPort)
+	return ok
+})
+var PrimOutputPortQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(values.OutputPort)
+	return ok
+})
 
 // PrimInputPortOpenQ implements the (input-port-open?) primitive.
 // Returns #t if input port is open.

--- a/internal/tokenizer/tokenizer.go
+++ b/internal/tokenizer/tokenizer.go
@@ -1114,9 +1114,7 @@ func (p *Tokenizer) readBigNum(isExpMarker func(rune) bool) {
 		return
 	}
 	// Integer part
-	for p.err == nil && isDigit(10, p.curr()) {
-		p.next()
-	}
+	p.readUnsignedBaseNNumber(10)
 	// Optional decimal point
 	if p.err == nil && p.curr() == '.' {
 		p.next()
@@ -1125,9 +1123,7 @@ func (p *Tokenizer) readBigNum(isExpMarker func(rune) bool) {
 		return
 	}
 	// Fractional part
-	for p.err == nil && isDigit(10, p.curr()) {
-		p.next()
-	}
+	p.readUnsignedBaseNNumber(10)
 	if p.err != nil {
 		return
 	}

--- a/internal/validate/register.go
+++ b/internal/validate/register.go
@@ -81,6 +81,6 @@ func registerValidator(name string, fn validatorFunc) {
 func registerPassthrough(name string) {
 	forms.RegisterValidator(name, func(_ context.Context, _ any, pair any, _ any) any {
 		p := pair.(*syntax.SyntaxPair)
-		return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: p.SourceContext()}, Value: p}
+		return newLiteralExpr(p.SourceContext(), p)
 	})
 }

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -34,13 +34,35 @@ func ValidateExpression(ctx context.Context, env *environment.EnvironmentFrame, 
 	return result
 }
 
+// validateBodySlice validates a contiguous slice of elements as body expressions.
+// Returns (body, true) if all elements validated, (nil, false) if any failed.
+func validateBodySlice(
+	ctx context.Context,
+	env *environment.EnvironmentFrame,
+	elements []syntax.SyntaxValue,
+	start int,
+	result *ValidationResult,
+) ([]ValidatedExpr, bool) {
+	var body []ValidatedExpr
+	for i := start; i < len(elements); i++ {
+		expr := validateExpr(ctx, env, elements[i], result)
+		if expr != nil {
+			body = append(body, expr)
+		}
+	}
+	if len(body) != len(elements)-start {
+		return nil, false
+	}
+	return body, true
+}
+
 func validateExpr(ctx context.Context, env *environment.EnvironmentFrame, expr syntax.SyntaxValue, result *ValidationResult) ValidatedExpr {
 	switch e := expr.(type) {
 	case *syntax.SyntaxPair:
 		// Empty list '() is a self-evaluating literal, not a form.
 		// R7RS §4.1.2: The empty list is a literal expression.
 		if e.IsEmptyList() {
-			return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: e.SourceContext()}, Value: e}
+			return newLiteralExpr(e.SourceContext(), e)
 		}
 		return validateForm(ctx, env, e, result)
 	case *syntax.SyntaxSymbol:
@@ -49,7 +71,7 @@ func validateExpr(ctx context.Context, env *environment.EnvironmentFrame, expr s
 		return validateSyntaxObject(e, result)
 	default:
 		// Self-evaluating: numbers, strings, booleans, etc.
-		return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal"}, Value: expr}
+		return newLiteralExpr(nil, expr)
 	}
 }
 
@@ -63,7 +85,7 @@ func validateSyntaxObject(obj *syntax.SyntaxObject, result *ValidationResult) Va
 		return nil
 	default:
 		// Self-evaluating literal wrapped in syntax
-		return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: obj.SourceContext()}, Value: obj}
+		return newLiteralExpr(obj.SourceContext(), obj)
 	}
 }
 

--- a/internal/validate/validate_case_lambda.go
+++ b/internal/validate/validate_case_lambda.go
@@ -74,23 +74,13 @@ func validateCaseLambdaClause(ctx context.Context, env *environment.EnvironmentF
 	// Validate parameters
 	params := validateParams(elements[0], result)
 
-	// Validate body - must have at least one expression
-	var body []ValidatedExpr
-	for i := 1; i < len(elements); i++ {
-		bodyExpr := validateExpr(ctx, env, elements[i], result)
-		if bodyExpr != nil {
-			body = append(body, bodyExpr)
-		}
-	}
-
-	// If body validation failed, return nil
-	if len(body) != len(elements)-1 {
+	body, ok := validateBodySlice(ctx, env, elements, 1, result)
+	if !ok {
 		return nil
 	}
 
 	return &ValidatedCaseLambdaClause{
-		validatedBase: validatedBase{formName: "@clause", source: source},
-		params:        params,
-		body:          body,
+		validatedBase:     validatedBase{formName: "@clause", source: source},
+		validatedProcBase: validatedProcBase{params: params, body: body},
 	}
 }

--- a/internal/validate/validate_define.go
+++ b/internal/validate/validate_define.go
@@ -88,25 +88,16 @@ func validateDefineFunction(ctx context.Context, env *environment.EnvironmentFra
 		return nil
 	}
 
-	var body []ValidatedExpr
-	for i := 2; i < len(elements); i++ {
-		expr := validateExpr(ctx, env, elements[i], result)
-		if expr != nil {
-			body = append(body, expr)
-		}
-	}
-
-	// If body validation failed, return nil
-	if len(body) != len(elements)-2 {
+	body, ok := validateBodySlice(ctx, env, elements, 2, result)
+	if !ok {
 		return nil
 	}
 
 	return &ValidatedDefine{
-		validatedBase: validatedBase{formName: "define", source: source},
-		name:          name,
-		IsFunction:    true,
-		params:        params,
-		body:          body,
+		validatedBase:     validatedBase{formName: "define", source: source},
+		validatedProcBase: validatedProcBase{params: params, body: body},
+		name:              name,
+		IsFunction:        true,
 	}
 }
 

--- a/internal/validate/validate_lambda.go
+++ b/internal/validate/validate_lambda.go
@@ -36,24 +36,14 @@ func validateLambda(ctx context.Context, env *environment.EnvironmentFrame, pair
 	// outer bindings including special forms (R7RS §4.2.2).
 	childEnv := createLambdaValidationEnv(env, params)
 
-	// Validate body - must have at least one expression
-	var body []ValidatedExpr
-	for i := 2; i < len(elements); i++ {
-		expr := validateExpr(ctx, childEnv, elements[i], result)
-		if expr != nil {
-			body = append(body, expr)
-		}
-	}
-
-	// If any validation failed, return nil
-	if len(body) != len(elements)-2 {
+	body, ok := validateBodySlice(ctx, childEnv, elements, 2, result)
+	if !ok {
 		return nil
 	}
 
 	return &ValidatedLambda{
-		validatedBase: validatedBase{formName: "lambda", source: source},
-		params:        params,
-		body:          body,
+		validatedBase:     validatedBase{formName: "lambda", source: source},
+		validatedProcBase: validatedProcBase{params: params, body: body},
 	}
 }
 

--- a/internal/validate/validate_macro.go
+++ b/internal/validate/validate_macro.go
@@ -43,7 +43,7 @@ func validateDefineSyntax(_ context.Context, env *environment.EnvironmentFrame, 
 	// The compiler/expander handles transformer validation
 
 	// Return as literal - compiler handles the rest
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateSyntaxRules validates (syntax-rules (literals...) clause...)
@@ -99,7 +99,7 @@ func validateSyntaxRules(ctx context.Context, env *environment.EnvironmentFrame,
 	}
 
 	// Return as literal - compiler handles the rest
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateImport validates (import import-set...)
@@ -121,7 +121,7 @@ func validateImport(_ context.Context, env *environment.EnvironmentFrame, pair *
 		}
 	}
 
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateExport validates (export export-spec...)
@@ -150,7 +150,7 @@ func validateExport(_ context.Context, env *environment.EnvironmentFrame, pair *
 		result.addErrorf(getSourceContext(spec), "export", "export-spec %d must be a symbol or rename form", i)
 	}
 
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateDefineLibrary validates (define-library (name...) declaration...)
@@ -193,7 +193,7 @@ func validateDefineLibrary(ctx context.Context, env *environment.EnvironmentFram
 		return nil
 	}
 
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateInclude validates (include filename...)
@@ -216,7 +216,7 @@ func validateInclude(_ context.Context, env *environment.EnvironmentFrame, pair 
 		result.addErrorf(getSourceContext(elements[i]), "include", "include argument %d must be a string", i)
 	}
 
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }
 
 // validateCondExpand validates (cond-expand clause...)
@@ -240,5 +240,5 @@ func validateCondExpand(_ context.Context, env *environment.EnvironmentFrame, pa
 		}
 	}
 
-	return &ValidatedLiteral{validatedBase: validatedBase{formName: "@literal", source: source}, Value: pair}
+	return newLiteralExpr(source, pair)
 }

--- a/internal/validate/validated_forms.go
+++ b/internal/validate/validated_forms.go
@@ -37,6 +37,23 @@ type ValidatedBodyAndParams interface {
 	Body() []ValidatedExpr
 }
 
+// validatedProcBase provides the shared params/body fields and accessors
+// for procedure-like validated forms (lambda, define-function, case-lambda clause).
+type validatedProcBase struct {
+	params *ValidatedParams
+	body   []ValidatedExpr
+}
+
+// Params returns the parameter list.
+func (p *validatedProcBase) Params() *ValidatedParams {
+	return p.params
+}
+
+// Body returns the body expressions.
+func (p *validatedProcBase) Body() []ValidatedExpr {
+	return p.body
+}
+
 // validatedBase provides the common FormName/SetFormName/Source implementation
 // embedded by all ValidatedExpr types. This eliminates ~36 identical method
 // definitions across the 13 validated form structs.
@@ -72,26 +89,15 @@ type ValidatedIf struct {
 // (define name expr) and (define (name params...) body...)
 type ValidatedDefine struct {
 	validatedBase
-	params     *ValidatedParams // For function form, nil for value form
-	body       []ValidatedExpr  // For function form, nil for value form
-	name       *syntax.SyntaxSymbol
-	subExp     ValidatedExpr // For (define name expr), nil for function form
-	IsFunction bool          // True for (define (name ...) ...)
+	validatedProcBase // params/body for function form, zero values for value form
+	name              *syntax.SyntaxSymbol
+	subExp            ValidatedExpr // For (define name expr), nil for function form
+	IsFunction        bool          // True for (define (name ...) ...)
 }
 
 // Name returns the name being defined.
 func (p *ValidatedDefine) Name() *syntax.SyntaxSymbol {
 	return p.name
-}
-
-// Params returns the parameter list for function definitions.
-func (p *ValidatedDefine) Params() *ValidatedParams {
-	return p.params
-}
-
-// Body returns the body expressions for function definitions.
-func (p *ValidatedDefine) Body() []ValidatedExpr {
-	return p.body
 }
 
 // SubExp returns the value expression for simple definitions.
@@ -102,18 +108,7 @@ func (p *ValidatedDefine) SubExp() ValidatedExpr {
 // ValidatedLambda represents (lambda (params...) body...)
 type ValidatedLambda struct {
 	validatedBase
-	params *ValidatedParams
-	body   []ValidatedExpr // At least one expression required
-}
-
-// Params returns the parameter list for this lambda.
-func (p *ValidatedLambda) Params() *ValidatedParams {
-	return p.params
-}
-
-// Body returns the body expressions for this lambda.
-func (p *ValidatedLambda) Body() []ValidatedExpr {
-	return p.body
+	validatedProcBase
 }
 
 // ValidatedParams represents a parameter list
@@ -183,6 +178,15 @@ type ValidatedLiteral struct {
 	Value syntax.SyntaxValue
 }
 
+// newLiteralExpr creates a ValidatedLiteral wrapping a syntax value as a
+// passthrough form. Used by structural validators and the passthrough registry.
+func newLiteralExpr(source *syntax.SourceContext, value syntax.SyntaxValue) *ValidatedLiteral {
+	return &ValidatedLiteral{
+		validatedBase: validatedBase{formName: "@literal", source: source},
+		Value:         value,
+	}
+}
+
 // ValidatedQuasiquote represents (quasiquote template)
 type ValidatedQuasiquote struct {
 	validatedBase
@@ -192,18 +196,7 @@ type ValidatedQuasiquote struct {
 // ValidatedCaseLambdaClause represents a single clause in case-lambda
 type ValidatedCaseLambdaClause struct {
 	validatedBase
-	params *ValidatedParams
-	body   []ValidatedExpr
-}
-
-// Params returns the parameter list for this clause.
-func (p *ValidatedCaseLambdaClause) Params() *ValidatedParams {
-	return p.params
-}
-
-// Body returns the body expressions for this clause.
-func (p *ValidatedCaseLambdaClause) Body() []ValidatedExpr {
-	return p.body
+	validatedProcBase
 }
 
 // ValidatedCaseLambda represents (case-lambda [clause] ...)

--- a/registry/core/prim_boxes.go
+++ b/registry/core/prim_boxes.go
@@ -29,11 +29,10 @@ func PrimBox(mc *machine.MachineContext) error {
 
 // PrimBoxQ implements the box? predicate.
 // Returns #t if the argument is a box, #f otherwise.
-func PrimBoxQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(*values.Box)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+var PrimBoxQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(*values.Box)
+	return ok
+})
 
 // PrimUnbox implements the unbox primitive.
 // Returns the value contained in a box.

--- a/registry/core/prim_hashtables.go
+++ b/registry/core/prim_hashtables.go
@@ -29,11 +29,10 @@ func PrimMakeHashtable(mc *machine.MachineContext) error {
 
 // PrimHashtableQ implements the hashtable? predicate.
 // Returns #t if the argument is a hash table, #f otherwise.
-func PrimHashtableQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(*values.Hashtable)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+var PrimHashtableQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(*values.Hashtable)
+	return ok
+})
 
 // PrimHashtableRef implements the hashtable-ref primitive.
 // (hashtable-ref ht key) — errors if key is missing.

--- a/registry/core/prim_lists.go
+++ b/registry/core/prim_lists.go
@@ -320,41 +320,15 @@ func PrimListTail(mc *machine.MachineContext) error {
 // PrimMemq implements the memq primitive.
 // Finds an element in a list using eq? for comparison.
 func PrimMemq(mc *machine.MachineContext) error {
-	obj := mc.Arg(0)
-	lst := mc.Arg(1)
-	for !values.IsEmptyList(lst) {
-		pr, ok := lst.(values.Tuple)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAList, "memq: expected a list but got %T", lst)
-		}
-		if pr.Car() == obj {
-			mc.SetValue(pr)
-			return nil
-		}
-		lst = pr.Cdr()
-	}
-	mc.SetValue(values.FalseValue)
-	return nil
+	return helpers.MemberLookup(mc, "memq", func(a, b values.Value) bool {
+		return a == b
+	})
 }
 
 // PrimMemv implements the memv primitive.
 // Finds an element in a list using eqv? for comparison.
 func PrimMemv(mc *machine.MachineContext) error {
-	obj := mc.Arg(0)
-	lst := mc.Arg(1)
-	for !values.IsEmptyList(lst) {
-		pr, ok := lst.(values.Tuple)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrNotAList, "memv: expected a list but got %T", lst)
-		}
-		if helpers.Eqv(pr.Car(), obj) {
-			mc.SetValue(pr)
-			return nil
-		}
-		lst = pr.Cdr()
-	}
-	mc.SetValue(values.FalseValue)
-	return nil
+	return helpers.MemberLookup(mc, "memv", helpers.Eqv)
 }
 
 // PrimMember implements the member primitive.

--- a/registry/core/prim_prompt.go
+++ b/registry/core/prim_prompt.go
@@ -52,11 +52,10 @@ func PrimDefaultContinuationPromptTag(mc *machine.MachineContext) error {
 }
 
 // PrimContinuationPromptTagQ tests whether a value is a continuation prompt tag.
-func PrimContinuationPromptTagQ(mc *machine.MachineContext) error {
-	_, ok := mc.Arg(0).(*machine.PromptTag)
-	mc.SetValue(values.BoolToBoolean(ok))
-	return nil
-}
+var PrimContinuationPromptTagQ = helpers.MakeTypePredicate(func(o values.Value) bool {
+	_, ok := o.(*machine.PromptTag)
+	return ok
+})
 
 // PrimCallWithContinuationPrompt installs a continuation prompt and runs the thunk.
 //

--- a/registry/helpers/list.go
+++ b/registry/helpers/list.go
@@ -78,6 +78,64 @@ func CollectVectors(rest values.Value, name string) ([]*values.Vector, int, erro
 	return vectors, minLen, nil
 }
 
+// CollectStrings extracts zero or more strings from a rest argument,
+// validates that each element is a string, converts them to rune slices, and returns
+// the minimum length of the strings. Callers are responsible for rejecting an empty
+// argument list if a non-empty list is required. Used by string-map and string-for-each.
+func CollectStrings(rest values.Value, name string) ([]*values.String, [][]rune, int, error) {
+	var strs []*values.String
+	current := rest
+	for !values.IsEmptyList(current) {
+		tuple, ok := current.(values.Tuple)
+		if !ok {
+			return nil, nil, 0, values.WrapForeignErrorf(values.ErrNotAList, "%s: improper argument list", name)
+		}
+		s, err := RequireType[*values.String](tuple.Car(), values.ErrNotAString, name)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		strs = append(strs, s)
+		current = tuple.Cdr()
+	}
+	if len(strs) == 0 {
+		return nil, nil, 0, nil
+	}
+	runeSlices := make([][]rune, len(strs))
+	minLen := -1
+	for i, s := range strs {
+		runeSlices[i] = s.Runes()
+		if minLen < 0 || len(runeSlices[i]) < minLen {
+			minLen = len(runeSlices[i])
+		}
+	}
+	return strs, runeSlices, minLen, nil
+}
+
+// MemberLookup is a helper for list membership primitives (memq, memv).
+// Takes obj at index 0, list at index 1. Uses eq predicate to find match.
+// On match, returns the tail of the list starting at the matched element.
+func MemberLookup(
+	mc *machine.MachineContext,
+	name string,
+	eq func(a, b values.Value) bool,
+) error {
+	obj := mc.Arg(0)
+	lst := mc.Arg(1)
+	for !values.IsEmptyList(lst) {
+		pr, ok := lst.(values.Tuple)
+		if !ok {
+			return values.WrapForeignErrorf(values.ErrNotAList, "%s: expected a list but got %T", name, lst)
+		}
+		if eq(pr.Car(), obj) {
+			mc.SetValue(pr)
+			return nil
+		}
+		lst = pr.Cdr()
+	}
+	mc.SetValue(values.FalseValue)
+	return nil
+}
+
 // AssocLookup is a helper for alist lookup primitives (assq, assv, assoc).
 // Takes key at index 0, alist at index 1. Uses eq predicate to find match.
 func AssocLookup(

--- a/registry/helpers/list_test.go
+++ b/registry/helpers/list_test.go
@@ -170,6 +170,150 @@ func TestCollectVectors_Errors(t *testing.T) {
 	}
 }
 
+// ── CollectStrings ───────────────────────────────────────────────────
+
+func TestCollectStrings(t *testing.T) {
+	c := qt.New(t)
+
+	s1 := values.NewString("abc")
+	s2 := values.NewString("de")
+	s3 := values.NewString("fghij")
+
+	tcs := []struct {
+		name       string
+		rest       values.Value
+		wantCount  int
+		wantMinLen int
+	}{
+		{"empty list", values.EmptyList, 0, 0},
+		{"single string", values.List(s1), 1, 3},
+		{"two strings min is shorter", values.List(s1, s2), 2, 2},
+		{"three strings min is middle", values.List(s1, s2, s3), 3, 2},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			strs, runeSlices, minLen, err := CollectStrings(tc.rest, "test")
+			c.Assert(err, qt.IsNil)
+			c.Assert(len(strs), qt.Equals, tc.wantCount)
+			if tc.wantCount > 0 {
+				c.Assert(len(runeSlices), qt.Equals, tc.wantCount)
+				c.Assert(minLen, qt.Equals, tc.wantMinLen)
+			}
+		})
+	}
+}
+
+func TestCollectStrings_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name     string
+		rest     values.Value
+		sentinel error
+	}{
+		{
+			"non-string element",
+			values.List(values.NewInteger(1)),
+			values.ErrNotAString,
+		},
+		{
+			"mixed string and non-string",
+			values.List(values.NewString("ok"), values.NewInteger(1)),
+			values.ErrNotAString,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := CollectStrings(tc.rest, "test")
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(errors.Is(err, tc.sentinel), qt.IsTrue)
+		})
+	}
+}
+
+// ── MemberLookup ─────────────────────────────────────────────────────
+
+func TestMemberLookup(t *testing.T) {
+	c := qt.New(t)
+
+	lst := values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3))
+
+	tcs := []struct {
+		name string
+		key  values.Value
+		list values.Value
+		eq   func(a, b values.Value) bool
+		want values.Value
+	}{
+		{
+			"found first element",
+			values.NewInteger(1),
+			lst,
+			valEq,
+			lst, // returns tail from match point
+		},
+		{
+			"found middle element",
+			values.NewInteger(2),
+			lst,
+			valEq,
+			lst.Cdr(), // (2 3)
+		},
+		{
+			"not found returns false",
+			values.NewInteger(99),
+			lst,
+			valEq,
+			values.FalseValue,
+		},
+		{
+			"empty list returns false",
+			values.NewInteger(1),
+			values.EmptyList,
+			valEq,
+			values.FalseValue,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := makeMC(tc.key, tc.list)
+			err := MemberLookup(mc, "test", tc.eq)
+			c.Assert(err, qt.IsNil)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestMemberLookup_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	tcs := []struct {
+		name     string
+		key      values.Value
+		list     values.Value
+		sentinel error
+	}{
+		{
+			"list not a list",
+			values.NewInteger(1),
+			values.NewInteger(42),
+			values.ErrNotAList,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := makeMC(tc.key, tc.list)
+			err := MemberLookup(mc, "test", valEq)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(errors.Is(err, tc.sentinel), qt.IsTrue)
+		})
+	}
+}
+
 // ── AssocLookup ──────────────────────────────────────────────────────
 
 func valEq(a, b values.Value) bool {

--- a/registry/helpers/type.go
+++ b/registry/helpers/type.go
@@ -50,6 +50,32 @@ func MakeNumericPredicate[T any](
 	}
 }
 
+// MakeCharPredicate creates a character predicate primitive that extracts
+// arg 0 as a Character and applies a boolean test on the rune value.
+func MakeCharPredicate(name string, test func(rune) bool) machine.ForeignFunction {
+	return func(mc *machine.MachineContext) error {
+		ch, err := RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, name)
+		if err != nil {
+			return err
+		}
+		mc.SetValue(values.BoolToBoolean(test(ch.Value)))
+		return nil
+	}
+}
+
+// MakeCharTransform creates a character transformation primitive that extracts
+// arg 0 as a Character, applies a rune transformation, and returns a new Character.
+func MakeCharTransform(name string, transform func(rune) rune) machine.ForeignFunction {
+	return func(mc *machine.MachineContext) error {
+		ch, err := RequireArg[*values.Character](mc, 0, values.ErrNotACharacter, name)
+		if err != nil {
+			return err
+		}
+		mc.SetValue(values.NewCharacter(transform(ch.Value)))
+		return nil
+	}
+}
+
 // ChainEquality implements variadic chain equality comparison for primitives
 // like boolean=? and symbol=?.
 //

--- a/registry/helpers/type_test.go
+++ b/registry/helpers/type_test.go
@@ -17,6 +17,7 @@ package helpers
 import (
 	"errors"
 	"testing"
+	"unicode"
 
 	qt "github.com/frankban/quicktest"
 
@@ -116,6 +117,82 @@ func TestMakeNumericPredicate_Errors(t *testing.T) {
 			c.Assert(errors.Is(err, values.ErrNotANumber), qt.IsTrue)
 		})
 	}
+}
+
+// ── MakeCharPredicate ────────────────────────────────────────────────
+
+func TestMakeCharPredicate(t *testing.T) {
+	c := qt.New(t)
+
+	isUpper := MakeCharPredicate("char-upper-case?", unicode.IsUpper)
+
+	tcs := []struct {
+		name string
+		arg  values.Value
+		want values.Value
+	}{
+		{"uppercase", values.NewCharacter('A'), values.TrueValue},
+		{"lowercase", values.NewCharacter('a'), values.FalseValue},
+		{"digit", values.NewCharacter('5'), values.FalseValue},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := makeMC(tc.arg)
+			err := isUpper(mc)
+			c.Assert(err, qt.IsNil)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestMakeCharPredicate_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	isUpper := MakeCharPredicate("char-upper-case?", unicode.IsUpper)
+
+	mc := makeMC(values.NewInteger(42))
+	err := isUpper(mc)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, values.ErrNotACharacter), qt.IsTrue)
+}
+
+// ── MakeCharTransform ────────────────────────────────────────────────
+
+func TestMakeCharTransform(t *testing.T) {
+	c := qt.New(t)
+
+	toUpper := MakeCharTransform("char-upcase", unicode.ToUpper)
+
+	tcs := []struct {
+		name string
+		arg  values.Value
+		want values.Value
+	}{
+		{"lowercase to upper", values.NewCharacter('a'), values.NewCharacter('A')},
+		{"already upper", values.NewCharacter('A'), values.NewCharacter('A')},
+		{"digit unchanged", values.NewCharacter('5'), values.NewCharacter('5')},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			mc := makeMC(tc.arg)
+			err := toUpper(mc)
+			c.Assert(err, qt.IsNil)
+			c.Assert(mc.GetValue(), valuestest.SchemeEquals, tc.want)
+		})
+	}
+}
+
+func TestMakeCharTransform_Errors(t *testing.T) {
+	c := qt.New(t)
+
+	toUpper := MakeCharTransform("char-upcase", unicode.ToUpper)
+
+	mc := makeMC(values.NewString("not a char"))
+	err := toUpper(mc)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errors.Is(err, values.ErrNotACharacter), qt.IsTrue)
 }
 
 // ── ChainEquality ────────────────────────────────────────────────────

--- a/values/binary_input_port.go
+++ b/values/binary_input_port.go
@@ -41,10 +41,7 @@ func NewBinaryInputPort(rdr *bufio.Reader) *BinaryInputPort {
 // NewBinaryInputPortFromReader creates a new input port reading from the given byte slice.
 func NewBinaryInputPortFromReader(reader io.Reader) *BinaryInputPort {
 	q := &BinaryInputPort{rdr: bufio.NewReader(reader)}
-	closer, ok := reader.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(reader)
 	return q
 }
 

--- a/values/binary_output_port.go
+++ b/values/binary_output_port.go
@@ -42,10 +42,7 @@ func NewBinaryOutputPort(wrt *bufio.Writer) *BinaryOutputPort {
 // NewBinaryOutputPortFromWriter creates a new input port reading from the given byte slice.
 func NewBinaryOutputPortFromWriter(writer io.Writer) *BinaryOutputPort {
 	q := &BinaryOutputPort{wrt: bufio.NewWriter(writer)}
-	closer, ok := writer.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(writer)
 	return q
 }
 

--- a/values/box.go
+++ b/values/box.go
@@ -55,22 +55,16 @@ func (p *Box) EqualTo(v Value) bool {
 	if p == other {
 		return true
 	}
-	if p == nil && other == nil {
-		return true
-	}
 	if p == nil || other == nil {
 		return false
 	}
-	if p.Value == nil && other.Value == nil {
-		return true
-	}
-	if p.Value == nil || other.Value == nil {
-		return false
-	}
-	return p.Value.EqualTo(other.Value)
+	return wrapperValueEqualTo(p.Value, other.Value)
 }
 
 // SchemeString returns the Scheme representation of the box.
 func (p *Box) SchemeString() string {
+	if p == nil {
+		return "#<box:void>"
+	}
 	return fmt.Sprintf("#&%s", p.Value.SchemeString())
 }

--- a/values/byte_vector_input_port.go
+++ b/values/byte_vector_input_port.go
@@ -41,10 +41,7 @@ func NewByteVectorInputPort(reader *bufio.Reader) *ByteVectorInputPort {
 // NewByteVectorInputPortFromReader creates a new input port reading from the given byte slice.
 func NewByteVectorInputPortFromReader(reader io.Reader) *ByteVectorInputPort {
 	q := &ByteVectorInputPort{rdr: bufio.NewReader(reader)}
-	closer, ok := reader.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(reader)
 	return q
 }
 

--- a/values/byte_vector_output_port.go
+++ b/values/byte_vector_output_port.go
@@ -43,10 +43,7 @@ func NewByteVectorOutputPortFromWriter(wrt io.Writer) *ByteVectorOutputPort {
 	q := &ByteVectorOutputPort{
 		wrt: bufio.NewWriter(wrt),
 	}
-	closer, ok := wrt.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(wrt)
 	return q
 }
 

--- a/values/character_input_port.go
+++ b/values/character_input_port.go
@@ -43,10 +43,7 @@ func NewCharacterInputPort(rdr *bufio.Reader) *CharacterInputPort {
 // NewCharacterInputPortFromReader creates a new character input port from an io.Reader.
 func NewCharacterInputPortFromReader(rdr io.Reader) *CharacterInputPort {
 	q := &CharacterInputPort{rdr: bufio.NewReader(rdr)}
-	closer, ok := rdr.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(rdr)
 	return q
 }
 

--- a/values/character_output_port.go
+++ b/values/character_output_port.go
@@ -42,10 +42,7 @@ func NewCharacterOutputPort(wrt *bufio.Writer) *CharacterOutputPort {
 // NewCharacterOutputPortFromWriter creates a new character output port wrapping the given buf.
 func NewCharacterOutputPortFromWriter(wrt io.Writer) *CharacterOutputPort {
 	q := NewCharacterOutputPort(bufio.NewWriter(wrt))
-	closer, ok := wrt.(io.Closer)
-	if ok {
-		q.clsr = closer
-	}
+	q.setCloser(wrt)
 	return q
 }
 

--- a/values/compile_time_value.go
+++ b/values/compile_time_value.go
@@ -50,22 +50,16 @@ func (p *CompileTimeValue) EqualTo(v Value) bool {
 	if p == other {
 		return true
 	}
-	if p == nil && other == nil {
-		return true
-	}
 	if p == nil || other == nil {
 		return false
 	}
-	if p.Value == nil && other.Value == nil {
-		return true
-	}
-	if p.Value == nil || other.Value == nil {
-		return false
-	}
-	return p.Value.EqualTo(other.Value)
+	return wrapperValueEqualTo(p.Value, other.Value)
 }
 
 // SchemeString returns the Scheme representation of the compile-time value.
 func (p *CompileTimeValue) SchemeString() string {
+	if p == nil {
+		return "#<compile-time-value:void>"
+	}
 	return fmt.Sprintf("#<compile-time-value %s>", p.Value.SchemeString())
 }

--- a/values/native_error.go
+++ b/values/native_error.go
@@ -40,71 +40,53 @@ type NativeError struct {
 	err       error           // Wrapped Go error (optional)
 }
 
+// newNativeError is the core constructor for all NativeError variants.
+func newNativeError(msg string, cause error, kind NativeErrorKind, irritants ...Value) *NativeError {
+	irr := List(irritants...)
+	if len(irritants) == 0 {
+		irr = EmptyList
+	}
+	return &NativeError{
+		message:   NewString(msg),
+		irritants: irr,
+		kind:      kind,
+		err:       cause,
+	}
+}
+
 // NewNativeError creates a new native error with the given message.
 func NewNativeError(msg string) *NativeError {
-	q := &NativeError{
-		message:   NewString(msg),
-		irritants: EmptyList,
-		kind:      NativeErrorKindGeneric,
-	}
-	return q
+	return newNativeError(msg, nil, NativeErrorKindGeneric)
 }
 
 // NewErrorObject creates a new error object with the given message and irritants.
 func NewErrorObject(message string, irritants ...Value) *NativeError {
-	q := &NativeError{
-		message:   NewString(message),
-		irritants: List(irritants...),
-		kind:      NativeErrorKindGeneric,
-	}
-	return q
+	return newNativeError(message, nil, NativeErrorKindGeneric, irritants...)
 }
 
 // NewErrorObjectWithCause creates a new error object that wraps a Go error.
 // This preserves the original error for debugging while providing R7RS-compliant
 // exception handling. The wrapped error can be retrieved with Datum() or Unwrap().
 func NewErrorObjectWithCause(message string, cause error, irritants ...Value) *NativeError {
-	q := &NativeError{
-		message:   NewString(message),
-		irritants: List(irritants...),
-		kind:      NativeErrorKindGeneric,
-		err:       cause,
-	}
-	return q
+	return newNativeError(message, cause, NativeErrorKindGeneric, irritants...)
 }
 
 // NewReadError creates a new read error object with the given message and irritants.
 // R7RS §6.11: read-error? predicate checks for errors during reading.
 func NewReadError(message string, irritants ...Value) *NativeError {
-	q := &NativeError{
-		message:   NewString(message),
-		irritants: List(irritants...),
-		kind:      NativeErrorKindRead,
-	}
-	return q
+	return newNativeError(message, nil, NativeErrorKindRead, irritants...)
 }
 
 // NewFileError creates a new file error object with the given message and irritants.
 // R7RS §6.11: file-error? predicate checks for errors during file operations.
 func NewFileError(message string, irritants ...Value) *NativeError {
-	q := &NativeError{
-		message:   NewString(message),
-		irritants: List(irritants...),
-		kind:      NativeErrorKindFile,
-	}
-	return q
+	return newNativeError(message, nil, NativeErrorKindFile, irritants...)
 }
 
 // NewErrorObjectWithCauseAndKind creates a new error object that wraps a Go error with a specific kind.
 // R7RS §6.11: The kind determines which error predicate (file-error?, read-error?) matches.
 func NewErrorObjectWithCauseAndKind(message string, cause error, kind NativeErrorKind, irritants ...Value) *NativeError {
-	q := &NativeError{
-		message:   NewString(message),
-		irritants: List(irritants...),
-		kind:      kind,
-		err:       cause,
-	}
-	return q
+	return newNativeError(message, cause, kind, irritants...)
 }
 
 // Message returns the error message string.

--- a/values/port_base.go
+++ b/values/port_base.go
@@ -48,6 +48,16 @@ func (b *portBase) Close() error {
 	return nil
 }
 
+// setCloser checks if v implements io.Closer and, if so, stores it
+// for use when the port is closed. Used by port constructors to detect
+// closeable underlying streams.
+func (b *portBase) setCloser(v any) {
+	closer, ok := v.(io.Closer)
+	if ok {
+		b.clsr = closer
+	}
+}
+
 // guardClosed returns ErrPortClosed if the port is closed.
 // I/O methods call this at the top to reject operations on closed ports.
 func (b *portBase) guardClosed() error {

--- a/values/string_input_port.go
+++ b/values/string_input_port.go
@@ -92,5 +92,5 @@ func (p *StringInputPort) String() string {
 
 // SchemeString returns the Scheme representation of the port.
 func (p *StringInputPort) SchemeString() string {
-	return fmt.Sprintf("<string-input-output-port %p>", p.buf)
+	return fmt.Sprintf("<string-input-port %p>", p.buf)
 }

--- a/values/string_output_port.go
+++ b/values/string_output_port.go
@@ -93,5 +93,5 @@ func (p *StringOutputPort) String() string {
 
 // SchemeString returns the Scheme representation of the port.
 func (p *StringOutputPort) SchemeString() string {
-	return fmt.Sprintf("<string-input-output-port %p>", p.buf)
+	return fmt.Sprintf("<string-output-port %p>", p.buf)
 }

--- a/values/string_port_test.go
+++ b/values/string_port_test.go
@@ -74,10 +74,18 @@ func TestStringInputOutputPort_EqualTo(t *testing.T) {
 	qt.Assert(t, port1.EqualTo(port1), qt.IsTrue)
 }
 
-func TestStringInputOutputPort_SchemeString(t *testing.T) {
+func TestStringOutputPort_SchemeString(t *testing.T) {
 	port := values.NewStringOutputPortWithBuffer(bytes.NewBufferString("test"))
 	s := port.SchemeString()
-	qt.Assert(t, strings.Contains(s, "string-input-output-port"), qt.IsTrue)
+	qt.Assert(t, strings.Contains(s, "string-output-port"), qt.IsTrue)
+	qt.Assert(t, strings.Contains(s, "string-input-output-port"), qt.IsFalse)
+}
+
+func TestStringInputPort_SchemeString(t *testing.T) {
+	port := values.NewStringInputPortWithBuffer(bytes.NewBufferString("test"))
+	s := port.SchemeString()
+	qt.Assert(t, strings.Contains(s, "string-input-port"), qt.IsTrue)
+	qt.Assert(t, strings.Contains(s, "string-input-output-port"), qt.IsFalse)
 }
 
 func TestStringInputOutputPort_NewStringOutputPort(t *testing.T) {

--- a/values/utils.go
+++ b/values/utils.go
@@ -90,6 +90,18 @@ type equalPairKey [2]Value
 // with a visited set to terminate on circular structures per R7RS §6.1.
 // This is the same technique used by Chez Scheme and Racket: when a
 // (pointer-a, pointer-b) pair is re-encountered during recursion, return true.
+// wrapperValueEqualTo compares two optional Value fields for structural equality.
+// Used by wrapper types (Box, CompileTimeValue) whose EqualTo delegates to inner values.
+func wrapperValueEqualTo(pVal, oVal Value) bool {
+	if pVal == oVal {
+		return true
+	}
+	if pVal == nil || oVal == nil {
+		return false
+	}
+	return pVal.EqualTo(oVal)
+}
+
 func EqualTo(a, b Value) bool {
 	if a == nil || b == nil {
 		return a == b


### PR DESCRIPTION
## Summary

- Add `MemberLookup`, `CollectStrings`, `MakeCharPredicate`, `MakeCharTransform` helpers parallel to existing factories
- Convert 9 inline type-assertion predicates to `MakeTypePredicate`, 8 char prims to factory vars
- Extract `newLiteralExpr`, `validateBodySlice`, `validatedProcBase` in validate package
- Consolidate `NativeError` constructors, port closer detection, wrapper `EqualTo` in values
- Fix `StringInputPort`/`StringOutputPort` `SchemeString` labels (both incorrectly said "input-output-port")

32 files changed, 282 insertions, 415 deletions. ~55 sites consolidated across 6 packages.

Design doc: `plans/CROSS_CUTTING_CONSOLIDATION.md`

## Test plan
- [x] `go test ./...` — all unit tests pass
- [x] `integration/TestR7RSConformance` — pass
- [x] No new tests needed (mechanical refactoring); existing coverage validates behavior
- [x] `goimports` applied to all changed files