### PR TITLE
test(control,macros): Scheme-domain control and macro tests

### DIFF
--- a/test/scheme/control-test.scm
+++ b/test/scheme/control-test.scm
@@ -1,0 +1,327 @@
+;;; control-test.scm - R7RS 6.10 Control features
+;;;
+;;; Edge cases and detailed coverage extracted from Go test suite:
+;;;   registry/core/prim_control_test.go
+;;; Complements the canonical R7RS tests in integration/testdata/r7rs-tests.scm.
+
+(import (scheme base)
+        (scheme write)
+        (chibi test))
+
+(test-begin "control")
+
+;; ── call/cc: basic ───────────────────────────────────────────────
+
+(test-group "call/cc basic"
+  ;; normal return (no escape)
+  (test 42 (call/cc (lambda (k) 42)))
+
+  ;; escape via continuation
+  (test 42 (call/cc (lambda (k) (k 42))))
+
+  ;; escape skips remaining computation
+  (test 11 (+ 1 (call/cc (lambda (k) (+ 2 (k 10))))))
+
+  ;; normal return continues surrounding computation
+  (test 11 (+ 1 (call/cc (lambda (k) 10))))
+
+  ;; call-with-current-continuation alias
+  (test 99 (call-with-current-continuation (lambda (k) (k 99))))
+
+  ;; call/cc inside nested function
+  (test 11
+    (let ()
+      (define (f) (+ 1 (call/cc (lambda (k) (k 10)))))
+      (f))))
+
+;; ── call/cc: multi-invoke ────────────────────────────────────────
+
+(test-group "call/cc multi-invoke"
+  ;; continuation invoked after call/cc returns
+  (test 2
+    (let ((k-saved #f))
+      (let ((result (call/cc (lambda (k) (set! k-saved k) 1))))
+        (if (= result 1)
+            (k-saved 2)
+            result))))
+
+  ;; continuation invoked multiple times
+  (test 3
+    (let ((k-saved #f) (count 0))
+      (let ((result (call/cc (lambda (k) (set! k-saved k) 'first))))
+        (set! count (+ count 1))
+        (if (< count 3)
+            (k-saved count)
+            count))))
+
+  ;; saved continuation invoked later with begin
+  (test 3
+    (begin
+      (define k-saved-ctrl #f)
+      (define count-ctrl 0)
+      (let ((result (call/cc (lambda (k) (set! k-saved-ctrl k) 'first))))
+        (set! count-ctrl (+ count-ctrl 1))
+        (if (< count-ctrl 3)
+            (k-saved-ctrl 'again)
+            count-ctrl)))))
+
+;; ── call/cc: with higher-order functions ─────────────────────────
+
+(test-group "call/cc with higher-order functions"
+  ;; escape from apply
+  (test 'big
+    (call/cc (lambda (return)
+      (apply (lambda (a b) (if (> b 5) (return 'big) (+ a b)))
+             '(1 10)))))
+
+  ;; escape from map
+  (test 'found
+    (call/cc (lambda (return)
+      (map (lambda (x) (if (> x 3) (return 'found) (* x x)))
+           '(1 2 3 4 5)))))
+
+  ;; no escape from map returns list
+  (test '(1 4 9)
+    (call/cc (lambda (return)
+      (map (lambda (x) (* x x)) '(1 2 3))))))
+
+;; ── call/cc: coroutines ──────────────────────────────────────────
+
+(test-group "call/cc coroutines"
+  ;; single coroutine yield and resume
+  ;; Output: "1 2 end" -- coroutine runs, yields, resumes, scheduler ends.
+  (test "1 2 end"
+    (let ((p (open-output-string)))
+      (define *queue* '())
+      (define (enqueue! thunk) (set! *queue* (append *queue* (list thunk))))
+      (define (dequeue!) (let ((n (car *queue*))) (set! *queue* (cdr *queue*)) n))
+      (define (scheduler-run) (if (not (null? *queue*)) ((dequeue!))))
+      (define (spawn thunk) (enqueue! (lambda () (thunk) (scheduler-run))))
+      (define (yield) (call/cc (lambda (k) (enqueue! (lambda () (k #f))) (scheduler-run))))
+
+      (spawn (lambda () (display "1 " p) (yield) (display "2 " p)))
+
+      (scheduler-run)
+      (display "end" p)
+      (get-output-string p)))
+
+  ;; Note: multi-coroutine tests are omitted here because continuation
+  ;; re-entry across Go-implemented primitives has known edge cases
+  ;; (see TestCallCCSubContextReentry in prim_control_test.go).
+  )
+
+;; ── apply ────────────────────────────────────────────────────────
+
+(test-group "apply"
+  ;; basic apply
+  (test 6 (apply + '(1 2 3)))
+
+  ;; apply with prefix args
+  (test 15 (apply + 1 2 '(3 4 5)))
+
+  ;; apply with many prefix args
+  (test 21 (apply + 1 2 3 4 '(5 6)))
+
+  ;; apply with empty final list
+  (test 6 (apply + 1 2 3 '()))
+
+  ;; apply with empty list (identity for +)
+  (test 0 (apply + '()))
+
+  ;; apply list constructor
+  (test '(1 2 3 4) (apply list 1 2 '(3 4))))
+
+(test-group "apply errors"
+  ;; non-list as final argument
+  (test-error (apply + 42))
+
+  ;; improper list as final argument
+  (test-error (apply + '(1 . 2))))
+
+;; ── apply with parameters ────────────────────────────────────────
+
+(test-group "apply with parameters"
+  ;; apply parameter get
+  (test 42
+    (let ((p (make-parameter 42)))
+      (apply p '())))
+
+  ;; apply parameter set then get
+  (test 99
+    (let ((p (make-parameter 0)))
+      (apply p '(99))
+      (p)))
+
+  ;; apply parameter with converter
+  (test 10
+    (let ((p (make-parameter 0 (lambda (x) (* x 2)))))
+      (apply p '(5))
+      (p))))
+
+;; ── values ───────────────────────────────────────────────────────
+
+(test-group "values"
+  ;; single value
+  (test 42 (values 42)))
+
+;; ── call-with-values ─────────────────────────────────────────────
+
+(test-group "call-with-values"
+  ;; single value producer
+  (test 84
+    (call-with-values (lambda () 42) (lambda (x) (* x 2))))
+
+  ;; multiple values: sum
+  (test 6
+    (call-with-values (lambda () (values 1 2 3))
+                      (lambda (a b c) (+ a b c))))
+
+  ;; consumer builds list
+  (test '(a b c)
+    (call-with-values (lambda () (values 'a 'b 'c)) list))
+
+  ;; no values producer
+  (test 'done
+    (call-with-values (lambda () (values)) (lambda () 'done)))
+
+  ;; single value passthrough
+  (test 42
+    (call-with-values (lambda () 42) (lambda (x) x)))
+
+  ;; two values
+  (test 3
+    (call-with-values (lambda () (values 1 2)) (lambda (x y) (+ x y))))
+
+  ;; three values
+  (test 6
+    (call-with-values (lambda () (values 1 2 3)) (lambda (a b c) (+ a b c)))))
+
+(test-group "call-with-values errors"
+  ;; exception in producer
+  (test-error (call-with-values (lambda () (error "fail")) (lambda (x) x)))
+
+  ;; exception in consumer
+  (test-error (call-with-values (lambda () 42) (lambda (x) (error "fail")))))
+
+;; ── map: multiple lists ──────────────────────────────────────────
+
+(test-group "map multiple lists"
+  ;; single list with lambda
+  (test '(2 4 6) (map (lambda (x) (* x 2)) '(1 2 3)))
+
+  ;; two lists with +
+  (test '(11 22 33) (map + '(1 2 3) '(10 20 30)))
+
+  ;; three lists
+  (test '(111 222 333)
+    (map (lambda (a b c) (+ a b c))
+         '(1 2 3) '(10 20 30) '(100 200 300)))
+
+  ;; map list constructor over two lists
+  (test '((a 1) (b 2) (c 3))
+    (map list '(a b c) '(1 2 3)))
+
+  ;; empty lists
+  (test '() (map + '() '()))
+
+  ;; unequal length lists (stops at shortest)
+  (test '(11 22) (map + '(1 2 3) '(10 20))))
+
+(test-group "map errors"
+  ;; exception in mapped procedure
+  (test-error (map (lambda (x) (if (= x 2) (error "boom") x)) '(1 2 3)))
+
+  ;; improper list argument
+  (test-error (map (lambda (x) x) '(1 . 2))))
+
+;; ── for-each: multiple lists ─────────────────────────────────────
+
+(test-group "for-each multiple lists"
+  ;; for-each with side effects
+  (test '(3 2 1)
+    (let ((result '()))
+      (for-each (lambda (x) (set! result (cons x result)))
+                '(1 2 3))
+      result))
+
+  ;; two lists
+  (test '(30 20 10)
+    (let ((result '()))
+      (for-each (lambda (x y)
+                  (set! result (cons (+ x y) result)))
+                '(1 2 3) '(9 18 27))
+      result))
+
+  ;; unequal length lists stops at shortest
+  (test 2
+    (let ((count 0))
+      (for-each (lambda (x y) (set! count (+ count 1)))
+                '(1 2 3) '(10 20))
+      count)))
+
+;; ── dynamic-wind ─────────────────────────────────────────────────
+
+(test-group "dynamic-wind basic"
+  ;; returns thunk result
+  (test 42
+    (dynamic-wind (lambda () 'before) (lambda () 42) (lambda () 'after)))
+
+  ;; before runs first (thunk sees before's mutation)
+  (test 1
+    (let ((v (make-vector 1 0)))
+      (dynamic-wind
+        (lambda () (vector-set! v 0 1))
+        (lambda () (vector-ref v 0))
+        (lambda () (vector-set! v 0 2)))))
+
+  ;; before/during/after ordering
+  (test '(after during before)
+    (let ((result '()))
+      (dynamic-wind
+        (lambda () (set! result (cons 'before result)))
+        (lambda () (set! result (cons 'during result)) 42)
+        (lambda () (set! result (cons 'after result))))
+      result)))
+
+(test-group "dynamic-wind with escape"
+  ;; escape returns correct value
+  (test 77
+    (call/cc (lambda (k)
+      (dynamic-wind
+        (lambda () #f)
+        (lambda () (k 77))
+        (lambda () #f)))))
+
+  ;; after thunk runs on escape
+  (test 2
+    (let ((v (make-vector 1 0)))
+      (call/cc (lambda (k)
+        (dynamic-wind
+          (lambda () (vector-set! v 0 1))
+          (lambda () (k 99))
+          (lambda () (vector-set! v 0 2)))))
+      (vector-ref v 0))))
+
+(test-group "dynamic-wind exception in thunks"
+  ;; exception in before thunk
+  (test-error
+    (dynamic-wind (lambda () (error "before-fail"))
+                  (lambda () 1)
+                  (lambda () 2)))
+
+  ;; exception in after thunk
+  (test-error
+    (dynamic-wind (lambda () #f)
+                  (lambda () 42)
+                  (lambda () (error "after-fail"))))
+
+  ;; after thunk runs on body exception
+  (test #t
+    (let ((after-ran #f))
+      (guard (e (#t after-ran))
+        (dynamic-wind
+          (lambda () #f)
+          (lambda () (error "body-fail"))
+          (lambda () (set! after-ran #t)))))))
+
+(test-end)

--- a/test/scheme/macros-test.scm
+++ b/test/scheme/macros-test.scm
@@ -1,0 +1,157 @@
+;;; macros-test.scm - R7RS 4.3 Macros
+;;;
+;;; Edge cases and detailed coverage extracted from Go test suites:
+;;;   machine/compile_syntax_rules_test.go
+;;;   machine/let_shadow_macro_test.go
+;;;   machine/hygiene_test.go
+;;; Complements the canonical R7RS tests in integration/testdata/r7rs-tests.scm.
+
+(import (scheme base)
+        (chibi test))
+
+(test-begin "macros")
+
+;; ── syntax-rules round-trip ──────────────────────────────────────
+;; These tests define a macro, then immediately use it and check the result.
+
+(test-group "syntax-rules round-trip"
+  ;; identity macro
+  (test 42
+    (let ()
+      (define-syntax m-id (syntax-rules () ((m-id x) x)))
+      (m-id 42)))
+
+  ;; rewrite with arithmetic
+  (test 11
+    (let ()
+      (define-syntax m-inc (syntax-rules () ((m-inc x) (+ x 1))))
+      (m-inc 10)))
+
+  ;; ellipsis capture
+  (test '(1 2 3)
+    (let ()
+      (define-syntax m-list (syntax-rules () ((m-list x ...) (list x ...))))
+      (m-list 1 2 3)))
+
+  ;; literals match
+  (test 42
+    (let ()
+      (define-syntax m-lit
+        (syntax-rules (lit)
+          ((m-lit lit x) x)
+          ((m-lit other x) (+ x 1))))
+      (m-lit lit 42)))
+
+  ;; literals non-match (second clause selected)
+  (test 11
+    (let ()
+      (define-syntax m-lit2
+        (syntax-rules (lit)
+          ((m-lit2 lit x) x)
+          ((m-lit2 other x) (+ x 1))))
+      (m-lit2 something 10)))
+
+  ;; multi-clause dispatch: zero args
+  (test 0
+    (let ()
+      (define-syntax m-multi
+        (syntax-rules ()
+          ((m-multi) 0)
+          ((m-multi x) x)
+          ((m-multi x y) (+ x y))))
+      (m-multi)))
+
+  ;; multi-clause dispatch: one arg
+  (test 7
+    (let ()
+      (define-syntax m-multi2
+        (syntax-rules ()
+          ((m-multi2) 0)
+          ((m-multi2 x) x)
+          ((m-multi2 x y) (+ x y))))
+      (m-multi2 7)))
+
+  ;; multi-clause dispatch: two args
+  (test 30
+    (let ()
+      (define-syntax m-multi3
+        (syntax-rules ()
+          ((m-multi3) 0)
+          ((m-multi3 x) x)
+          ((m-multi3 x y) (+ x y))))
+      (m-multi3 10 20)))
+
+  ;; custom ellipsis
+  (test '(1 2)
+    (let ()
+      (define-syntax m-cust (syntax-rules ::: () ((m-cust x :::) (list x :::))))
+      (m-cust 1 2)))
+
+  ;; nested pattern
+  (test 7
+    (let ()
+      (define-syntax m-nest (syntax-rules () ((m-nest (a b)) (+ a b))))
+      (m-nest (3 4))))
+
+  ;; ellipsis in literals disables ellipsis
+  (test 42
+    (let ()
+      (define-syntax m-elli-lit (syntax-rules ... () ((m-elli-lit x) x)))
+      (m-elli-lit 42))))
+
+;; ── let shadows macro ────────────────────────────────────────────
+;; R7RS 4.2.2: let bindings shadow outer bindings including macros.
+
+(test-group "let shadows macro"
+  ;; let shadows 'and' macro - use as value
+  (test 100 (let ((and 100)) and))
+
+  ;; let shadows 'or' macro - use as value
+  (test 200 (let ((or 200)) or))
+
+  ;; nested let shadows macro
+  (test 2 (let ((and 2)) (let ((x and)) x)))
+
+  ;; lambda parameter shadows 'and' macro
+  (test 123 ((lambda (and) and) 123))
+
+  ;; lambda parameter shadows 'or' macro
+  (test 51 ((lambda (or) (+ or 1)) 50))
+
+  ;; shadowed macro name can be used in arithmetic
+  (test 8 (let ((and 5)) (+ and 3)))
+
+  ;; macro still works when not shadowed - and
+  (test #t (let ((x 1)) (and #t #t)))
+
+  ;; macro still works when not shadowed - or
+  (test #t (let ((x 1)) (or #f #t)))
+
+  ;; shadow in inner let only
+  (test 11 (let ((x (and #t 10)))
+             (let ((and 1))
+               (+ x and)))))
+
+;; ── hygiene preserved with shadowing ─────────────────────────────
+;; Verify that the let-shadows-macro feature does not break hygiene.
+
+(test-group "hygiene preserved with shadowing"
+  ;; and macro still works correctly
+  (test 42 (and #t #t 42))
+
+  ;; or macro still works correctly
+  (test 99 (or #f #f 99))
+
+  ;; shadowed and doesn't affect outer scope
+  (test 10
+    (let ((result (and #t 10)))
+      (let ((and 1))
+        result)))
+
+  ;; let macro expands correctly with shadowed variable
+  (test 5
+    (let ((x 5))
+      (let ((and x))
+        and))))
+
+(test-end)


### PR DESCRIPTION
## Summary

- Add `test/scheme/control-test.scm` — ~53 test groups (327 lines) covering call/cc (basic, multi-invoke, higher-order, coroutines), apply (with prefix args, parameters), values/call-with-values, map/for-each with multiple lists, dynamic-wind (ordering, escape, exceptions), and error conditions
- Add `test/scheme/macros-test.scm` — ~23 test groups (157 lines) covering syntax-rules round-trip (identity, ellipsis, literals, multi-clause, custom ellipsis, nested patterns), let-binding macro shadowing, and hygiene preservation

Final PR in the series per `plans/SCHEME_TEST_EXPANSION.md` (sections 9 and 10).

## Test plan

- [x] `make test-scheme` passes (11 test files, all pass)
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)