### PR TITLE
refactor: migrate *wile.Error to sentinel+wrap pattern

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -114,12 +114,12 @@ func NewEngine(ctx context.Context, opts ...EngineOption) (*Engine, error) {
 	// Register syntax compilers and primitive expanders
 	err = machine.RegisterSyntaxCompilers(env)
 	if err != nil {
-		return nil, &Error{Message: "failed to register syntax compilers", Cause: err}
+		return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, err, "failed to register syntax compilers")
 	}
 
 	err = machine.RegisterPrimitiveExpanders(env)
 	if err != nil {
-		return nil, &Error{Message: "failed to register primitive expanders", Cause: err}
+		return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, err, "failed to register primitive expanders")
 	}
 
 	// Load bootstrap macros
@@ -156,14 +156,16 @@ func NewEngine(ctx context.Context, opts ...EngineOption) (*Engine, error) {
 				parts = []string{"wile", snap.name}
 			}
 			if slices.Contains(parts, "") {
-				return nil, &Error{
-					Message: fmt.Sprintf("invalid library name for extension %q: empty name part", snap.name),
-				}
+				return nil, values.WrapForeignErrorf(
+					values.ErrEngineInit,
+					"invalid library name for extension %q: empty name part", snap.name,
+				)
 			}
 			if len(parts) == 0 {
-				return nil, &Error{
-					Message: fmt.Sprintf("invalid library name for extension %q: no name parts", snap.name),
-				}
+				return nil, values.WrapForeignErrorf(
+					values.ErrEngineInit,
+					"invalid library name for extension %q: no name parts", snap.name,
+				)
 			}
 
 			libName := machine.NewLibraryName(parts...)
@@ -173,7 +175,7 @@ func NewEngine(ctx context.Context, opts ...EngineOption) (*Engine, error) {
 			}
 			regErr := libReg.Register(lib)
 			if regErr != nil {
-				return nil, &Error{Message: "failed to register extension library", Cause: regErr}
+				return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, regErr, "failed to register extension library")
 			}
 		}
 
@@ -182,29 +184,29 @@ func NewEngine(ctx context.Context, opts ...EngineOption) (*Engine, error) {
 		topLevel.SetLibraryEnvFactory(func(ctx context.Context, callerEnv *environment.EnvironmentFrame) (*environment.EnvironmentFrame, error) {
 			callerTopLevel := callerEnv.TopLevelEnv()
 			if callerTopLevel == nil {
-				return nil, &Error{Message: "library env factory: caller has no TopLevelEnvironment"}
+				return nil, values.WrapForeignErrorf(values.ErrEngineInit, "library env factory: caller has no TopLevelEnvironment")
 			}
 
 			libEnv := callerTopLevel.NewChildRuntime()
 
 			applyErr := reg.Apply(ctx, libEnv)
 			if applyErr != nil {
-				return nil, &Error{Message: "library env factory: failed to apply registry", Cause: applyErr}
+				return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, applyErr, "library env factory: failed to apply registry")
 			}
 
 			applyErr = machine.RegisterSyntaxCompilers(libEnv)
 			if applyErr != nil {
-				return nil, &Error{Message: "library env factory: failed to register syntax compilers", Cause: applyErr}
+				return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, applyErr, "library env factory: failed to register syntax compilers")
 			}
 
 			applyErr = machine.RegisterPrimitiveExpanders(libEnv)
 			if applyErr != nil {
-				return nil, &Error{Message: "library env factory: failed to register primitive expanders", Cause: applyErr}
+				return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, applyErr, "library env factory: failed to register primitive expanders")
 			}
 
 			applyErr = loadBootstrapMacros(ctx, libEnv, macroSources)
 			if applyErr != nil {
-				return nil, &Error{Message: "library env factory: failed to load bootstrap macros", Cause: applyErr}
+				return nil, values.WrapForeignErrorWithCause(values.ErrEngineInit, applyErr, "library env factory: failed to load bootstrap macros")
 			}
 
 			return libEnv, nil

--- a/error.go
+++ b/error.go
@@ -20,23 +20,6 @@ import (
 	"strings"
 )
 
-// Error represents a Wile engine error, including initialization failures.
-type Error struct {
-	Message string
-	Cause   error
-}
-
-func (p *Error) Error() string {
-	if p.Cause != nil {
-		return p.Message + ": " + p.Cause.Error()
-	}
-	return p.Message
-}
-
-func (p *Error) Unwrap() error {
-	return p.Cause
-}
-
 // CompilationError wraps errors from parsing, expanding, or compiling Scheme code.
 type CompilationError struct {
 	Message string

--- a/ffi.go
+++ b/ffi.go
@@ -72,15 +72,17 @@ func analyzeReturnShape(fnType reflect.Type, errPrefix string) (returnShape, err
 		return returnShape{valueType: fnType.Out(0)}, nil
 	case 2:
 		if fnType.Out(1) != errorType {
-			return returnShape{}, &Error{
-				Message: fmt.Sprintf("%s: second return value must be error, got %s", errPrefix, fnType.Out(1)),
-			}
+			return returnShape{}, values.WrapForeignErrorf(
+				values.ErrFFIRegistration,
+				"%s: second return value must be error, got %s", errPrefix, fnType.Out(1),
+			)
 		}
 		return returnShape{hasError: true, valueType: fnType.Out(0)}, nil
 	default:
-		return returnShape{}, &Error{
-			Message: fmt.Sprintf("%s: too many return values (%d), maximum is 2", errPrefix, numOut),
-		}
+		return returnShape{}, values.WrapForeignErrorf(
+			values.ErrFFIRegistration,
+			"%s: too many return values (%d), maximum is 2", errPrefix, numOut,
+		)
 	}
 }
 
