### PR TITLE
fix: make arity errors catchable by Scheme exception handlers

### DIFF
--- a/machine/foreign_closure.go
+++ b/machine/foreign_closure.go
@@ -35,6 +35,26 @@ func goErrorToSchemeException(mc *MachineContext, err error) error {
 	}
 }
 
+// applyCallableError converts errors from ApplyCallable into Scheme
+// exceptions so they are catchable by guard and with-exception-handler.
+// Errors that are already Scheme-level control flow (exception escapes,
+// prompt aborts, exit escapes) pass through unchanged.
+func applyCallableError(mc *MachineContext, err error) error {
+	var excErr *ErrExceptionEscape
+	if errors.As(err, &excErr) {
+		return err
+	}
+	var abortErr *ErrPromptAbort
+	if errors.As(err, &abortErr) {
+		return err
+	}
+	var exitErr *ErrExitEscape
+	if errors.As(err, &exitErr) {
+		return err
+	}
+	return goErrorToSchemeException(mc, err)
+}
+
 var _ Closure = (*ForeignClosure)(nil)
 
 // ForeignClosure wraps a Go function as a directly-callable Scheme procedure.

--- a/machine/machine_context.go
+++ b/machine/machine_context.go
@@ -794,7 +794,7 @@ func (p *MachineContext) Run() error {
 			mc.counters.RecordStackDepth(len(vs))
 			result, err := mc.ApplyCallable(mc.GetValue(), vs...)
 			if err != nil {
-				return mc.WrapError(err, "")
+				return applyCallableError(mc, err)
 			}
 			mc = result
 
@@ -939,7 +939,7 @@ func (p *MachineContext) Run() error {
 			mc.counters.RecordStackDepth(len(vs))
 			result, err := mc.ApplyCallable(mc.GetValue(), vs...)
 			if err != nil {
-				return mc.WrapError(err, "")
+				return applyCallableError(mc, err)
 			}
 			mc = result
 


### PR DESCRIPTION
## Summary

- Arity violations, case-lambda mismatches, and not-a-procedure errors are now catchable by `guard` and `with-exception-handler`
- Previously these errors bypassed the Scheme exception system entirely — `OpApply` and `OpPullApply` used `WrapError` (Go-only error) instead of `goErrorToSchemeException`
- Adds `applyCallableError` helper that passes through existing Scheme control flow (`ErrExceptionEscape`, `ErrPromptAbort`, `ErrExitEscape`) and converts everything else to Scheme exceptions

**Before:**
```scheme
(guard (e (#t "caught")) (digit-value #\0 #\1))
;; => unhandled error, crashes to top level
```

**After:**
```scheme
(guard (e (#t "caught")) (digit-value #\0 #\1))
;; => "caught"
```

## Root cause

`OpApply` (machine_context.go:797) and `OpPullApply` (machine_context.go:942) called `mc.WrapError(err, "")` on errors from `ApplyCallable`. `WrapError` returns a `*SchemeError` — a Go error with source/trace info that exits `Run()` directly, never entering the Scheme exception handler chain.

Type errors from primitive bodies worked because `applyForeign` already calls `goErrorToSchemeException` at line 504 for errors from the function body. But arity errors are raised *before* the body runs (line 428), so they returned through `ApplyCallable` → `OpApply` → `WrapError` → raw Go error.

## Test plan

- [x] `go test ./...` — all pass
- [x] `guard` catches arity errors: `(guard (e (#t 'caught)) (digit-value #\0 #\1))`
- [x] `guard` catches case-lambda mismatches: `(guard (e (#t 'caught)) (f 1 2 3))`
- [x] `guard` catches not-a-procedure: `(guard (e (#t 'caught)) (42 1 2))`
- [x] `test-error` works for arity violations
- [x] `make test-scheme` passes
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)