### PR TITLE
docs(plans): update stale status lines

### DIFF
--- a/plans/ALLOCATION_OPTIMIZATION.md
+++ b/plans/ALLOCATION_OPTIMIZATION.md
@@ -1,7 +1,7 @@
 # Allocation Optimization Plan
 
 Date: 2026-02-22
-Status: In progress — three optimizations complete (-42.1% combined), remaining items pending
+Status: Mostly complete — initial 3 fixes (-42.1%), plus block-allocated pairs (#311), numeric fold escape fix (#312), binding copy optimization (#313/#314), ArrayList removal (#316), unified Pool[T] with env frame pooling (#325), PopAll elimination, batch ctx.Done(), peephole fusion. Remaining: rest-arg cons elimination, compile-time global binding resolution.
 
 ## Problem Statement
 

--- a/plans/CLAUDE.md
+++ b/plans/CLAUDE.md
@@ -25,6 +25,12 @@ When investigating R7RS conformance issues:
 | `BREAKPOINT_INLINE_TRAPS.md` | Inline breakpoint traps — remove per-instruction debugger check from VM loop | Proposed |
 | `ER_MACRO_TRANSFORMER.md` | `er-macro-transformer` (explicit renaming macros) | Proposed |
 
+### Optimizations
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `OPTIMIZATIONS.md` | Index of all optimization files (plans, reference data, session plans) | Active |
+
 ### Proposed Designs (Future)
 
 | File | Purpose | Status |


### PR DESCRIPTION
## Summary
- Update ALLOCATION_OPTIMIZATION.md status to reflect all completed work
- Add OPTIMIZATIONS.md reference to plans/CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)