### PR TITLE
style(machine): expand single-line function definitions

### DIFF
--- a/machine/composable_continuation.go
+++ b/machine/composable_continuation.go
@@ -49,9 +49,17 @@ func NewComposableContinuation(cont *MachineContinuation, windingStack WindingSt
 	return q
 }
 
-func (p *ComposableContinuation) Cont() *MachineContinuation { return p.cont }
-func (p *ComposableContinuation) WindingStack() WindingStack { return p.windingStack }
-func (p *ComposableContinuation) ThreadID() uint64           { return p.threadID }
+func (p *ComposableContinuation) Cont() *MachineContinuation {
+	return p.cont
+}
+
+func (p *ComposableContinuation) WindingStack() WindingStack {
+	return p.windingStack
+}
+
+func (p *ComposableContinuation) ThreadID() uint64 {
+	return p.threadID
+}
 
 // BarrierValid returns the barrier identity token captured when this continuation
 // was created. Used by applyComposableContinuation to detect barrier crossings.
@@ -70,7 +78,9 @@ func (p *ComposableContinuation) SchemeString() string {
 	return "#<composable-continuation>"
 }
 
-func (p *ComposableContinuation) IsVoid() bool { return p == nil }
+func (p *ComposableContinuation) IsVoid() bool {
+	return p == nil
+}
 
 func (p *ComposableContinuation) EqualTo(o values.Value) bool {
 	v, ok := o.(*ComposableContinuation)

--- a/machine/machine_continuation.go
+++ b/machine/machine_continuation.go
@@ -145,11 +145,25 @@ func (p *MachineContinuation) Copy() *MachineContinuation {
 	return q
 }
 
-func (p *MachineContinuation) PromptTag() *PromptTag              { return p.promptTag }
-func (p *MachineContinuation) SetPromptTag(t *PromptTag)          { p.promptTag = t }
-func (p *MachineContinuation) PromptHandler() *MachineClosure     { return p.promptHandler }
-func (p *MachineContinuation) SetPromptHandler(h *MachineClosure) { p.promptHandler = h }
-func (p *MachineContinuation) ThreadID() uint64                   { return p.threadID }
+func (p *MachineContinuation) PromptTag() *PromptTag {
+	return p.promptTag
+}
+
+func (p *MachineContinuation) SetPromptTag(t *PromptTag) {
+	p.promptTag = t
+}
+
+func (p *MachineContinuation) PromptHandler() *MachineClosure {
+	return p.promptHandler
+}
+
+func (p *MachineContinuation) SetPromptHandler(h *MachineClosure) {
+	p.promptHandler = h
+}
+
+func (p *MachineContinuation) ThreadID() uint64 {
+	return p.threadID
+}
 
 // NewMachineContinuationWithPrompt creates a continuation frame that acts as
 // a continuation prompt. The tag identifies the prompt for abort/capture, and

--- a/machine/prompt_tag.go
+++ b/machine/prompt_tag.go
@@ -54,7 +54,9 @@ func (p *PromptTag) SchemeString() string {
 	return fmt.Sprintf("#<continuation-prompt-tag:%d>", p.id)
 }
 
-func (p *PromptTag) IsVoid() bool { return p == nil }
+func (p *PromptTag) IsVoid() bool {
+	return p == nil
+}
 
 func (p *PromptTag) EqualTo(o values.Value) bool {
 	v, ok := o.(*PromptTag)


### PR DESCRIPTION
## Summary

- Expanded single-line function definitions to multi-line form in three files: `machine/composable_continuation.go`, `machine/machine_continuation.go`, and `machine/prompt_tag.go`.
- Single-line accessor methods (getters, simple delegations) were the primary targets.
- Change enforces the project style rule: every function body must start on the line after the opening brace, with the closing brace on its own line — no exceptions.

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (pure style change, no behavioral delta)
- [ ] `make lint` passes