### PR TITLE
feat(cli): add shebang support and R7RS (command-line) args

### DIFF
--- a/cmd/scheme/main.go
+++ b/cmd/scheme/main.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 
 	"github.com/aalpar/wile/environment"
+	"github.com/aalpar/wile/extensions/system"
 	"github.com/aalpar/wile/internal/bootstrap"
 	"github.com/aalpar/wile/internal/parser"
 	"github.com/aalpar/wile/internal/repl"
@@ -151,7 +152,7 @@ func setupSignals(quiet bool) {
 }
 
 func main() {
-	var fin io.RuneReader
+	var fin *bufio.Reader
 
 	parser := flags.NewParser(&opts, flags.Default)
 	parser.Name = "scheme"
@@ -172,9 +173,26 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Handle positional argument as file if --file not specified
+	// Handle positional argument as file if --file not specified.
+	// Remaining positional args after the filename are script arguments.
+	// positionalFile tracks whether the file came from a positional arg
+	// (i.e. shebang execution context) vs -f flag (pure Scheme source).
+	var scriptArgs []string
+	positionalFile := false
 	if len(opts.File) == 0 && len(args) > 0 {
 		opts.File = append(opts.File, args[0])
+		scriptArgs = args[1:]
+		positionalFile = true
+	} else {
+		scriptArgs = args
+	}
+
+	// Set (command-line) to [script-name, script-args...] per R7RS §6.14
+	if len(opts.File) > 0 {
+		cmdLine := make([]string, 0, 1+len(scriptArgs))
+		cmdLine = append(cmdLine, opts.File[len(opts.File)-1])
+		cmdLine = append(cmdLine, scriptArgs...)
+		system.SetCommandLine(cmdLine)
 	}
 
 	// CPU profiling
@@ -232,7 +250,7 @@ func main() {
 				} else {
 					// Run last file (print results) and exit in non-interactive mode
 					fin = bufio.NewReader(fd)
-					runFile(ctx, env, fin, fn)
+					runFile(ctx, env, fin, fn, positionalFile)
 				}
 			}(filename, descriptor)
 		}
@@ -263,7 +281,17 @@ func main() {
 // runFile processes a Scheme file, exiting on errors.
 // All top-level expressions are wrapped in a single (begin ...) form to enable
 // proper R7RS continuation semantics across expression boundaries.
-func runFile(ctx context.Context, env *environment.EnvironmentFrame, fin io.RuneReader, filename string) {
+// When shebang is true, a leading #! line is skipped if present.
+func runFile(ctx context.Context, env *environment.EnvironmentFrame, fin *bufio.Reader, filename string, shebang bool) {
+	// Skip shebang line: only for files executed as programs (positional arg),
+	// not for files loaded via -f which should be pure Scheme source.
+	if shebang {
+		peek, err := fin.Peek(2)
+		if err == nil && peek[0] == '#' && peek[1] == '!' {
+			_, _ = fin.ReadString('\n')
+		}
+	}
+
 	p := parser.NewParserWithFile(env, true, fin, filename)
 
 	// Collect all expressions from the file

--- a/cmd/scheme/main_test.go
+++ b/cmd/scheme/main_test.go
@@ -474,6 +474,53 @@ func TestRunFile(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 3b: Shebang and command-line argument tests
+// ---------------------------------------------------------------------------
+
+func TestShebang(t *testing.T) {
+	t.Run("shebang line skipped for positional arg", func(t *testing.T) {
+		c := qt.New(t)
+		path := writeTempScheme(t, "#!/usr/bin/env scheme\n(+ 1 2)")
+		result := runCLI(t, "-q", path)
+		c.Assert(result.exitCode, qt.Equals, 0)
+		c.Assert(result.stdout, qt.Equals, "3\n")
+	})
+
+	t.Run("shebang not skipped for -f flag", func(t *testing.T) {
+		c := qt.New(t)
+		path := writeTempScheme(t, "#!/usr/bin/env scheme\n(+ 1 2)")
+		result := runCLI(t, "-q", "-f", path)
+		// #! is not valid Scheme when fed via -f, so this should fail
+		c.Assert(result.exitCode, qt.Not(qt.Equals), 0)
+	})
+
+	t.Run("file without shebang still works as positional arg", func(t *testing.T) {
+		c := qt.New(t)
+		path := writeTempScheme(t, "(+ 10 20)")
+		result := runCLI(t, "-q", path)
+		c.Assert(result.exitCode, qt.Equals, 0)
+		c.Assert(result.stdout, qt.Equals, "30\n")
+	})
+
+	t.Run("shebang with script arguments via command-line", func(t *testing.T) {
+		c := qt.New(t)
+		path := writeTempScheme(t, "#!/usr/bin/env scheme\n(display (length (command-line)))\n(newline)")
+		result := runCLI(t, "-q", path, "arg1", "arg2")
+		c.Assert(result.exitCode, qt.Equals, 0)
+		// (command-line) returns (script-name arg1 arg2) => length 3
+		c.Assert(result.stdout, qt.Equals, "3\n")
+	})
+
+	t.Run("command-line first element is script name", func(t *testing.T) {
+		c := qt.New(t)
+		path := writeTempScheme(t, "#!/usr/bin/env scheme\n(display (car (command-line)))\n(newline)")
+		result := runCLI(t, "-q", path)
+		c.Assert(result.exitCode, qt.Equals, 0)
+		c.Assert(result.stdout, qt.Equals, path+"\n")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Phase 4: Error tests
 // ---------------------------------------------------------------------------
 

--- a/extensions/system/prim_system.go
+++ b/extensions/system/prim_system.go
@@ -27,10 +27,24 @@ import (
 // ProgramStartTime is used for current-jiffy to measure elapsed time.
 var ProgramStartTime = time.Now()
 
-// PrimCommandLine implements the (command-line) primitive.
-// Returns a list of command line arguments.
+// commandLineArgs holds the script-relative command-line arguments set by the CLI.
+// When set, PrimCommandLine returns these instead of os.Args.
+var commandLineArgs []string
+
+// SetCommandLine sets the command-line arguments returned by (command-line).
+// The first element should be the script name, followed by script arguments.
+func SetCommandLine(args []string) {
+	commandLineArgs = args
+}
+
+// PrimCommandLine implements the (command-line) primitive per R7RS §6.14.
+// Returns a list whose first element is the script name and the rest are
+// script arguments. Falls back to os.Args when no script is being executed.
 func PrimCommandLine(mc *machine.MachineContext) error {
-	args := os.Args
+	args := commandLineArgs
+	if args == nil {
+		args = os.Args
+	}
 	list := values.EmptyList
 	for i := len(args) - 1; i >= 0; i-- {
 		list = values.NewCons(values.NewString(args[i]), list)


### PR DESCRIPTION
## Summary
- Skip `#!` shebang lines for files executed as positional args (`scheme script.scm`), not for `-f` loaded files
- Forward script arguments to `(command-line)` per R7RS §6.14 instead of exposing raw `os.Args`
- Add `SetCommandLine` to `extensions/system` for CLI to configure script-relative args

## Test plan
- [x] Shebang line skipped for positional arg
- [x] Shebang NOT skipped for `-f` flag (fails as expected)
- [x] File without shebang still works as positional arg
- [x] Script arguments forwarded through `(command-line)` with correct length
- [x] Script name is first element of `(command-line)`
- [x] Existing CLI tests pass
- [x] Lint clean