### PR TITLE
fix(engine): preserve Callable type evidence, fix doc comment

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -318,15 +318,19 @@ func (p *Engine) Call(ctx context.Context, proc Value, args ...Value) (Value, er
 	}
 
 	// Reject non-procedures before entering the VM.
-	_, isCallable := callee.(values.Callable)
+	// Parameter and ComposableContinuation are both Callable but require
+	// special handling above — Parameter supports 0-arg get without the VM,
+	// and ComposableContinuation needs the winding stack. The general
+	// Callable path below handles closures and case-lambdas.
+	callable, isCallable := callee.(values.Callable)
 	if !isCallable {
 		return nil, &RuntimeError{Message: "not a procedure"}
 	}
 
-	return p.callCallable(ctx, callee, unwrappedArgs)
+	return p.callCallable(ctx, callable, unwrappedArgs)
 }
 
-func (p *Engine) callCallable(ctx context.Context, callable values.Value, args []values.Value) (Value, error) {
+func (p *Engine) callCallable(ctx context.Context, callable values.Callable, args []values.Value) (Value, error) {
 	tpl := machine.NewEmptyNativeTemplate()
 	cont := machine.NewMachineContinuation(nil, tpl, p.env)
 	mc := machine.NewMachineContext(ctx, cont)
@@ -426,7 +430,7 @@ func registerExtensionLibraries(reg *registry.Registry, env *environment.Environ
 
 // applyBaseEnvironment performs the four-step setup that every usable environment
 // requires: apply registry bindings, register syntax compilers, register primitive
-// expanders, and load bootstrap macros. Callers own error wrapping.
+// expanders, and load bootstrap macros. Each step wraps errors with ErrEngineInit.
 func applyBaseEnvironment(ctx context.Context, env *environment.EnvironmentFrame, reg *registry.Registry, macroSources []string) error {
 	err := reg.Apply(ctx, env)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `callCallable` now takes `values.Callable` instead of `values.Value`, eliminating boolean blindness where `Call()` proved `Callable` then discarded the type evidence
- Added comment explaining why `Parameter` and `ComposableContinuation` dispatch precedes the general `Callable` path (both implement `Callable` but need special handling)
- Fixed `applyBaseEnvironment` doc comment — claimed "callers own error wrapping" but the function wraps all four steps with `ErrEngineInit` itself

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./...` all pass