@@ -134,7 +136,7 @@ type ffiSpec struct {
 // callback for later invocation or calling it from another goroutine is
 // unsafe — the closure captures VM state that is not goroutine-safe.
 //
-// Returns a *[Error] if fn is not a function or uses unsupported types.
+// Returns an error wrapping [values.ErrFFIRegistration] if fn is not a function or uses unsupported types.
 func (p *Engine) RegisterFunc(name string, fn any) error {
 	spec, err := buildFFISpec(name, fn)
 	if err != nil {
@@ -174,7 +176,7 @@ func (p *Engine) RegisterFuncs(funcs map[string]any) error {
 func buildFFISpec(name string, fn any) (*ffiSpec, error) {
 	fnType := reflect.TypeOf(fn)
 	if fnType == nil || fnType.Kind() != reflect.Func {
-		return nil, &Error{Message: fmt.Sprintf("RegisterFunc %q: not a function", name)}
+		return nil, values.WrapForeignErrorf(values.ErrFFIRegistration, "RegisterFunc %q: not a function", name)
 	}
 
 	spec := &ffiSpec{
@@ -193,9 +195,10 @@ func buildFFISpec(name string, fn any) (*ffiSpec, error) {
 	// Validate no context.Context in non-first position.
 	for i := paramStart; i < fnType.NumIn(); i++ {
 		if fnType.In(i) == contextType {
-			return nil, &Error{
-				Message: fmt.Sprintf("RegisterFunc %q: context.Context must be first parameter", name),
-			}
+			return nil, values.WrapForeignErrorf(
+				values.ErrFFIRegistration,
+				"RegisterFunc %q: context.Context must be first parameter", name,
+			)
 		}
 	}
 
@@ -350,9 +353,10 @@ func makeArgConverter(name string, pos int, t reflect.Type) (argConverter, error
 		return makeCallbackArgConverter(name, pos, t)
 
 	default:
-		return nil, &Error{
-			Message: fmt.Sprintf("RegisterFunc %q: unsupported parameter type at position %d: %s", name, pos, t),
-		}
+		return nil, values.WrapForeignErrorf(
+			values.ErrFFIRegistration,
+			"RegisterFunc %q: unsupported parameter type at position %d: %s", name, pos, t,
+		)
 	}
 }
 
@@ -409,9 +413,10 @@ func makeMapArgConverter(name string, pos int, t reflect.Type) (argConverter, er
 
 	// Validate key type at registration time.
 	if !isSupportedMapKeyType(keyType) {
-		return nil, &Error{
-			Message: fmt.Sprintf("RegisterFunc %q: unsupported map key type at position %d: %s (must be string, int64, int, or bool)", name, pos, keyType),
-		}
+		return nil, values.WrapForeignErrorf(
+			values.ErrFFIRegistration,
+			"RegisterFunc %q: unsupported map key type at position %d: %s (must be string, int64, int, or bool)", name, pos, keyType,
+		)
 	}
 
 	keyConv, err := makeArgConverter(name, pos, keyType)
@@ -547,9 +552,10 @@ func makeCallbackArgConverter(name string, pos int, t reflect.Type) (argConverte
 	for i := range numIn {
 		conv, err := makeRetConverter(name, t.In(i))
 		if err != nil {
-			return nil, &Error{
-				Message: fmt.Sprintf("RegisterFunc %q: unsupported callback parameter type at position %d: %s", name, pos, t.In(i)),
-			}
+			return nil, values.WrapForeignErrorf(
+				values.ErrFFIRegistration,
+				"RegisterFunc %q: unsupported callback parameter type at position %d: %s", name, pos, t.In(i),
+			)
 		}
 		paramConvs[i] = conv
 	}
@@ -792,9 +798,10 @@ func makeRetConverter(name string, t reflect.Type) (retConverter, error) {
 		return makeStructRetConverter(name, t)
 
 	default:
-		return nil, &Error{
-			Message: fmt.Sprintf("RegisterFunc %q: unsupported return type: %s", name, t),
-		}
+		return nil, values.WrapForeignErrorf(
+			values.ErrFFIRegistration,
+			"RegisterFunc %q: unsupported return type: %s", name, t,
+		)
 	}
 }
 
@@ -834,9 +841,10 @@ func makeSliceRetConverter(name string, t reflect.Type) (retConverter, error) {
 func makeMapRetConverter(name string, t reflect.Type) (retConverter, error) {
 	keyType := t.Key()
 	if !isSupportedMapKeyType(keyType) {
-		return nil, &Error{
-			Message: fmt.Sprintf("RegisterFunc %q: unsupported map key type in return: %s (must be string, int64, int, or bool)", name, keyType),
-		}
+		return nil, values.WrapForeignErrorf(
+			values.ErrFFIRegistration,
+			"RegisterFunc %q: unsupported map key type in return: %s (must be string, int64, int, or bool)", name, keyType,
+		)
 	}
 
 	keyConv, err := makeRetConverter(name, t.Key())

--- a/ffi_test.go
+++ b/ffi_test.go
@@ -75,9 +75,8 @@ func TestRegisterFuncValidation(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error")
 			}
-			var wileErr *wile.Error
-			if !errors.As(err, &wileErr) {
-				t.Fatalf("expected *wile.Error, got %T", err)
+			if !errors.Is(err, values.ErrFFIRegistration) {
+				t.Fatalf("expected ErrFFIRegistration, got %T: %v", err, err)
 			}
 		})
 	}
@@ -1312,9 +1311,8 @@ func TestRegisterFuncsFailFast(t *testing.T) {
 		t.Fatal("expected error from RegisterFuncs with non-function value")
 	}
 
-	var wileErr *wile.Error
-	if !errors.As(err, &wileErr) {
-		t.Fatalf("expected *wile.Error, got %T", err)
+	if !errors.Is(err, values.ErrFFIRegistration) {
+		t.Fatalf("expected ErrFFIRegistration, got %T: %v", err, err)
 	}
 	if !strings.Contains(err.Error(), "bad") {
 		t.Errorf("expected error to mention binding name %q, got: %v", "bad", err)

--- a/values/CLAUDE.md
+++ b/values/CLAUDE.md
@@ -51,7 +51,6 @@ Never wrap with empty messages (`WrapForeignErrorf(err, "")` produces `": underl
 
 | Type | When to use | Where defined |
 |------|------------|---------------|
-| `*wile.Error` | Engine initialization failures | `error.go` |
 | `*wile.CompilationError` | Parse, expand, compile failures | `error.go` |
 | `*wile.RuntimeError` | Execution failures, Scheme exceptions | `error.go` |
 | `*machine.SchemeError` | Internal VM errors with source location | `machine/scheme_error.go` |

--- a/values/foreign_error.go
+++ b/values/foreign_error.go
@@ -113,9 +113,13 @@ var (
 	ErrImmutableString       = NewStaticError("cannot mutate immutable string")
 
 	// FFI errors
+	ErrFFIRegistration          = NewStaticError("FFI registration error")
 	ErrFFICallbackError         = NewStaticError("FFI callback error")
 	ErrCallbackResultConversion = NewStaticError("callback result conversion failed")
 	ErrHashtableInsertionFailed = NewStaticError("hashtable insertion failed")
+
+	// Engine initialization errors
+	ErrEngineInit = NewStaticError("engine initialization error")
 
 	// Environment errors (keep as panics but use sentinels)
 	ErrMissingTopLevelEnvironment = NewStaticError("missing TopLevelEnvironment")

--- a/wile_test.go
+++ b/wile_test.go
@@ -277,32 +277,6 @@ func TestEngine_TopLevelEnvironment(t *testing.T) {
 	c.Assert(engine.TopLevelEnvironment(), qt.IsNotNil)
 }
 
-// Error type
-
-func TestError_Error(t *testing.T) {
-	c := qt.New(t)
-
-	t.Run("with cause", func(t *testing.T) {
-		e := &Error{Message: "failed", Cause: errors.New("bad input")}
-		c.Assert(e.Error(), qt.Equals, "failed: bad input")
-	})
-
-	t.Run("without cause", func(t *testing.T) {
-		e := &Error{Message: "failed"}
-		c.Assert(e.Error(), qt.Equals, "failed")
-	})
-}
-
-func TestError_Unwrap(t *testing.T) {
-	c := qt.New(t)
-	cause := errors.New("root cause")
-	e := &Error{Message: "wrapper", Cause: cause}
-	c.Assert(e.Unwrap(), qt.Equals, cause)
-
-	e2 := &Error{Message: "no cause"}
-	c.Assert(e2.Unwrap(), qt.IsNil)
-}
-
 // CompiledCode.String
 
 func TestCompiledCode_String(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove legacy `*wile.Error` struct, replacing all 19 construction sites with `WrapForeignErrorf`/`WrapForeignErrorWithCause`
- Add two new sentinels: `ErrFFIRegistration` (9 sites in `ffi.go`) and `ErrEngineInit` (10 sites in `engine.go`)
- Callers can now use `errors.Is(err, values.ErrFFIRegistration)` instead of `errors.As(err, &wileErr)` which matched all `*Error` values indiscriminately
- Errors now carry stack traces via `ForeignError`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Zero lint issues (`make lint`)
- [x] `grep -rn '&Error{' *.go` returns zero hits in wile package root
- [x] `grep -rn 'wile.Error' .` returns zero hits