### PR TITLE
docs: add performance table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ result, _ := engine.Eval(ctx, "(* width height)")  // => 480000
 | Cross-compilation | ✓ | ✗ | ✓ | ✓ | ✗ |
 | Go GC integration | ✓ | ✗ | ✓ | ✓ | ✗ |
 
+### Performance
+
+Gabriel benchmark suite (16 benchmarks), showing improvement from allocation and dispatch optimizations:
+
+| Benchmark | v1.3.0 | v1.4.0 | Change |
+|-----------|-------:|-------:|-------:|
+| tak | 0.381s | 0.274s | -28% |
+| fib | 1.262s | 0.920s | -27% |
+| sumfp | 4.271s | 3.204s | -25% |
+| peval | 0.168s | 0.134s | -20% |
+| **Geo-mean (all 16)** | | | **-15%** |
+
+Full results and methodology in [examples/benchmarks/](examples/benchmarks/).
+
 ## Embedding in Go
 
 Wile provides a public API for embedding Scheme in Go programs via the `wile` package.


### PR DESCRIPTION
## Summary

- Add Gabriel benchmark highlights to README showing v1.3.0 → v1.4.0 improvements
- Top 4 benchmarks (tak -28%, fib -27%, sumfp -25%, peval -20%) plus -15% geo-mean
- Links to full results in examples/benchmarks/

## Test plan

- [x] `make check-readme-links` passes (new link to examples/benchmarks/ is valid)