### PR TITLE
docs: mark Scheme test expansion complete, update TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 TODO
 ----
 
-**Last Updated**: 2026-02-22
+**Last Updated**: 2026-02-25
 
 ### Current Project Status
 
@@ -9,7 +9,7 @@ TODO
 **Core Language**: R7RS-small complete with hygienic macros, composable continuations, numeric tower
 **Extensions**: 9 extension packages — 6 public (files, math, system, threads, exceptions, gointerop), 3 internal (io, eval, all); all importable as R7RS `(wile <name>)` libraries
 **Examples**: 73 examples across 12 categories, 21 Gabriel benchmarks, Schelog
-**Tests**: Go test suite comprehensive; Scheme test infrastructure exists but needs content
+**Tests**: Go test suite comprehensive; Scheme test suite: 3,187 lines across 11 files (strings, characters, ports, numbers, exceptions, lazy, records, eval, control, macros) + 915-test R7RS conformance suite
 **Libraries**: (chibi test), (chibi optional), (chibi diff), (chibi term ansi), (srfi 1) complete
 
 ### Summary
@@ -18,7 +18,7 @@ Items are ordered by priority: P1 (core adoption blockers), P2 (growth enablers)
 
 | Priority | Item | Category | Status | Notes |
 |----------|------|----------|--------|-------|
-| P1 | Unit testing library | Standard library | Partial | `(chibi test)` exists, infrastructure in `test/`, needs content |
+| P1 | Unit testing library | Standard library | **Done** | 11 test files (3,187 lines) extracted from Go suite. `plans/SCHEME_TEST_EXPANSION.md` |
 | P2 | Performance refactoring Phase 7 | Performance | Deferred | Phases 0–6 complete (shipped in v1.4.0). Peephole optimizer shipped (PR #309): fused opcodes + MakeClosure promotion → **~4% geomean improvement**. Phase 7 (tagged integers, compilation caching, library pre-compilation) deferred |
 | P4 | Go FFI Phase 3 — Plugin support | Embedding | Not started | Dynamic extension loading via registry. Note: `ApplyContext` removed in v1.4.0; `InitFunc` now takes `*registry.Registry` directly |
 | P4 | Environment introspection | Feature | Planned | Read-only primitives (`environment?`, `environment-bound-names`, etc.). `plans/ENVIRONMENT_INTROSPECTION.md` |
@@ -86,7 +86,7 @@ See `plans/AUTHORIZATION_FRAMEWORK.md` for full design.
 - [ ] File system operations beyond R7RS (permissions, symlinks, stat)
 - [ ] Signal handling
 
-**Unit Testing Library** — Partial
+**Unit Testing Library** — Done (initial extraction)
 
 **What Exists**:
 - `(chibi test)` framework in `lib/chibi/test.scm`
@@ -94,12 +94,13 @@ See `plans/AUTHORIZATION_FRAMEWORK.md` for full design.
 - Automated test discovery (`*-test.scm` files)
 - CI integration (`make test-scheme`)
 - Cross-implementation testing support
+- 11 test files (3,187 lines) covering strings, characters, ports, numbers, exceptions, lazy evaluation, records, eval, control features, and macros
+- 915-test R7RS conformance suite in `integration/testdata/r7rs-tests.scm`
 
-**What's Missing**:
-- [ ] Comprehensive test content (only 1 smoke test exists)
+**Future expansion**:
 - [ ] Regression test files (`test/regression/`)
 - [ ] Library-specific tests (`lib/*/test/`)
-- [ ] Full coverage of R7RS features
+- [ ] New test cases for features not covered by Go test extraction
 
 **Logging Library**
 - [ ] Log levels (debug, info, warn, error, fatal)

--- a/plans/SCHEME_TEST_EXPANSION.md
+++ b/plans/SCHEME_TEST_EXPANSION.md
@@ -1,7 +1,8 @@
 # Scheme Test Suite Expansion
 
-**Status**: In progress
+**Status**: Complete
 **Created**: 2026-02-25
+**Completed**: 2026-02-25
 
 ## Goal
 
@@ -69,18 +70,24 @@ Incremental by R7RS section. One PR per section. Each PR:
 
 ## Prioritized section order
 
-| Order | File | Source Go tests | Approx cases |
-|-------|------|----------------|--------------|
-| 1 | `strings-test.scm` | `prim_strings_test.go` | ~38 |
-| 2 | `characters-test.scm` | `prim_characters_test.go` | ~15 |
-| 3 | `ports-test.scm` | `prim_ports_test.go`, `prim_read_write_test.go` | ~60 |
-| 4 | `numbers-test.scm` | `extensions/math/` tests | ~20 |
-| 5 | `exceptions-test.scm` | `extensions/exceptions/` tests | ~10 |
-| 6 | `lazy-test.scm` | `prim_all_test.go` (promises) | ~5-10 |
-| 7 | `records-test.scm` | `prim_all_test.go` (records) | ~10 |
-| 8 | `eval-test.scm` | `prim_eval_test.go` | ~15 |
-| 9 | `control-test.scm` | `machine/` tests (dynamic-wind, call/cc) | ~25 |
-| 10 | `macros-test.scm` | `machine/` tests (syntax-rules, syntax-case) | ~30 |
+| Order | File | Source Go tests | Lines | PR | Status |
+|-------|------|----------------|-------|-----|--------|
+| 1 | `strings-test.scm` | `prim_strings_test.go` | 178 | #338 | Done |
+| 2 | `characters-test.scm` | `prim_characters_test.go` | 135 | #338 | Done |
+| 3 | `ports-test.scm` | `prim_ports_test.go`, `prim_read_write_test.go` | 663 | #340 | Done |
+| 4 | `numbers-test.scm` | `extensions/math/` tests, `prim_arithmetic_test.go`, `prim_numeric_predicate_test.go` | 531 | #341 | Done |
+| 5 | `exceptions-test.scm` | `prim_exceptions_test.go`, `prim_exception_test.go` | 637 | #342 | Done |
+| 6 | `lazy-test.scm` | `prim_all_test.go`, `prim_promise_test.go`, `prim_promise_extra_test.go` | 141 | #343 | Done |
+| 7 | `records-test.scm` | `prim_all_test.go` | 304 | #343 | Done |
+| 8 | `eval-test.scm` | `prim_eval_test.go` | 81 | #344 | Done |
+| 9 | `control-test.scm` | `prim_control_test.go` | 327 | #345 | Done |
+| 10 | `macros-test.scm` | `compile_syntax_rules_test.go`, `let_shadow_macro_test.go`, `hygiene_test.go` | 157 | #345 | Done |
+
+**Total: 3,187 lines across 11 files (including smoke-test.scm).**
+
+Additional fixes shipped alongside:
+- PR #339: Arity errors now catchable by Scheme exception handlers (`guard`, `with-exception-handler`)
+- PR #342: Flaky pool capacity test relaxed for CI stability
 
 ## Scope boundaries
 


### PR DESCRIPTION
## Summary

- Mark `plans/SCHEME_TEST_EXPANSION.md` as complete with final stats (3,187 lines, 11 files, PRs #338-#345)
- Update `TODO.md`: P1 unit testing library marked Done, project status reflects test counts, last-updated date bumped to 2026-02-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)