### PR TITLE
refactor(environment): simplify PhaseRegistry struct fields

### DIFF
--- a/environment/phase_registry.go
+++ b/environment/phase_registry.go
@@ -43,10 +43,8 @@ const (
 type PhaseRegistry struct {
 	mu   sync.RWMutex
 	envs map[int]*EnvironmentFrame
-	// topLevelEnv is the owning TopLevelEnvironment (nil for legacy environments)
-	topLevelEnv *TopLevelEnvironment
-	// topLevelEnvFrm is the runtime (phase 0) environment frame
-	topLevelEnvFrm *EnvironmentFrame
+	// owner is the owning TopLevelEnvironment
+	owner *TopLevelEnvironment
 }
 
 // Get returns the environment for the given phase, or nil if not yet created.
@@ -89,14 +87,14 @@ func (p *PhaseRegistry) GetOrCreate(phase int) *EnvironmentFrame {
 func (p *PhaseRegistry) createPhaseEnv(phase int) *EnvironmentFrame {
 	// Create a new GlobalEnvironmentFrame for this phase.
 	global := NewGlobalEnvironmentFrame()
-	global.topLevel = p.topLevelEnv
+	global.topLevel = p.owner
 
 	q := &EnvironmentFrame{
-		parent:     p.topLevelEnvFrm, // Phase envs parent to runtime frame
+		parent:     p.envs[PhaseRuntime], // Phase envs parent to runtime frame
 		global:     global,
 		phaseLevel: phase,
 		phases:     p,
-		topLevel:   p.topLevelEnv,
+		topLevel:   p.owner,
 	}
 	return q
 }
@@ -116,11 +114,10 @@ func (p *PhaseRegistry) Phases() []int {
 
 // TopLevelFrame returns the runtime (phase 0) environment frame.
 func (p *PhaseRegistry) TopLevelFrame() *EnvironmentFrame {
-	return p.topLevelEnvFrm
+	return p.Get(PhaseRuntime)
 }
 
 // TopLevelEnv returns the owning TopLevelEnvironment.
-// Returns nil for legacy environments created without TopLevelEnvironment.
 func (p *PhaseRegistry) TopLevelEnv() *TopLevelEnvironment {
-	return p.topLevelEnv
+	return p.owner
 }

--- a/environment/top_level_environment.go
+++ b/environment/top_level_environment.go
@@ -443,9 +443,8 @@ func (p *TopLevelEnvironment) NewChildRuntime() *EnvironmentFrame {
 
 	// Create a new phase registry for the child
 	childPhases := &PhaseRegistry{
-		envs:           make(map[int]*EnvironmentFrame),
-		topLevelEnv:    p, // Share the TopLevelEnvironment
-		topLevelEnvFrm: runtime,
+		envs:  make(map[int]*EnvironmentFrame),
+		owner: p,
 	}
 	childPhases.envs[PhaseRuntime] = runtime
 	runtime.phases = childPhases
@@ -505,9 +504,8 @@ func newGlobalEnvironmentFrameWithTopLevel(topLevel *TopLevelEnvironment) *Globa
 // newPhaseRegistryWithTopLevel creates a new PhaseRegistry owned by the given TopLevelEnvironment.
 func newPhaseRegistryWithTopLevel(topLevel *TopLevelEnvironment) *PhaseRegistry {
 	q := &PhaseRegistry{
-		envs:           make(map[int]*EnvironmentFrame),
-		topLevelEnv:    topLevel,
-		topLevelEnvFrm: topLevel.runtime,
+		envs:  make(map[int]*EnvironmentFrame),
+		owner: topLevel,
 	}
 	// TopLevel is phase 0 (runtime)
 	q.envs[PhaseRuntime] = topLevel.runtime


### PR DESCRIPTION
## Summary

- Eliminate redundant `topLevelEnvFrm` field from `PhaseRegistry` — derive it from `envs[PhaseRuntime]` instead
- Rename `topLevelEnv` to `owner` for clarity
- Remove stale "nil for legacy environments" comment (all environments now require a `TopLevelEnvironment`)
- Net -5 lines

## Test plan

- [x] `go test ./environment/...` passes
- [x] `go build ./...` passes