### PR TITLE
refactor: structural consolidation of compiler and expander internals

### DIFF
--- a/internal/extensions/all/prim_strings.go
+++ b/internal/extensions/all/prim_strings.go
@@ -285,50 +285,32 @@ func PrimStringCiGeVariadic(mc *machine.MachineContext) error {
 	})
 }
 
-// PrimStringUpcase implements the string-upcase primitive.
-// R7RS §6.7: Returns a string whose characters are the uppercase versions of the characters in string.
-// Uses Unicode full case mapping which can expand characters (e.g., ß → SS).
-func PrimStringUpcase(mc *machine.MachineContext) error {
-	str, err := helpers.RequireArg[*values.String](mc, 0, values.ErrNotAString, "string-upcase")
-	if err != nil {
-		return err
+// makeStringCaser creates a string case-mapping primitive that extracts
+// arg 0 as a String, applies a cases.Caser, and returns a new mutable string.
+func makeStringCaser(name string, makeCaser func() cases.Caser) machine.ForeignFunction {
+	return func(mc *machine.MachineContext) error {
+		str, err := helpers.RequireArg[*values.String](mc, 0, values.ErrNotAString, name)
+		if err != nil {
+			return err
+		}
+		caser := makeCaser()
+		result := caser.String(str.Value)
+		mc.SetValue(values.NewMutableString(result))
+		return nil
 	}
-	// Use Unicode full case mapping (language-independent)
-	caser := cases.Upper(language.Und)
-	result := caser.String(str.Value)
-	// R7RS §6.7: string-upcase returns a newly allocated mutable string
-	mc.SetValue(values.NewMutableString(result))
-	return nil
 }
 
-// PrimStringDowncase implements the string-downcase primitive.
-// R7RS §6.7: Returns a string whose characters are the lowercase versions of the characters in string.
-// Uses Unicode full case mapping which can expand characters.
-func PrimStringDowncase(mc *machine.MachineContext) error {
-	str, err := helpers.RequireArg[*values.String](mc, 0, values.ErrNotAString, "string-downcase")
-	if err != nil {
-		return err
-	}
-	// Use Unicode full case mapping (language-independent)
-	caser := cases.Lower(language.Und)
-	result := caser.String(str.Value)
-	// R7RS §6.7: string-downcase returns a newly allocated mutable string
-	mc.SetValue(values.NewMutableString(result))
-	return nil
-}
+// String case-mapping primitives — R7RS §6.7.
+// Uses Unicode full case mapping (language-independent).
 
-// PrimStringFoldcase implements the string-foldcase primitive.
-// R7RS §6.7: Returns a string whose characters are the case-folded versions of the characters in string.
-// Uses Unicode full case folding which can expand characters (e.g., ß → ss).
-func PrimStringFoldcase(mc *machine.MachineContext) error {
-	str, err := helpers.RequireArg[*values.String](mc, 0, values.ErrNotAString, "string-foldcase")
-	if err != nil {
-		return err
-	}
-	// Use Unicode full case folding
-	caser := cases.Fold()
-	result := caser.String(str.Value)
-	// R7RS §6.7: string-foldcase returns a newly allocated mutable string
-	mc.SetValue(values.NewMutableString(result))
-	return nil
-}
+var PrimStringUpcase = makeStringCaser("string-upcase", func() cases.Caser {
+	return cases.Upper(language.Und)
+})
+
+var PrimStringDowncase = makeStringCaser("string-downcase", func() cases.Caser {
+	return cases.Lower(language.Und)
+})
+
+var PrimStringFoldcase = makeStringCaser("string-foldcase", func() cases.Caser {
+	return cases.Fold()
+})

--- a/machine/compile_begin_for_syntax.go
+++ b/machine/compile_begin_for_syntax.go
@@ -15,30 +15,22 @@
 package machine
 
 import (
-	"context"
-
 	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 )
 
 // CompileBeginForSyntax handles (begin-for-syntax expr ...).
 //
-// This form evaluates a sequence of expressions at compile time in the
-// expand phase environment. It is useful for setting up compile-time
-// state like hash tables or registries that macros can access.
-//
-// Each expression is compiled and executed at compile time. The expressions
-// can use define-for-syntax bindings and runtime primitives. The result
-// of the last expression is discarded (begin-for-syntax is used for side effects).
+// Evaluates a sequence of expressions at compile time in the expand phase
+// environment. Used for setting up compile-time state (hash tables, registries)
+// that macros can access. No runtime effect — used for side effects only.
 func (p *CompileTimeContinuation) CompileBeginForSyntax(ctctx CompileTimeCallContext, expr syntax.SyntaxValue) error {
 	err := p.ensureState("begin-for-syntax")
 	if err != nil {
 		return err
 	}
 
-	// expr is (expr ...) - the expressions after 'begin-for-syntax'
 	if syntax.IsSyntaxEmptyList(expr) {
-		// No expressions - nothing to do
 		return nil
 	}
 	exprPair, ok := expr.(*syntax.SyntaxPair)
@@ -46,25 +38,5 @@ func (p *CompileTimeContinuation) CompileBeginForSyntax(ctctx CompileTimeCallCon
 		return values.WrapForeignErrorf(values.ErrNotASyntaxPair, "begin-for-syntax: expected expressions")
 	}
 
-	// Get expand phase environment for execution
-	expandEnv := p.env.Expand()
-
-	// Create expander for macro expansion
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
-
-	// Process each expression
-	current := exprPair
-	v, err := current.SyntaxForEach(ctctx.ctx, func(_ context.Context, _ int, _ bool, stxVal syntax.SyntaxValue) error {
-		_, err := p.expandCompileExecute(ctctx.ctx, ctctx, stxVal, expandEnv, expander, "begin-for-syntax")
-		return err
-	})
-	if err != nil {
-		return values.WrapForeignErrorf(err, "begin-for-syntax: error processing expressions")
-	}
-	if !syntax.IsSyntaxEmptyList(v) {
-		return values.WrapForeignErrorf(values.ErrNotAList, "begin-for-syntax: expected a proper list of expressions")
-	}
-
-	// begin-for-syntax has no runtime effect - don't emit any operations
-	return nil
+	return p.executeFormsAtCompileTime(ctctx, "begin-for-syntax", exprPair)
 }

--- a/machine/compile_eval_when.go
+++ b/machine/compile_eval_when.go
@@ -169,36 +169,11 @@ func (p *CompileTimeContinuation) parseEvalWhenPhases(ctx context.Context, phase
 }
 
 // evalWhenExecuteAtCompileTime executes body expressions at compile time.
-// Similar to begin-for-syntax behavior.
 func (p *CompileTimeContinuation) evalWhenExecuteAtCompileTime(ctctx CompileTimeCallContext, bodyPair *syntax.SyntaxPair) error {
-	// Handle empty body
 	if syntax.IsSyntaxEmptyList(bodyPair) {
 		return nil
 	}
-
-	// Get expand phase environment for execution
-	expandEnv := p.env.Expand()
-
-	// Create expander for macro expansion
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
-
-	// Process each expression
-	current := bodyPair
-	v, err := current.SyntaxForEach(ctctx.ctx, func(ctx context.Context, _ int, _ bool, exprVal syntax.SyntaxValue) error {
-		if exprVal == nil {
-			return values.WrapForeignErrorf(values.ErrUnexpectedNil, "eval-when: nil expression")
-		}
-		_, err := p.expandCompileExecute(ctx, ctctx, exprVal, expandEnv, expander, "eval-when")
-		return err
-	})
-	if err != nil {
-		return values.WrapForeignErrorf(err, "eval-when: error processing body expressions")
-	}
-	if !syntax.IsSyntaxEmptyList(v) {
-		return values.WrapForeignErrorf(values.ErrNotAList, "eval-when: improper body expressions list")
-	}
-
-	return nil
+	return p.executeFormsAtCompileTime(ctctx, "eval-when", bodyPair)
 }
 
 // evalWhenCompileForRuntime compiles body expressions for runtime execution.

--- a/machine/compile_helpers.go
+++ b/machine/compile_helpers.go
@@ -61,6 +61,29 @@ func (p *CompileTimeContinuation) expandCompileExecute(
 	return mc.GetValue(), nil
 }
 
+// executeFormsAtCompileTime expands, compiles, and executes each expression
+// in bodyPair at compile time. Used by eval-when and begin-for-syntax.
+func (p *CompileTimeContinuation) executeFormsAtCompileTime(
+	ctctx CompileTimeCallContext,
+	formName string,
+	bodyPair *syntax.SyntaxPair,
+) error {
+	expandEnv := p.env.Expand()
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+
+	v, err := bodyPair.SyntaxForEach(ctctx.ctx, func(_ context.Context, _ int, _ bool, stxVal syntax.SyntaxValue) error {
+		_, err := p.expandCompileExecute(ctctx.ctx, ctctx, stxVal, expandEnv, expander, formName)
+		return err
+	})
+	if err != nil {
+		return values.WrapForeignErrorf(err, "%s: error processing body expressions", formName)
+	}
+	if !syntax.IsSyntaxEmptyList(v) {
+		return values.WrapForeignErrorf(values.ErrNotAList, "%s: improper body expressions list", formName)
+	}
+	return nil
+}
+
 // ensureState checks that the compiler has a valid environment and template.
 // Every compile-time form (define-syntax, begin-for-syntax, define-for-syntax,
 // eval-when) must call this before accessing p.env or p.template.

--- a/machine/compile_syntax_case.go
+++ b/machine/compile_syntax_case.go
@@ -148,7 +148,7 @@ func (p *CompileTimeContinuation) CompileSyntaxCase(ctctx CompileTimeCallContext
 	// Patch all success jumps to point here (end of syntax-case)
 	endIndex := p.template.CodeLen()
 	for _, patch := range successJumps {
-		p.patchBranchOffset(patch.opIndex, endIndex)
+		p.patchBranchTarget(patch.opIndex, endIndex)
 	}
 
 	// Clear the syntax-case input global
@@ -159,9 +159,8 @@ func (p *CompileTimeContinuation) CompileSyntaxCase(ctctx CompileTimeCallContext
 
 // jumpPatch represents a branch operation that needs to be patched later
 type jumpPatch struct {
-	clauseIndex          int
-	opIndex              int
-	isBranchOnFalseValue bool // true = BranchOnFalseValue, false = Branch
+	clauseIndex int
+	opIndex     int
 }
 
 // compileSyntaxCaseClause compiles a single syntax-case clause.
@@ -218,7 +217,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	// Branch on match failure (reads value register directly, no Push needed)
 	failBranchIdx := p.template.CodeLen()
 	p.AppendOperations(NewOperationBranchOnFalseValueOffsetImmediate(0)) // Offset patched later
-	*failJumps = append(*failJumps, jumpPatch{clauseIndex, failBranchIdx, true})
+	*failJumps = append(*failJumps, jumpPatch{clauseIndex, failBranchIdx})
 
 	// Create environment with pattern variables bound (shared between fender and body)
 	bodyEnv := p.createPatternVarEnvironment(patternVars)
@@ -265,13 +264,13 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	// Jump to end on success
 	successJumpIdx := p.template.CodeLen()
 	p.AppendOperations(NewOperationBranchOffsetImmediate(0)) // Offset patched later
-	*successJumps = append(*successJumps, jumpPatch{clauseIndex, successJumpIdx, false})
+	*successJumps = append(*successJumps, jumpPatch{clauseIndex, successJumpIdx})
 
 	// If there was a fender, add cleanup block: PopEnv, then branch to next clause
 	if fender != nil {
 		// Patch fender branch to jump here (cleanup block start)
 		cleanupStart := p.template.CodeLen()
-		p.patchBranchOnFalseValueOffset(fenderBranchIdx, cleanupStart)
+		p.patchBranchTarget(fenderBranchIdx, cleanupStart)
 
 		// Restore parent environment
 		p.AppendOperations(NewOperationPopEnv())
@@ -279,7 +278,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 		// Branch to next clause (will be patched below)
 		cleanupBranchIdx := p.template.CodeLen()
 		p.AppendOperations(NewOperationBranchOffsetImmediate(0))
-		*failJumps = append(*failJumps, jumpPatch{clauseIndex, cleanupBranchIdx, false})
+		*failJumps = append(*failJumps, jumpPatch{clauseIndex, cleanupBranchIdx})
 	}
 
 	// Patch fail jumps for this clause to point to the next clause
@@ -287,12 +286,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	for i := len(*failJumps) - 1; i >= 0; i-- {
 		patch := (*failJumps)[i]
 		if patch.clauseIndex == clauseIndex {
-			// Use the stored branch type to call the appropriate patch function
-			if patch.isBranchOnFalseValue {
-				p.patchBranchOnFalseValueOffset(patch.opIndex, nextClauseStart)
-			} else {
-				p.patchBranchOffset(patch.opIndex, nextClauseStart)
-			}
+			p.patchBranchTarget(patch.opIndex, nextClauseStart)
 		}
 	}
 

--- a/machine/compile_time_continuation.go
+++ b/machine/compile_time_continuation.go
@@ -427,16 +427,9 @@ func (p *CompileTimeContinuation) patchSaveContinuationOffset(idx int) {
 	p.template.PatchInstructionArg(idx, int32(offset))
 }
 
-// patchBranchOnFalseValueOffset patches a previously emitted BranchOnFalseValue
-// instruction with the target offset.
-func (p *CompileTimeContinuation) patchBranchOnFalseValueOffset(idx, targetIdx int) {
-	offset := targetIdx - idx
-	p.template.PatchInstructionArg(idx, int32(offset))
-}
-
-// patchBranchOffset patches a previously emitted Branch instruction with the
-// target offset.
-func (p *CompileTimeContinuation) patchBranchOffset(idx, targetIdx int) {
+// patchBranchTarget patches a previously emitted branch instruction (Branch,
+// BranchOnFalseValue, or SaveContinuation) with the offset to targetIdx.
+func (p *CompileTimeContinuation) patchBranchTarget(idx, targetIdx int) {
 	offset := targetIdx - idx
 	p.template.PatchInstructionArg(idx, int32(offset))
 }

--- a/machine/compile_time_continuation_library.go
+++ b/machine/compile_time_continuation_library.go
@@ -390,7 +390,13 @@ func (p *CompileTimeContinuation) processLibraryImport(ctctx CompileTimeCallCont
 	return err
 }
 
-// parseImportSet parses an import set with optional modifiers.
+// parseImportSet parses an import set from syntax objects (compile-time).
+//
+// A parallel set of functions exists in import_set_datum.go operating on
+// plain values.Tuple for runtime datum parsing. The two families are
+// structurally identical but use different accessor methods due to the
+// syntax/datum phase boundary. Changes here should be mirrored there.
+//
 // Import sets can be:
 //   - (<library-name>)              : import all exports
 //   - (only <import-set> <id> ...)  : import only specified identifiers
@@ -453,10 +459,7 @@ func parseImportSetOnly(ctx context.Context, pair *syntax.SyntaxPair) (*ImportSe
 	}
 
 	// Get identifiers
-	idsExpr, ok := cdrExpr.Cdr().(syntax.SyntaxValue)
-	if !ok {
-		return nil, values.WrapForeignErrorf(values.ErrNotAPair, "only: expected identifiers")
-	}
+	idsExpr := cdrExpr.SyntaxCdr()
 
 	ids, err := parseIdentifierList(ctx, idsExpr)
 	if err != nil {
@@ -494,7 +497,7 @@ func parseImportSetExcept(ctx context.Context, pair *syntax.SyntaxPair) (*Import
 
 // parseImportSetPrefix parses (prefix <import-set> <prefix>)
 func parseImportSetPrefix(ctx context.Context, pair *syntax.SyntaxPair) (*ImportSet, error) {
-	cdrExpr, ok := pair.Cdr().(*syntax.SyntaxPair)
+	cdrExpr, ok := pair.SyntaxCdr().(*syntax.SyntaxPair)
 	if !ok {
 		return nil, values.WrapForeignErrorf(values.ErrNotAPair, "prefix: expected import-set and prefix")
 	}

--- a/machine/compile_time_continuation_test.go
+++ b/machine/compile_time_continuation_test.go
@@ -928,9 +928,7 @@ func TestCompileLambdaParameterListVariants(t *testing.T) {
 
 // TestSyntaxCompilerNameMethod tests the Name method of PrimitiveCompiler
 func TestSyntaxCompilerNameMethod(t *testing.T) {
-	pc := &SyntaxCompiler{
-		name: "test-compiler",
-	}
+	pc := NewSyntaxCompiler("test-compiler", nil)
 	qt.Assert(t, pc.Name(), qt.Equals, "test-compiler")
 }
 

--- a/machine/compile_validated.go
+++ b/machine/compile_validated.go
@@ -35,6 +35,28 @@ import (
 //     that maps to a registered compiler in the forms registry.
 //  2. Type switch fallback: Expressions without form names (symbols, calls, literals)
 //     are dispatched by their concrete ValidatedExpr type.
+
+// compileValidatedSequence compiles a slice of validated expressions in order,
+// with all but the last compiled in NotInTail position. Used by CompileValidatedBegin
+// (pass 2) and compileBody (pass 2) to share the "last in tail position" logic.
+func (p *CompileTimeContinuation) compileValidatedSequence(
+	ctctx CompileTimeCallContext,
+	body []validate.ValidatedExpr,
+) error {
+	for i, expr := range body {
+		isLast := i == len(body)-1
+		exprCtx := ctctx.NotInTail()
+		if isLast {
+			exprCtx = ctctx
+		}
+		err := p.compileValidated(exprCtx, expr)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (p *CompileTimeContinuation) compileValidated(ctctx CompileTimeCallContext, expr validate.ValidatedExpr) error {
 	// Push the validated expression's source for finer-grained attribution.
 	// Inner sub-expressions will push their own source, naturally creating
@@ -157,8 +179,8 @@ func (p *CompileTimeContinuation) CompileValidatedIf(ctctx CompileTimeCallContex
 
 	// Fix up branch targets
 	endIndex := p.template.CodeLen()
-	p.patchBranchOnFalseValueOffset(branchOnFalseIndex, altStart)
-	p.patchBranchOffset(branchToEndIndex, endIndex)
+	p.patchBranchTarget(branchOnFalseIndex, altStart)
+	p.patchBranchTarget(branchToEndIndex, endIndex)
 
 	return nil
 }
@@ -365,80 +387,79 @@ func setScopesOnLastBinding(scopes []*syntax.Scope, lenv *environment.LocalEnvir
 	bindings[len(bindings)-1].SetScopes(scopes)
 }
 
-// compileClosure compiles a complete closure (lambda or define-fn body).
-// It binds required and rest parameters to the local environment, compiles body expressions,
-// and emits MakeClosure operations. Used by both lambda and function-style define.
-func (p *CompileTimeContinuation) compileClosure(ctctx CompileTimeCallContext, tpl *NativeTemplate, lenv *environment.LocalEnvironmentFrame, v validate.ValidatedProcedure) error {
+// compileClosureBody binds parameters, compiles the body, optimizes, and registers
+// the template and environment as literals. Returns the literal indices so the
+// caller can emit the appropriate closure opcodes.
+//
+// Used by compileClosure (lambda, define-fn) and CompileValidatedCaseLambda.
+func (p *CompileTimeContinuation) compileClosureBody(
+	ctctx CompileTimeCallContext,
+	tpl *NativeTemplate,
+	lenv *environment.LocalEnvironmentFrame,
+	v validate.ValidatedBodyAndParams,
+	errContext string,
+) (LiteralIndex, LiteralIndex, error) {
 	// Phase 1: Bind required parameters to the local environment.
-	// Each parameter becomes a local variable slot that the VM will populate
-	// with argument values when the closure is called. Parameters are processed
-	// in order, matching the left-to-right argument passing convention.
-	for _, paramSym := range v.Params().Required {
-		// Intern the symbol to ensure consistent identity across the compilation.
-		// This is necessary because symbols must be interned before comparison or storage.
-		param := p.env.InternSymbol(paramSym.Sym)
-		paramScopes := paramSym.Scopes()
+	// Each parameter becomes a local variable slot populated by the VM at call time.
+	// Params() is nil for zero-arg case-lambda clauses: (() ...).
+	if v.Params() != nil {
+		for _, paramSym := range v.Params().Required {
+			param := p.env.InternSymbol(paramSym.Sym)
+			paramScopes := paramSym.Scopes()
 
-		// Create a local binding slot for this parameter. The binding index
-		// corresponds to the argument position at runtime.
-		_, ok := lenv.EnsureLocalBinding(param, environment.BindingTypeVariable)
-		if !ok {
-			return values.WrapForeignErrorf(values.ErrDuplicateBinding, "duplicate parameter %q in lambda", param.Key)
+			_, ok := lenv.EnsureLocalBinding(param, environment.BindingTypeVariable)
+			if !ok {
+				return 0, 0, values.WrapForeignErrorf(
+					values.ErrDuplicateBinding,
+					"duplicate parameter %q in %s", param.Key, errContext,
+				)
+			}
+
+			// Preserve hygiene scopes from the source — tracks which macro
+			// expansion introduced this binding (R7RS sets-of-scopes model).
+			setScopesOnLastBinding(paramScopes, lenv)
+			tpl.parameterCount++
 		}
 
-		// Preserve hygiene information from the source. Scopes track which
-		// macro expansion introduced this binding, enabling hygienic macro
-		// expansion per R6RS/R7RS.
-		setScopesOnLastBinding(paramScopes, lenv)
-
-		// Track parameter count in the template. The VM uses this to validate
-		// argument counts and set up the local environment frame at call time.
-		tpl.parameterCount++
+		// Phase 2: Bind the rest parameter (if any) for variadic functions.
+		// For (lambda (a b . rest) ...), binds 'rest' to receive excess args as a list.
+		err := bindRestParameter(v, p, lenv, tpl)
+		if err != nil {
+			return 0, 0, err
+		}
 	}
 
-	// Phase 2: Bind the rest parameter (if any) for variadic functions.
-	// For (lambda (a b . rest) ...), this binds 'rest' to receive excess arguments as a list.
-	err := bindRestParameter(v, p, lenv, tpl)
-	if err != nil {
-		return err
-	}
-
-	// Create the child environment after all lenv mutations are complete.
-	// The EnvironmentFrame embeds LocalEnvironmentFrame by value, so lenv
-	// must be fully populated before being passed to the constructor.
+	// Phase 3: Create child environment and register literals.
+	// lenv must be fully populated before NewEnvironmentFrameWithParent (embeds by value).
 	childEnv := environment.NewEnvironmentFrameWithParent(lenv, p.env)
-
-	// Phase 3: Register the template and environment in the parent's literals pool.
-	// These will be loaded at runtime to construct the closure. The literals pool
-	// deduplicates values, so repeated closures can share template references.
 	tpli := p.template.MaybeAppendLiteral(tpl)
 	envi := p.template.MaybeAppendLiteral(childEnv)
 
-	// Phase 4: Compile the body expressions into the child template.
-	// Body compilation happens in the child environment where parameters are bound.
-	// The last expression is compiled in tail position for proper tail-call optimization.
-	err = p.compileBody(ctctx, v, childEnv, tpl)
+	// Phase 4: Compile body expressions into child template. The last expression
+	// is compiled in tail position for proper tail-call optimization.
+	err := p.compileBody(ctctx, v, childEnv, tpl)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Phase 5: Peephole optimization before escape analysis (optimization may
+	// change which ops are present). Escape analysis determines whether Apply
+	// can skip copying the closure's environment frame — safe when the body
+	// contains no SaveContinuation and no MakeClosure.
+	tpl.Optimize()
+	tpl.computeNoCopyApply()
+
+	return tpli, envi, nil
+}
+
+// compileClosure compiles a complete closure (lambda or define-fn body).
+// Binds parameters, compiles body, and emits MakeClosure operations.
+func (p *CompileTimeContinuation) compileClosure(ctctx CompileTimeCallContext, tpl *NativeTemplate, lenv *environment.LocalEnvironmentFrame, v validate.ValidatedProcedure) error {
+	tpli, envi, err := p.compileClosureBody(ctctx, tpl, lenv, v, "lambda")
 	if err != nil {
 		return err
 	}
 
-	// Phase 4b: Peephole optimization — remove dead instructions before
-	// escape analysis, since optimization may change which ops are present.
-	tpl.Optimize()
-
-	// Phase 4c: Escape analysis — determine whether Apply can skip copying
-	// the closure's environment frame. Safe when the body contains no
-	// OpSaveContinuation and no MakeClosure (the two paths that capture mc.env).
-	tpl.computeNoCopyApply()
-
-	// Phase 5: Emit bytecode to construct the closure at runtime.
-	// The closure captures the current environment (for lexical scoping) and
-	// references the compiled template. The sequence is:
-	//   1. Load template from literals → value register
-	//   2. Push template to eval stack
-	//   3. Load child environment from literals → value register
-	//   4. Push environment to eval stack
-	//   5. MakeClosure pops both and creates closure → value register
 	p.AppendOperations(
 		NewOperationLoadLiteralByLiteralIndexImmediate(tpli),
 		NewOperationPush(),
@@ -481,16 +502,9 @@ func (p *CompileTimeContinuation) compileBody(ctctx CompileTimeCallContext, clau
 	}
 
 	// Pass 2: Compile all expressions (with all bindings now visible)
-	for i, bodyExpr := range clause.Body() {
-		isLast := i == len(clause.Body())-1
-		bodyCtx := lambdaBodyContext.NotInTail()
-		if isLast {
-			bodyCtx = lambdaBodyContext
-		}
-		err := childCompiler.compileValidated(bodyCtx, bodyExpr)
-		if err != nil {
-			return err
-		}
+	err := childCompiler.compileValidatedSequence(lambdaBodyContext, clause.Body())
+	if err != nil {
+		return err
 	}
 
 	childCompiler.AppendOperations(NewOperationRestoreContinuation())
@@ -574,70 +588,21 @@ func (p *CompileTimeContinuation) CompileValidatedCaseLambda(ctctx CompileTimeCa
 	// multiple closures (one per clause) that are combined into a dispatch structure.
 	// Each clause closure is pushed to the eval stack for later combination.
 	for _, clause := range v.Clauses() {
-		// Each clause gets its own environment and template, since each has
-		// independent parameters and body. This is similar to compiling separate lambdas.
 		lenv := environment.NewLocalEnvironment(0)
 		tpl := NewNativeTemplate(0, 0, false)
 
-		// Bind parameters for this clause. The parameter list determines which
-		// argument counts this clause will match at runtime.
-		if clause.Params() != nil {
-			// Bind required parameters, same as in compileClosure.
-			for _, paramSym := range clause.Params().Required {
-				param := p.env.InternSymbol(paramSym.Sym)
-				paramScopes := paramSym.Scopes()
-				_, ok := lenv.EnsureLocalBinding(param, environment.BindingTypeVariable)
-				if !ok {
-					return values.WrapForeignErrorf(values.ErrDuplicateBinding, "duplicate parameter %q in case-lambda clause", param.Key)
-				}
-				// Preserve hygiene scopes for macro-introduced parameters.
-				setScopesOnLastBinding(paramScopes, lenv)
-				tpl.parameterCount++
-			}
-
-			// Bind rest parameter if present. A clause with rest parameter like
-			// ((x . rest) ...) matches 1 or more arguments.
-			err := bindRestParameter(clause, p, lenv, tpl)
-			if err != nil {
-				return err
-			}
-		}
-		// Note: clause.Params() == nil represents a clause that takes no arguments: (() ...)
-
-		// Create the child environment after all lenv mutations are complete.
-		childEnv := environment.NewEnvironmentFrameWithParent(lenv, p.env)
-
-		// Register the clause's template and environment in the literals pool.
-		tpli := p.template.MaybeAppendLiteral(tpl)
-		envi := p.template.MaybeAppendLiteral(childEnv)
-
-		// Compile the clause body into its template.
-		err := p.compileBody(ctctx, clause, childEnv, tpl)
+		tpli, envi, err := p.compileClosureBody(ctctx, tpl, lenv, clause, "case-lambda clause")
 		if err != nil {
 			return err
 		}
 
-		// Peephole optimization — same as compileClosure Phase 4b.
-		tpl.Optimize()
-
-		// Escape analysis — same as compileClosure Phase 4c.
-		// TODO: the no-copy path reuses the closure's own EnvironmentFrame,
-		// which is unsafe if the same closure is invoked concurrently from
-		// multiple SRFI-18 threads. This applies to both compileClosure and
-		// case-lambda clauses. Investigate a thread-aware guard (e.g., disable
-		// no-copy when the Engine has threads enabled, or track an in-use flag
-		// on MachineClosure).
-		tpl.computeNoCopyApply()
-
-		// Emit bytecode to construct this clause's closure and push it to the stack.
-		// After processing all clauses, the stack will contain [clause0, clause1, ...].
 		p.AppendOperations(
 			NewOperationLoadLiteralByLiteralIndexImmediate(tpli),
 			NewOperationPush(),
 			NewOperationLoadLiteralByLiteralIndexImmediate(envi),
 			NewOperationPush(),
 			NewOperationMakeClosure(),
-			NewOperationPush(), // Push this closure to stack (unlike regular lambda)
+			NewOperationPush(),
 		)
 	}
 
@@ -744,20 +709,7 @@ func (p *CompileTimeContinuation) CompileValidatedBegin(ctctx CompileTimeCallCon
 	}
 
 	// Pass 2: Compile each expression in sequence
-	for i, expr := range v.Body() {
-		isLast := i == len(v.Body())-1
-		exprCtx := ctctx.NotInTail()
-		if isLast {
-			exprCtx = ctctx
-		}
-
-		err := p.compileValidated(exprCtx, expr)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return p.compileValidatedSequence(ctctx, v.Body())
 }
 
 // compileValidatedCall compiles a validated function call (proc args...).

--- a/machine/import_set_datum.go
+++ b/machine/import_set_datum.go
@@ -55,8 +55,14 @@ func ParseLibraryNameFromDatum(ctx context.Context, expr values.Value) (LibraryN
 	return NewLibraryName(parts...), nil
 }
 
-// ParseImportSetFromDatum parses an import set from a datum value.
+// ParseImportSetFromDatum parses an import set from datum values (runtime).
 // This is for runtime use by the 'environment' procedure.
+//
+// A parallel set of functions exists in compile_time_continuation_library.go
+// operating on *syntax.SyntaxPair for compile-time parsing. The two families
+// are structurally identical but use different accessor methods due to the
+// syntax/datum phase boundary. Changes here should be mirrored there.
+//
 // Import sets can be:
 //   - (<library-name>)              : import all exports
 //   - (only <import-set> <id> ...)  : import only specified identifiers

--- a/machine/named_handler_base.go
+++ b/machine/named_handler_base.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+// namedHandlerBase provides shared Name, IsVoid, and SchemeString
+// implementations for named compile-time handlers stored as values.Value
+// in the environment (SyntaxCompiler, PrimitiveExpander).
+type namedHandlerBase struct {
+	name   string
+	prefix string
+}
+
+// Name returns the handler's name.
+func (p *namedHandlerBase) Name() string {
+	return p.name
+}
+
+// IsVoid returns false — named handlers are never void.
+func (p *namedHandlerBase) IsVoid() bool {
+	return false
+}
+
+// SchemeString returns the Scheme representation: #<prefix:name>.
+func (p *namedHandlerBase) SchemeString() string {
+	return "#<" + p.prefix + ":" + p.name + ">"
+}

--- a/machine/primitive_expander.go
+++ b/machine/primitive_expander.go
@@ -38,18 +38,16 @@ type PrimitiveExpanderFunc func(
 // PrimitiveExpander wraps a PrimitiveExpanderFunc as a values.Value so it can
 // be stored in the environment.
 type PrimitiveExpander struct {
-	name string
-	fn   PrimitiveExpanderFunc
+	namedHandlerBase
+	fn PrimitiveExpanderFunc
 }
 
 // NewPrimitiveExpander creates a new primitive expander.
 func NewPrimitiveExpander(name string, fn PrimitiveExpanderFunc) *PrimitiveExpander {
-	return &PrimitiveExpander{name: name, fn: fn}
-}
-
-// Name returns the name of this primitive expander.
-func (p *PrimitiveExpander) Name() string {
-	return p.name
+	return &PrimitiveExpander{
+		namedHandlerBase: namedHandlerBase{name: name, prefix: "primitive-expander"},
+		fn:               fn,
+	}
 }
 
 // Expand invokes the primitive expander function.
@@ -59,16 +57,6 @@ func (p *PrimitiveExpander) Expand(
 	expr syntax.SyntaxValue,
 ) (syntax.SyntaxValue, error) {
 	return p.fn(etc, sym, expr)
-}
-
-// SchemeString implements values.Value interface.
-func (p *PrimitiveExpander) SchemeString() string {
-	return "#<primitive-expander:" + p.name + ">"
-}
-
-// IsVoid implements values.Value interface.
-func (p *PrimitiveExpander) IsVoid() bool {
-	return false
 }
 
 // EqualTo implements values.Value interface.

--- a/machine/syntax_compiler.go
+++ b/machine/syntax_compiler.go
@@ -34,33 +34,21 @@ type SyntaxCompilerFunc func(ctc *CompileTimeContinuation, ctctx CompileTimeCall
 // SyntaxCompiler wraps a SyntaxCompilerFunc as a values.Value so it can
 // be stored in the environment.
 type SyntaxCompiler struct {
-	name string
-	fn   SyntaxCompilerFunc
+	namedHandlerBase
+	fn SyntaxCompilerFunc
 }
 
 // NewSyntaxCompiler creates a new syntax compiler.
 func NewSyntaxCompiler(name string, fn SyntaxCompilerFunc) *SyntaxCompiler {
-	return &SyntaxCompiler{name: name, fn: fn}
-}
-
-// Name returns the name of this syntax compiler.
-func (p *SyntaxCompiler) Name() string {
-	return p.name
+	return &SyntaxCompiler{
+		namedHandlerBase: namedHandlerBase{name: name, prefix: "syntax-compiler"},
+		fn:               fn,
+	}
 }
 
 // Compile invokes the syntax compiler function.
 func (p *SyntaxCompiler) Compile(ctc *CompileTimeContinuation, ctctx CompileTimeCallContext, expr syntax.SyntaxValue) error {
 	return p.fn(ctc, ctctx, expr)
-}
-
-// SchemeString implements values.Value interface.
-func (p *SyntaxCompiler) SchemeString() string {
-	return "#<syntax-compiler:" + p.name + ">"
-}
-
-// IsVoid implements values.Value interface.
-func (p *SyntaxCompiler) IsVoid() bool {
-	return false
 }
 
 // EqualTo implements values.Value interface.


### PR DESCRIPTION
## Summary

- Collapse `patchBranchOnFalseValueOffset`/`patchBranchOffset` into `patchBranchTarget`; remove `isBranchOnFalseValue` dispatch field
- Extract `executeFormsAtCompileTime` helper from `evalWhenExecuteAtCompileTime` and `CompileBeginForSyntax`
- Extract `compileValidatedSequence` for the "last in tail position" loop used by `CompileValidatedBegin` and `compileBody`
- Extract `compileClosureBody` from `compileClosure` and `CompileValidatedCaseLambda` — eliminates duplicated parameter binding loop
- Embed `namedHandlerBase` in `SyntaxCompiler` and `PrimitiveExpander` for shared `Name`/`IsVoid`/`SchemeString`
- Add `makeStringCaser` factory for `string-upcase`/`string-downcase`/`string-foldcase`
- Fix 2 `Cdr()`/`SyntaxCdr()` inconsistencies in import set parsers; add cross-reference comments

13 files changed, 217 insertions, 308 deletions.

Design doc: `plans/CROSS_CUTTING_CONSOLIDATION_T2.md`

## Test plan
- [x] `go test ./...` — all unit tests pass
- [x] Full suite run after `compileClosureBody` extraction (touches closure compilation)
- [x] `goimports` applied to all changed files