### PR TITLE
fix(engine): restore q naming, document conventions, minor cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,16 @@ Public API (embedders): `wile/`, `values/`, `registry/`. Internal: `internal/*`.
 
 After any Go code changes, run `make lint` (or at minimum `goimports -w` on changed files) before considering the task complete. Do not report completion with outstanding formatting or import issues.
 
+### Variable Naming Convention
+
+| Name | Role | Rationale |
+|------|------|-----------|
+| `p` | Method receiver (always) | Type is in the signature; role is clear from being a receiver. No need to name it after the type. Exception: compiler uses `c`. |
+| `q` | Primary return value | Assign `q` as early as possible so the reader can track "this is what gets returned" through the code flow. |
+| `err` | Error return value | Standard Go convention. |
+
+These names save mental space: `p` is always the receiver, `q` is always the result being built, `err` is always the error. No need to invent descriptive names for roles that are already clear from position.
+
 ### Error Handling (summary)
 
 Two-layer convention: **sentinel + wrap**. Use `values.NewStaticError` for sentinels, `values.WrapForeignErrorf` at return sites. Never use bare `errors.New` or `fmt.Errorf` in production code. Always use `errors.Is`/`errors.As`, never `==`/`!=`.

--- a/engine.go
+++ b/engine.go
@@ -160,14 +160,14 @@ func NewEngine(ctx context.Context, opts ...EngineOption) (*Engine, error) {
 		}
 	}
 
-	eng := &Engine{
+	q := &Engine{
 		topLevel:     topLevel,
 		env:          env,
 		registry:     reg,
 		closers:      closers,
 		maxCallDepth: cfg.maxCallDepth,
 	}
-	return eng, nil
+	return q, nil
 }
 
 // Eval parses, compiles, and executes Scheme code, returning the result.
@@ -525,10 +525,10 @@ func (p *Engine) wrapRuntimeError(err error) *RuntimeError {
 func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame, sources []string) error {
 	for _, source := range sources {
 		reader := strings.NewReader(source)
-		p := parser.NewParser(env, true, reader)
+		pr := parser.NewParser(env, true, reader)
 
 		for {
-			stx, err := p.ReadSyntax(ctx)
+			stx, err := pr.ReadSyntax(ctx)
 			if err != nil {
 				if isEOF(err) {
 					break
@@ -604,7 +604,8 @@ func (p *Engine) CurrentLoadDirectory() string {
 }
 
 // PushLoadPath pushes an absolute path onto the load path stack.
-// Returns an error if absPath is not absolute.
+// Returns an error if absPath is not absolute. When the library system
+// is not enabled (no WithLibraryPaths option), this is a silent no-op.
 //
 // Advanced embedders who need fine-grained control can use Push/Pop directly,
 // but most should use WithLoadPath for automatic cleanup.


### PR DESCRIPTION
## Summary

- Revert `eng` back to `q` — `q` is the project convention for primary return values (see CODING_STYLE.md)
- Add `p`/`q`/`err` naming convention summary to CLAUDE.md for quick reference
- Fix `PushLoadPath` doc: document silent no-op behavior when library system is not enabled
- Rename parser variable `p` to `pr` in `loadBootstrapMacros` to avoid shadowing the receiver convention

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./...` all pass