### PR TITLE
refactor: introduce MacroEvaluator and ExpanderCtx interfaces

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -628,13 +628,13 @@ func applyBaseEnvironment(ctx context.Context, env *environment.EnvironmentFrame
 func expandAndCompile(ctx context.Context, env *environment.EnvironmentFrame, stx syntax.SyntaxValue, resolver machine.FileResolver) (*machine.NativeTemplate, error) {
 	tpl := machine.NewEmptyNativeTemplate()
 
-	expanded, err := machine.NewExpanderTimeContinuation(ctx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ctx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, err
 	}
 
 	cctx := machine.NewCompileTimeCallContext(ctx, false)
-	compiler := machine.NewCompiletimeContinuation(tpl, env)
+	compiler := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	if resolver != nil {
 		compiler.SetFileResolver(resolver)
 	}

--- a/internal/bootstrap/environment_tiny.go
+++ b/internal/bootstrap/environment_tiny.go
@@ -230,7 +230,7 @@ func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame,
 			}
 
 			// Expand the syntax
-			expanded, err := machine.NewExpanderTimeContinuation(ctx, env).ExpandExpression(stx)
+			expanded, err := machine.NewExpanderTimeContinuation(ctx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 			if err != nil {
 				return werr.WrapForeignErrorf(err, "error expanding bootstrap macro")
 			}
@@ -239,7 +239,7 @@ func loadBootstrapMacros(ctx context.Context, env *environment.EnvironmentFrame,
 			tpl := machine.NewNativeTemplate(0, 0, false)
 			// Use inTail=false for top-level expressions
 			cctx := machine.NewCompileTimeCallContext(ctx, false)
-			compiler := machine.NewCompiletimeContinuation(tpl, env)
+			compiler := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 			if resolver != nil {
 				compiler.SetFileResolver(resolver)
 			}

--- a/internal/bootstrap/multithreading_test.go
+++ b/internal/bootstrap/multithreading_test.go
@@ -38,14 +38,14 @@ func evalScheme(t *testing.T, env *environment.EnvironmentFrame, code string) (v
 	}
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, err
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/bootstrap/roundtrip_test.go
+++ b/internal/bootstrap/roundtrip_test.go
@@ -40,14 +40,14 @@ func evalSchemeEscape(t *testing.T, env *environment.EnvironmentFrame, code stri
 	}
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, err
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extensions/eval/prim_eval.go
+++ b/internal/extensions/eval/prim_eval.go
@@ -310,7 +310,7 @@ func PrimEnvironment(mc *machine.MachineContext) error {
 		}
 
 		// Load the library (uses callerEnv for registry access)
-		lib, err := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv)
+		lib, err := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv, machine.NewVMMacroEvaluator())
 		if err != nil {
 			return werr.WrapForeignErrorf(err, "environment: failed to load %s",
 				importSet.LibraryName.SchemeString())

--- a/internal/extensions/eval/prim_eval.go
+++ b/internal/extensions/eval/prim_eval.go
@@ -73,7 +73,7 @@ func PrimEval(mc *machine.MachineContext) error {
 	stx := schemeutil.DatumToSyntaxValue(mc.Context(), sctx, expr)
 
 	// Expand the expression
-	expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "eval: expansion error")
 	}
@@ -81,7 +81,7 @@ func PrimEval(mc *machine.MachineContext) error {
 	// Compile the expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(mc.Context(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "eval: compilation error")
 	}
@@ -154,7 +154,7 @@ func PrimLoad(mc *machine.MachineContext) error {
 		}
 
 		// Expand the expression
-		expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env).ExpandExpression(stx)
+		expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 		if err != nil {
 			return werr.WrapForeignErrorf(err, "load: expansion error in %s", filename.Value)
 		}
@@ -162,7 +162,7 @@ func PrimLoad(mc *machine.MachineContext) error {
 		// Compile the expression
 		tpl := machine.NewNativeTemplate(0, 0, false)
 		cctx := machine.NewCompileTimeCallContext(mc.Context(), false)
-		err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+		err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 		if err != nil {
 			return werr.WrapForeignErrorf(err, "load: compilation error in %s", filename.Value)
 		}
@@ -368,7 +368,7 @@ func PrimExpand(mc *machine.MachineContext) error {
 
 	// Not in expansion phase - create temporary expander
 	env := mc.EnvironmentFrame()
-	expander := machine.NewExpanderTimeContinuation(mc.Context(), env)
+	expander := machine.NewExpanderTimeContinuation(mc.Context(), env, machine.NewVMMacroEvaluator())
 	expanded, err := expander.ExpandExpression(syntaxVal)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "expand: expansion failed")
@@ -403,7 +403,7 @@ func PrimExpandOnce(mc *machine.MachineContext) error {
 
 	// Not in expansion phase - create temporary expander
 	env := mc.EnvironmentFrame()
-	expander := machine.NewExpanderTimeContinuation(mc.Context(), env)
+	expander := machine.NewExpanderTimeContinuation(mc.Context(), env, machine.NewVMMacroEvaluator())
 	expanded, didExpand, err := expander.ExpandOnce(syntaxVal)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "expand-once: expansion failed")
@@ -442,7 +442,7 @@ func PrimCompile(mc *machine.MachineContext) error {
 	env := mc.EnvironmentFrame()
 
 	// Step 1: Expand the syntax object
-	expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env).ExpandExpression(syntaxVal)
+	expanded, err := machine.NewExpanderTimeContinuation(mc.Context(), env, machine.NewVMMacroEvaluator()).ExpandExpression(syntaxVal)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "compile: expansion failed")
 	}
@@ -451,7 +451,7 @@ func PrimCompile(mc *machine.MachineContext) error {
 	// Create a thunk template (0 params, 0 locals, not variadic)
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(mc.Context(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "compile: compilation failed")
 	}

--- a/internal/extensions/namespace/prim_namespace.go
+++ b/internal/extensions/namespace/prim_namespace.go
@@ -76,7 +76,7 @@ func PrimMakeNamespace(mc *machine.MachineContext) error {
 			return werr.WrapForeignErrorf(parseErr, "make-namespace: invalid import spec")
 		}
 
-		lib, loadErr := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv)
+		lib, loadErr := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv, machine.NewVMMacroEvaluator())
 		if loadErr != nil {
 			return werr.WrapForeignErrorf(loadErr, "make-namespace: failed to load %s",
 				importSet.LibraryName.SchemeString())
@@ -255,7 +255,7 @@ func PrimNamespaceRequire(mc *machine.MachineContext) error {
 		return werr.WrapForeignErrorf(parseErr, "namespace-require: invalid import spec")
 	}
 
-	lib, loadErr := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv)
+	lib, loadErr := machine.LoadLibrary(mc.Context(), importSet.LibraryName, callerEnv, machine.NewVMMacroEvaluator())
 	if loadErr != nil {
 		return werr.WrapForeignErrorf(loadErr, "namespace-require: failed to load %s",
 			importSet.LibraryName.SchemeString())

--- a/machine/compile_begin_for_syntax_test.go
+++ b/machine/compile_begin_for_syntax_test.go
@@ -61,7 +61,7 @@ func TestCompileBeginForSyntax_Error_NotPair(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Not a pair
 	expr := syntax.NewSyntaxSymbol("bad", nil)
@@ -76,7 +76,7 @@ func TestCompileBeginForSyntax_Empty(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty list singleton
 	exprPair := syntax.SyntaxEmptyList

--- a/machine/compile_closure.go
+++ b/machine/compile_closure.go
@@ -139,7 +139,7 @@ func (p *CompileTimeContinuation) compileClosure(ctctx CompileTimeCallContext, t
 // R7RS §5.3.2: Internal definitions use letrec* semantics - all defined names are visible
 // throughout the body, enabling forward references between defines.
 func (p *CompileTimeContinuation) compileBody(ctctx CompileTimeCallContext, clause validate.ValidatedBodyAndParams, childEnv *environment.EnvironmentFrame, tpl *NativeTemplate) error {
-	childCompiler := NewCompiletimeContinuation(tpl, childEnv)
+	childCompiler := NewCompiletimeContinuation(tpl, childEnv, p.evaluator)
 	lambdaBodyContext := NewCompileTimeCallContext(ctctx.ctx, true)
 
 	body := clause.Body()

--- a/machine/compile_cond_expand.go
+++ b/machine/compile_cond_expand.go
@@ -113,7 +113,7 @@ func (p *CompileTimeContinuation) CompileCondExpand(ctctx CompileTimeCallContext
 	// (since cond-expand is not expanded, we must expand the body here)
 	_, err = syntax.SyntaxForEach(ctctx.ctx, bodyPair, func(_ context.Context, _ int, hasNext bool, expr syntax.SyntaxValue) error {
 		// Expand the expression
-		expanded, expandErr := NewExpanderTimeContinuation(ctctx.ctx, p.env).ExpandExpression(expr)
+		expanded, expandErr := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator).ExpandExpression(expr)
 		if expandErr != nil {
 			return werr.WrapForeignErrorf(expandErr, "cond-expand: error expanding body expression")
 		}

--- a/machine/compile_define_for_syntax.go
+++ b/machine/compile_define_for_syntax.go
@@ -90,7 +90,7 @@ func (p *CompileTimeContinuation) CompileDefineForSyntax(ctctx CompileTimeCallCo
 	// Uses the expand-phase environment so the expression can access other
 	// define-for-syntax bindings and runtime primitives
 	expandEnv := p.env.Expand()
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator)
 	result, err := p.expandCompileExecute(ctctx.ctx, ctctx, valueExpr, expandEnv, expander, "define-for-syntax")
 	if err != nil {
 		return err

--- a/machine/compile_define_for_syntax.go
+++ b/machine/compile_define_for_syntax.go
@@ -98,11 +98,12 @@ func (p *CompileTimeContinuation) CompileDefineForSyntax(ctctx CompileTimeCallCo
 
 	// Store the result in the expand phase environment with BindingTypeVariable
 	globalIndex, _ := expandEnv.MaybeCreateOwnGlobalBinding(nameSym, environment.BindingTypeVariable)
-	if globalIndex != nil {
-		err = expandEnv.SetOwnGlobalValue(globalIndex, result)
-		if err != nil {
-			return werr.WrapForeignErrorf(err, "define-for-syntax: failed to store value")
-		}
+	if globalIndex == nil {
+		return werr.WrapForeignErrorf(werr.ErrUnexpectedNil, "define-for-syntax: failed to create binding for %s", nameSym.Key)
+	}
+	err = expandEnv.SetOwnGlobalValue(globalIndex, result)
+	if err != nil {
+		return werr.WrapForeignErrorf(err, "define-for-syntax: failed to store value for %s", nameSym.Key)
 	}
 
 	// define-for-syntax has no runtime effect - don't emit any operations

--- a/machine/compile_define_for_syntax_test.go
+++ b/machine/compile_define_for_syntax_test.go
@@ -61,7 +61,7 @@ func TestCompileDefineForSyntax_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -76,7 +76,7 @@ func TestCompileDefineForSyntax_Error_MissingExpression(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (name) - missing expression
 	name := syntax.NewSyntaxSymbol("x", nil)

--- a/machine/compile_define_syntax.go
+++ b/machine/compile_define_syntax.go
@@ -92,19 +92,21 @@ func (p *CompileTimeContinuation) CompileDefineSyntax(ctctx CompileTimeCallConte
 		// Update existing binding
 		globalIndex = expandEnv.GetGlobalIndex(keyword)
 	}
-	if globalIndex != nil {
-		// Set scopes from the keyword symbol for hygiene
-		// This ensures local define-syntax bindings have correct scopes for lookup
-		symbolScopes := keywordSym.Scopes()
-		binding := expandEnv.GetGlobalBinding(globalIndex)
-		if binding != nil && symbolScopes != nil {
-			binding.SetScopes(symbolScopes)
-		}
+	if globalIndex == nil {
+		return werr.WrapForeignErrorf(werr.ErrUnexpectedNil, "define-syntax: failed to create or find binding for %s", keyword.Key)
+	}
 
-		err = expandEnv.SetOwnGlobalValue(globalIndex, closure)
-		if err != nil {
-			return err
-		}
+	// Set scopes from the keyword symbol for hygiene
+	// This ensures local define-syntax bindings have correct scopes for lookup
+	symbolScopes := keywordSym.Scopes()
+	binding := expandEnv.GetGlobalBinding(globalIndex)
+	if binding != nil && symbolScopes != nil {
+		binding.SetScopes(symbolScopes)
+	}
+
+	err = expandEnv.SetOwnGlobalValue(globalIndex, closure)
+	if err != nil {
+		return werr.WrapForeignErrorf(err, "define-syntax: failed to store transformer for %s", keyword.Key)
 	}
 
 	// define-syntax is compile-time only, emit no runtime operations

--- a/machine/compile_define_syntax.go
+++ b/machine/compile_define_syntax.go
@@ -79,7 +79,7 @@ func (p *CompileTimeContinuation) CompileDefineSyntax(ctctx CompileTimeCallConte
 	}
 
 	// Compile the transformer (supports syntax-rules and lambda)
-	closure, err := compileTransformerToMachineClosure(ctctx.ctx, p.env, transformerExpr, p.libraryScope)
+	closure, err := compileTransformerToMachineClosure(ctctx.ctx, p.env, transformerExpr, p.libraryScope, p.evaluator)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "could not compile transformer")
 	}

--- a/machine/compile_er_macro.go
+++ b/machine/compile_er_macro.go
@@ -28,6 +28,7 @@ func compileERMacroTransformer(
 	ctx context.Context,
 	env *environment.EnvironmentFrame,
 	erForm *syntax.SyntaxPair,
+	evaluator MacroEvaluator,
 ) (*ERMacroTransformer, error) {
 	// Extract the lambda expression from (er-macro-transformer <lambda>)
 	cdr := erForm.SyntaxCdr()
@@ -58,7 +59,7 @@ func compileERMacroTransformer(
 
 	// Compile and evaluate the lambda to get a MachineClosure.
 	// compileAndEvalLambdaTransformer handles expansion, compilation, and evaluation.
-	closure, err := compileAndEvalLambdaTransformer(ctx, env, lambdaExpr)
+	closure, err := compileAndEvalLambdaTransformer(ctx, env, lambdaExpr, evaluator)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(
 			err,

--- a/machine/compile_eval_when.go
+++ b/machine/compile_eval_when.go
@@ -189,7 +189,7 @@ func (p *CompileTimeContinuation) evalWhenCompileForRuntime(ctctx CompileTimeCal
 	}
 
 	// Create expander for macro expansion
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator)
 
 	// Collect all expressions
 	var exprs []syntax.SyntaxValue

--- a/machine/compile_eval_when_test.go
+++ b/machine/compile_eval_when_test.go
@@ -62,7 +62,7 @@ func TestCompileEvalWhen_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -77,7 +77,7 @@ func TestCompileEvalWhen_EmptyBody(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// ((run)) - phases with empty body, should emit void
 	phases := syntax.NewSyntaxCons(
@@ -94,7 +94,7 @@ func TestCompileEvalWhen_Error_UnknownPhase(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// ((unknown) body)
 	phases := syntax.NewSyntaxCons(
@@ -114,7 +114,7 @@ func TestCompileEvalWhen_RunPhase(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// ((run) 42)
 	phases := syntax.NewSyntaxCons(
@@ -134,7 +134,7 @@ func TestCompileEvalWhen_EmptyPhases(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (() 42) - no phases, should emit void
 	phases := syntax.SyntaxEmptyList

--- a/machine/compile_helpers.go
+++ b/machine/compile_helpers.go
@@ -45,21 +45,19 @@ func (p *CompileTimeContinuation) expandCompileExecute(
 	}
 
 	tmpTpl := NewNativeTemplate(0, 0, false)
-	tmpCcnt := NewCompiletimeContinuation(tmpTpl, expandEnv)
+	tmpCcnt := NewCompiletimeContinuation(tmpTpl, expandEnv, p.evaluator)
 
 	err = tmpCcnt.CompileExpression(ctctx, expandedExpr)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "%s: compilation failed", errPrefix)
 	}
 
-	cont := NewMachineContinuation(nil, tmpTpl, expandEnv)
-	mc := NewMachineContext(ctx, cont)
-	err = mc.Run()
+	result, err := p.evaluator.EvalTemplate(ctx, tmpTpl, expandEnv)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "%s: evaluation failed", errPrefix)
 	}
 
-	return mc.GetValue(), nil
+	return result, nil
 }
 
 // executeFormsAtCompileTime expands, compiles, and executes each expression
@@ -70,7 +68,7 @@ func (p *CompileTimeContinuation) executeFormsAtCompileTime(
 	bodyPair *syntax.SyntaxPair,
 ) error {
 	expandEnv := p.env.Expand()
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator)
 
 	v, err := bodyPair.SyntaxForEach(ctctx.ctx, func(_ context.Context, _ int, _ bool, stxVal syntax.SyntaxValue) error {
 		_, err := p.expandCompileExecute(ctctx.ctx, ctctx, stxVal, expandEnv, expander, formName)

--- a/machine/compile_import.go
+++ b/machine/compile_import.go
@@ -45,7 +45,7 @@ func (p *CompileTimeContinuation) CompileImport(ctctx CompileTimeCallContext, ex
 
 	// Process each import set
 	v, err := syntax.SyntaxForEach(ctctx.ctx, importSets, func(ctx context.Context, _ int, _ bool, importSetExpr syntax.SyntaxValue) error {
-		return ResolveAndInstallImportSet(ctx, importSetExpr.UnwrapAll(), p.env, environment.PhaseCompile)
+		return ResolveAndInstallImportSet(ctx, importSetExpr.UnwrapAll(), p.env, environment.PhaseCompile, p.evaluator)
 	})
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "import: error processing import sets")
@@ -74,7 +74,7 @@ func (p *CompileTimeContinuation) processLibraryImport(ctctx CompileTimeCallCont
 
 	// Process each import set
 	_, err := syntax.SyntaxForEach(ctctx.ctx, argsPair, func(ctx context.Context, _ int, _ bool, importSetExpr syntax.SyntaxValue) error {
-		res, err := resolveImportSet(ctx, importSetExpr.UnwrapAll(), p.env)
+		res, err := resolveImportSet(ctx, importSetExpr.UnwrapAll(), p.env, p.evaluator)
 		if err != nil {
 			return err
 		}

--- a/machine/compile_library_forms.go
+++ b/machine/compile_library_forms.go
@@ -101,7 +101,7 @@ func (p *CompileTimeContinuation) CompileDefineLibrary(ctctx CompileTimeCallCont
 
 	// Create a compiler for the library environment
 	libTemplate := NewNativeTemplate(0, 0, false)
-	libCompiler := NewCompiletimeContinuation(libTemplate, libEnv)
+	libCompiler := NewCompiletimeContinuation(libTemplate, libEnv, p.evaluator)
 	libCompiler.libraryScope = libScope
 
 	// Process each declaration

--- a/machine/compile_quasisyntax_test.go
+++ b/machine/compile_quasisyntax_test.go
@@ -63,7 +63,7 @@ func makeTestQuasisyntax(body syntax.SyntaxValue) *syntax.SyntaxPair {
 func newTestCompiler() (*CompileTimeContinuation, *environment.EnvironmentFrame) {
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	return ccnt, env
 }
 
@@ -74,7 +74,7 @@ func TestCompileQuasisyntax_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -89,7 +89,7 @@ func TestCompileUnsyntax_Error(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	expr := syntax.SyntaxEmptyList
 
@@ -103,7 +103,7 @@ func TestCompileUnsyntaxSplicing_Error(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	expr := syntax.SyntaxEmptyList
 

--- a/machine/compile_syntax_case.go
+++ b/machine/compile_syntax_case.go
@@ -222,7 +222,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 
 	// Create environment with pattern variables bound (shared between fender and body)
 	bodyEnv := p.createPatternVarEnvironment(patternVars)
-	bodyCompiler := NewCompiletimeContinuation(p.template, bodyEnv)
+	bodyCompiler := NewCompiletimeContinuation(p.template, bodyEnv, p.evaluator)
 	// Inherit the parent compiler's current source so that operations emitted
 	// by bodyCompiler (like BindPatternVars) are tagged with the syntax-case
 	// form's source location.
@@ -232,7 +232,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	bodyCompiler.AppendOperations(NewOperationBindPatternVars(patternVars))
 
 	// Create expander for the body environment (to expand macros like let)
-	bodyExpander := NewExpanderTimeContinuation(ctctx.ctx, bodyEnv)
+	bodyExpander := NewExpanderTimeContinuation(ctctx.ctx, bodyEnv, p.evaluator)
 
 	// If there's a fender, evaluate it and branch to cleanup on false
 	var fenderBranchIdx int

--- a/machine/compile_syntax_case_test.go
+++ b/machine/compile_syntax_case_test.go
@@ -31,7 +31,7 @@ func TestCompileSyntaxCase_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -47,7 +47,7 @@ func TestCompileSyntaxCase_Error_NoLiterals(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (input) - missing literals and clauses
 	input := syntax.NewSyntaxSymbol("x", nil)
@@ -63,7 +63,7 @@ func TestCompileSyntaxCase_Error_NoClauses(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (input ()) - missing clauses
 	input := syntax.NewSyntaxSymbol("x", nil)

--- a/machine/compile_syntax_form_test.go
+++ b/machine/compile_syntax_form_test.go
@@ -31,7 +31,7 @@ func TestCompileSyntax_SingleArg(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (syntax bindSymbolWithScopes) -> (bindSymbolWithScopes)
 	template := syntax.NewSyntaxSymbol("bindSymbolWithScopes", nil)
@@ -47,7 +47,7 @@ func TestCompileSyntax_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -63,7 +63,7 @@ func TestCompileSyntax_Error_TooManyArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (syntax bindSymbolWithScopes bar) -> (bindSymbolWithScopes bar)
 	template := syntax.NewSyntaxSymbol("bindSymbolWithScopes", nil)
@@ -177,7 +177,7 @@ func TestCompileSyntax_EscapeFormCompilesDirectly(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (syntax (... bindSymbolWithScopes)) - escape form should compile directly
 	ellipsis := syntax.NewSyntaxSymbol("...", nil)
@@ -205,7 +205,7 @@ func TestCompileSyntax_NonEscapeEllipsisUsesRuntimeExpansion(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (syntax (bindSymbolWithScopes ...)) - actual ellipsis, needs runtime expansion
 	foo := syntax.NewSyntaxSymbol("bindSymbolWithScopes", nil)

--- a/machine/compile_time_continuation.go
+++ b/machine/compile_time_continuation.go
@@ -40,12 +40,16 @@ type CompileTimeContinuation struct {
 	// Defaults to the resolver stored on Namespace (usually
 	// OSFileResolver); set to EmbedFileResolver for bootstrap.
 	fileResolver FileResolver
+	// evaluator abstracts VM execution for compile-time evaluation
+	// and transformer invocation so the compiler can be tested
+	// without the concrete VM.
+	evaluator MacroEvaluator
 }
 
 // NewCompiletimeContinuation creates a new CompileTimeContinuation.
 // The file resolver defaults to the one stored on the Namespace.
 // If none is set, falls back to a fresh OSFileResolver.
-func NewCompiletimeContinuation(tpl *NativeTemplate, env *environment.EnvironmentFrame) *CompileTimeContinuation {
+func NewCompiletimeContinuation(tpl *NativeTemplate, env *environment.EnvironmentFrame, evaluator MacroEvaluator) *CompileTimeContinuation {
 	var resolver FileResolver
 	if r, ok := env.FileResolver().(FileResolver); ok {
 		resolver = r
@@ -56,6 +60,7 @@ func NewCompiletimeContinuation(tpl *NativeTemplate, env *environment.Environmen
 		env:          env,
 		template:     tpl,
 		fileResolver: resolver,
+		evaluator:    evaluator,
 	}
 	return q
 }
@@ -236,7 +241,7 @@ func (p *CompileTimeContinuation) CompileMeta(ctctx CompileTimeCallContext, expr
 	}
 	// Get the expand environment and compile expressions in it
 	metaEnv := p.env.Expand()
-	metaCont := NewCompiletimeContinuation(p.template, metaEnv)
+	metaCont := NewCompiletimeContinuation(p.template, metaEnv, p.evaluator)
 	err := metaCont.compileExpressionList(ctctx, rest)
 	if err != nil {
 		return werr.WrapForeignErrorf(err, "failed to compile meta")

--- a/machine/compile_time_continuation_include.go
+++ b/machine/compile_time_continuation_include.go
@@ -143,7 +143,7 @@ func (p *CompileTimeContinuation) processFormsWithLetrecSemantics(ctctx CompileT
 	}
 
 	// Pass 1: Expand all forms, compiling define-syntax as encountered
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator)
 	expander.libraryScope = p.libraryScope
 	expandedForms, err := expander.ExpandBodyWithDefineSyntax(forms)
 	if err != nil {

--- a/machine/compile_time_continuation_library.go
+++ b/machine/compile_time_continuation_library.go
@@ -61,7 +61,7 @@ func (p *CompileTimeContinuation) compileLibraryBegin(ctctx CompileTimeCallConte
 	}
 
 	// Pass 1: Expand all forms, compiling define-syntax as encountered
-	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env)
+	expander := NewExpanderTimeContinuation(ctctx.ctx, p.env, p.evaluator)
 	expander.libraryScope = p.libraryScope
 	expandedForms, err := expander.ExpandBodyWithDefineSyntax(forms)
 	if err != nil {

--- a/machine/compile_time_continuation_mutual_test.go
+++ b/machine/compile_time_continuation_mutual_test.go
@@ -60,9 +60,9 @@ func TestCompileContext_CompileDefine_MutualRecursion_NotSupported(t *testing.T)
 
 	// Try to compile first function - should error because g is not defined yet
 	tpl1 := NewNativeTemplate(0, 0, false)
-	cctx1 := NewCompiletimeContinuation(tpl1, env)
+	cctx1 := NewCompiletimeContinuation(tpl1, env, NewVMMacroEvaluator())
 	ectx := context.Background()
-	econt1 := NewExpanderTimeContinuation(ectx, env)
+	econt1 := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator())
 	prog1Syntax, err := econt1.ExpandExpression(prog1)
 	qt.Assert(t, err, qt.IsNil)
 	cnt := NewCompileTimeCallContext(context.Background(), false)
@@ -89,9 +89,9 @@ func TestCompileContext_CompileDefine_SelfRecursion_FunctionForm(t *testing.T) {
 
 	// Compile the function - should not error even though fact references itself
 	tpl := NewNativeTemplate(0, 0, false)
-	cctx := NewCompiletimeContinuation(tpl, env)
+	cctx := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ectx := context.Background()
-	econt := NewExpanderTimeContinuation(ectx, env)
+	econt := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator())
 	progSyntax, err := econt.ExpandExpression(prog)
 	qt.Assert(t, err, qt.IsNil)
 	cnt := NewCompileTimeCallContext(context.Background(), false)

--- a/machine/compile_time_continuation_test.go
+++ b/machine/compile_time_continuation_test.go
@@ -1115,45 +1115,6 @@ func TestCompileIfBranches(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 }
 
-// TestExpandQuasiquoteAndQuoteDirect tests the expander methods directly
-func TestExpandQuasiquoteAndQuoteDirect(t *testing.T) {
-	env := newNamespace(environment.NewNamespace().Runtime())
-	err := RegisterSyntaxCompilers(env)
-	qt.Assert(t, err, qt.IsNil)
-
-	econt := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
-	sctx := syntax.NewZeroValueSourceContext()
-
-	// Test ExpandQuote - currently returns nil, nil
-	quoteExpr := syntax.NewSyntaxCons(
-		syntax.NewSyntaxSymbol("quote", sctx),
-		syntax.NewSyntaxCons(
-			syntax.NewSyntaxSymbol("x", sctx),
-			syntax.SyntaxEmptyList,
-			sctx,
-		),
-		sctx,
-	)
-	expanded, err := econt.ExpandQuote(quoteExpr)
-	// The function returns nil, nil (unimplemented)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, expanded, qt.IsNil)
-
-	// Test ExpandQuasiquote - currently returns nil, nil
-	qqExpr := syntax.NewSyntaxCons(
-		syntax.NewSyntaxSymbol("quasiquote", sctx),
-		syntax.NewSyntaxCons(
-			syntax.NewSyntaxSymbol("y", sctx),
-			syntax.SyntaxEmptyList,
-			sctx,
-		),
-		sctx,
-	)
-	expanded, err = econt.ExpandQuasiquote(qqExpr)
-	qt.Assert(t, err, qt.IsNil)
-	qt.Assert(t, expanded, qt.IsNil)
-}
-
 // TestCompileUnquoteError tests error when compiling unquote outside quasiquote
 func TestCompileUnquoteError(t *testing.T) {
 	env := newNamespace(environment.NewNamespace().Runtime())

--- a/machine/compile_time_continuation_test.go
+++ b/machine/compile_time_continuation_test.go
@@ -371,7 +371,7 @@ func evalSchemeString(code string) (values.Value, error) {
 
 		// Expand
 		ectx := context.Background()
-		econt := NewExpanderTimeContinuation(ectx, env)
+		econt := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator())
 		expanded, err := econt.ExpandExpression(stx)
 		if err != nil {
 			return nil, err
@@ -379,7 +379,7 @@ func evalSchemeString(code string) (values.Value, error) {
 
 		// Compile
 		tpl := NewNativeTemplate(0, 0, false)
-		cctx := NewCompiletimeContinuation(tpl, env)
+		cctx := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 		cnt := NewCompileTimeCallContext(context.Background(), false)
 		err = cctx.CompileExpression(cnt, expanded)
 		if err != nil {
@@ -635,9 +635,9 @@ func TestCompileContext_CompileMeta(t *testing.T) {
 
 func newTopLevelThunk(prog syntax.SyntaxValue, env *environment.EnvironmentFrame) (*MachineContinuation, error) {
 	tpl := NewNativeTemplate(0, 0, false)
-	cctx := NewCompiletimeContinuation(tpl, env)
+	cctx := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ectx := context.Background()
-	econt := NewExpanderTimeContinuation(ectx, env)
+	econt := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator())
 	prog, err := econt.ExpandExpression(prog)
 	if err != nil {
 		return nil, err
@@ -927,7 +927,7 @@ func TestExpandQuasiquoteAndQuote(t *testing.T) {
 	// Test quote expansion
 	quoteProg := values.List(values.NewSymbol("quote"), values.NewSymbol("x"))
 	ectx := context.Background()
-	econt := NewExpanderTimeContinuation(ectx, env)
+	econt := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator())
 	expanded, err := econt.ExpandExpression(schemeutil.DatumToSyntaxValue(context.Background(), sctx, quoteProg))
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, expanded, qt.IsNotNil)
@@ -1121,7 +1121,7 @@ func TestExpandQuasiquoteAndQuoteDirect(t *testing.T) {
 	err := RegisterSyntaxCompilers(env)
 	qt.Assert(t, err, qt.IsNil)
 
-	econt := NewExpanderTimeContinuation(context.Background(), env)
+	econt := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// Test ExpandQuote - currently returns nil, nil
@@ -1810,7 +1810,7 @@ func TestCompileSelfEvaluatingNil(t *testing.T) {
 func TestCompileSelfEvaluatingNilDirect(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
-	ctc := NewCompiletimeContinuation(tpl, env)
+	ctc := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
 
 	// Call with nil to test the nil branch
@@ -2047,7 +2047,7 @@ func TestFindFileCWDFallback(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
-	cont := NewCompiletimeContinuation(NewNativeTemplate(0, 0, false), env)
+	cont := NewCompiletimeContinuation(NewNativeTemplate(0, 0, false), env, NewVMMacroEvaluator())
 
 	// findFile should resolve "cwd-test.scm" via CWD fallback.
 	// Use filepath.EvalSymlinks on dir to normalize: on macOS, t.TempDir()
@@ -2066,7 +2066,7 @@ func TestFindFileCWDFallback(t *testing.T) {
 func TestFindFileEmptyPath(t *testing.T) {
 	env := newNamespace(environment.NewNamespace().Runtime())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
-	cont := NewCompiletimeContinuation(NewNativeTemplate(0, 0, false), env)
+	cont := NewCompiletimeContinuation(NewNativeTemplate(0, 0, false), env, NewVMMacroEvaluator())
 
 	_, _, err := findFile(cont, ctctx, "")
 	qt.Assert(t, err, qt.IsNotNil)

--- a/machine/compile_transformer.go
+++ b/machine/compile_transformer.go
@@ -38,6 +38,7 @@ func compileTransformerToMachineClosure(
 	env *environment.EnvironmentFrame,
 	transformerExpr syntax.SyntaxValue,
 	libraryScope *syntax.Scope,
+	evaluator MacroEvaluator,
 ) (values.Value, error) {
 	transformerPair, ok := transformerExpr.(*syntax.SyntaxPair)
 	if !ok {
@@ -69,10 +70,10 @@ func compileTransformerToMachineClosure(
 		return CompileSyntaxRules(ctx, env, transformerPair, libraryScope)
 
 	case "lambda":
-		return compileAndEvalLambdaTransformer(ctx, env, transformerPair)
+		return compileAndEvalLambdaTransformer(ctx, env, transformerPair, evaluator)
 
 	case "er-macro-transformer":
-		return compileERMacroTransformer(ctx, env, transformerPair)
+		return compileERMacroTransformer(ctx, env, transformerPair, evaluator)
 
 	default:
 		return nil, werr.WrapForeignErrorf(werr.ErrUnexpectedTransformer, "define-syntax: unsupported transformer type %q (expected syntax-rules, lambda, or er-macro-transformer)", symbol.Key)
@@ -81,31 +82,28 @@ func compileTransformerToMachineClosure(
 
 // compileAndEvalLambdaTransformer compiles a lambda expression and evaluates it at
 // compile time to produce a closure that can be used as a syntax transformer.
-func compileAndEvalLambdaTransformer(ctx context.Context, env *environment.EnvironmentFrame, lambdaExpr syntax.SyntaxValue) (*MachineClosure, error) {
+func compileAndEvalLambdaTransformer(ctx context.Context, env *environment.EnvironmentFrame, lambdaExpr syntax.SyntaxValue, evaluator MacroEvaluator) (*MachineClosure, error) {
 	tpl := NewNativeTemplate(0, 0, false)
 
 	expandEnv := env.Expand()
 
-	expandedExpr, err := NewExpanderTimeContinuation(ctx, expandEnv).ExpandExpression(lambdaExpr)
+	expandedExpr, err := NewExpanderTimeContinuation(ctx, expandEnv, evaluator).ExpandExpression(lambdaExpr)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "error expanding transformer")
 	}
 
 	cctx := NewCompileTimeCallContext(ctx, false)
-	compiler := NewCompiletimeContinuation(tpl, expandEnv)
+	compiler := NewCompiletimeContinuation(tpl, expandEnv, evaluator)
 	err = compiler.CompileExpression(cctx, expandedExpr)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "error compiling transformer")
 	}
 
-	cont := NewMachineContinuation(nil, tpl, expandEnv)
-	mc := NewMachineContext(ctx, cont)
-	err = mc.Run()
+	result, err := evaluator.EvalTemplate(ctx, tpl, expandEnv)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "error evaluating transformer")
 	}
 
-	result := mc.GetValue()
 	closure, ok := result.(*MachineClosure)
 	if !ok {
 		return nil, werr.WrapForeignErrorf(werr.ErrNotAProcedure, "define-syntax: transformer must evaluate to a procedure, got %T", result)

--- a/machine/compile_transformer_test.go
+++ b/machine/compile_transformer_test.go
@@ -41,7 +41,7 @@ func TestCompileTransformerToMachineClosure_SyntaxRules(t *testing.T) {
 	)
 	transformerStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, transformer)
 
-	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil)
+	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, closure, qt.IsNotNil)
 }
@@ -58,7 +58,7 @@ func TestCompileTransformerToMachineClosure_Lambda(t *testing.T) {
 	)
 	transformerStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, transformer)
 
-	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil)
+	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, closure, qt.IsNotNil)
 }
@@ -78,7 +78,7 @@ func TestCompileTransformerToMachineClosure_ERMacroTransformer(t *testing.T) {
 	)
 	transformerStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, transformer)
 
-	result, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil)
+	result, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, result, qt.IsNotNil)
 
@@ -97,7 +97,7 @@ func TestCompileTransformerToMachineClosure_UnsupportedType(t *testing.T) {
 	)
 	transformerStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, transformer)
 
-	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil)
+	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNotNil)
 	qt.Assert(t, closure, qt.IsNil)
 	qt.Assert(t, err.Error(), qt.Contains, "unsupported transformer type")
@@ -110,7 +110,7 @@ func TestCompileTransformerToMachineClosure_NotAPair(t *testing.T) {
 	// Just a symbol, not a pair
 	transformerStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, values.NewSymbol("not-a-list"))
 
-	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil)
+	closure, err := compileTransformerToMachineClosure(context.Background(), env, transformerStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNotNil)
 	qt.Assert(t, closure, qt.IsNil)
 	qt.Assert(t, err.Error(), qt.Contains, "transformer must be a list")
@@ -142,7 +142,7 @@ func TestProceduralMacroExpandTimePath(t *testing.T) {
 	defineSyntaxStx := schemeutil.DatumToSyntaxValue(context.Background(), sctx, defineSyntaxExpr).(*syntax.SyntaxPair)
 
 	// Use the expand-time path to compile the define-syntax
-	err := compileDefineSyntaxFromSyntax(context.Background(), env, defineSyntaxStx, nil)
+	err := compileDefineSyntaxFromSyntax(context.Background(), env, defineSyntaxStx, nil, NewVMMacroEvaluator())
 	qt.Assert(t, err, qt.IsNil)
 
 	// Verify the macro is stored in the expand environment

--- a/machine/compile_validated_test.go
+++ b/machine/compile_validated_test.go
@@ -283,7 +283,7 @@ func TestCompileValidated_UnknownExprType(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ctc := NewCompiletimeContinuation(tpl, env)
+	ctc := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
 
 	// Create a mock ValidatedExpr that compileValidated doesn't know about

--- a/machine/compile_with_syntax_test.go
+++ b/machine/compile_with_syntax_test.go
@@ -30,7 +30,7 @@ func TestCompileWithSyntax_Error_NoArgs(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// Empty args
 	expr := syntax.SyntaxEmptyList
@@ -45,7 +45,7 @@ func TestCompileWithSyntax_Error_NoBody(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (()) - empty bindings list, no body
 	bindings := syntax.SyntaxEmptyList
@@ -61,7 +61,7 @@ func TestCompileWithSyntax_EmptyBindings(t *testing.T) {
 
 	env := newNamespace(environment.NewNamespace().Runtime())
 	tpl := NewNativeTemplate(0, 0, false)
-	ccnt := NewCompiletimeContinuation(tpl, env)
+	ccnt := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 
 	// (() body) - empty bindings, simple body
 	bindings := syntax.SyntaxEmptyList

--- a/machine/coverage_fullruntime_test.go
+++ b/machine/coverage_fullruntime_test.go
@@ -54,7 +54,7 @@ func newFullRuntimeEnv(t *testing.T) *environment.EnvironmentFrame {
 // newTopLevelThunkExt creates a top-level thunk from an expression using the expander and compiler
 func newTopLevelThunkExt(sv syntax.SyntaxValue, env *environment.EnvironmentFrame) (*machine.MachineContinuation, error) {
 	// Expand the expression
-	econt := machine.NewExpanderTimeContinuation(context.Background(), env)
+	econt := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := econt.ExpandExpression(sv)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func newTopLevelThunkExt(sv syntax.SyntaxValue, env *environment.EnvironmentFram
 
 	// Compile the expanded expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err = ctc.CompileExpression(ctctx, expanded)
 	if err != nil {

--- a/machine/coverage_improvement_test.go
+++ b/machine/coverage_improvement_test.go
@@ -90,7 +90,7 @@ func TestCompileUnquoteSplicing(t *testing.T) {
 func TestCompileUnquoteDirectCall(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
-	ctc := NewCompiletimeContinuation(tpl, env)
+	ctc := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
 
 	sctx := syntax.NewZeroValueSourceContext()
@@ -105,7 +105,7 @@ func TestCompileUnquoteDirectCall(t *testing.T) {
 func TestCompileUnquoteSplicingDirectCall(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
 	tpl := NewNativeTemplate(0, 0, false)
-	ctc := NewCompiletimeContinuation(tpl, env)
+	ctc := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator())
 	ctctx := NewCompileTimeCallContext(context.Background(), false)
 
 	sctx := syntax.NewZeroValueSourceContext()

--- a/machine/er_macro_transformer_test.go
+++ b/machine/er_macro_transformer_test.go
@@ -75,7 +75,7 @@ func TestCompileERMacroTransformer(t *testing.T) {
 		    (lambda (form rename compare) form)))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, form)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -103,7 +103,7 @@ func TestERMacro_EndToEnd_Constant(t *testing.T) {
 		    (lambda (form rename compare) 42)))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, form)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -111,7 +111,7 @@ func TestERMacro_EndToEnd_Constant(t *testing.T) {
 
 	// Expand: (my-const anything) — transformer returns 42 regardless
 	testForm := parseString(t, env, `(my-const anything)`)
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	c.Assert(err, qt.IsNil)
 
@@ -134,7 +134,7 @@ func TestERMacro_InLetSyntax(t *testing.T) {
 		  (my-const anything))
 	`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(form)
 	c.Assert(err, qt.IsNil)
 

--- a/machine/expander_body.go
+++ b/machine/expander_body.go
@@ -120,7 +120,7 @@ func (p *ExpanderTimeContinuation) ExpandBodyWithDefineSyntax(
 		// If define-syntax, compile it now for subsequent forms
 		if isSyntaxFormWithKeyword(expanded, "define-syntax") {
 			pair := expanded.(*syntax.SyntaxPair)
-			err = compileDefineSyntaxFromSyntax(p.ctx, p.env, pair, p.libraryScope)
+			err = compileDefineSyntaxFromSyntax(p.ctx, p.env, pair, p.libraryScope, p.evaluator)
 			if err != nil {
 				return nil, err
 			}
@@ -137,7 +137,7 @@ func (p *ExpanderTimeContinuation) ExpandBodyWithDefineSyntax(
 // The env parameter is used for free identifier resolution during compilation (so macros
 // can see local bindings like lambda parameters), while the actual macro binding is stored
 // in env.Expand() for lookup during expansion.
-func compileDefineSyntaxFromSyntax(ctx context.Context, env *environment.EnvironmentFrame, dsPair *syntax.SyntaxPair, libraryScope *syntax.Scope) error {
+func compileDefineSyntaxFromSyntax(ctx context.Context, env *environment.EnvironmentFrame, dsPair *syntax.SyntaxPair, libraryScope *syntax.Scope, evaluator MacroEvaluator) error {
 	expandEnv := env.Expand()
 
 	// Extract: (define-syntax keyword transformer)
@@ -161,7 +161,7 @@ func compileDefineSyntaxFromSyntax(ctx context.Context, env *environment.Environ
 	// Compile the transformer using the full environment for free identifier resolution
 	// This allows macros to see local bindings (e.g., lambda parameters, forward references)
 	// Supports both syntax-rules and lambda (procedural) transformers
-	closure, err := compileTransformerToMachineClosure(ctx, env, transformer, libraryScope)
+	closure, err := compileTransformerToMachineClosure(ctx, env, transformer, libraryScope, evaluator)
 	if err != nil {
 		return err
 	}

--- a/machine/expander_context_test.go
+++ b/machine/expander_context_test.go
@@ -28,7 +28,7 @@ func TestNewExpanderContext(t *testing.T) {
 	c := qt.New(t)
 
 	env := environment.NewNamespace().Runtime()
-	expander := NewExpanderTimeContinuation(context.Background(), env)
+	expander := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 
 	ctx := NewExpanderContext(env, expander)
 
@@ -40,7 +40,7 @@ func TestExpanderContext_IntroductionScope(t *testing.T) {
 	c := qt.New(t)
 
 	env := environment.NewNamespace().Runtime()
-	expander := NewExpanderTimeContinuation(context.Background(), env)
+	expander := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 
 	ctx := NewExpanderContext(env, expander)
 
@@ -57,7 +57,7 @@ func TestExpanderContext_UseSiteScope(t *testing.T) {
 	c := qt.New(t)
 
 	env := environment.NewNamespace().Runtime()
-	expander := NewExpanderTimeContinuation(context.Background(), env)
+	expander := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 
 	ctx := NewExpanderContext(env, expander)
 

--- a/machine/expander_coverage_test.go
+++ b/machine/expander_coverage_test.go
@@ -28,7 +28,7 @@ import (
 // newExpanderEnv creates a test environment with expander support.
 func newExpanderEnv() (*environment.EnvironmentFrame, *ExpanderTimeContinuation) {
 	env := newNamespace(environment.NewNamespace().Runtime())
-	expander := NewExpanderTimeContinuation(context.Background(), env)
+	expander := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	return env, expander
 }
 

--- a/machine/expander_ctx.go
+++ b/machine/expander_ctx.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"github.com/aalpar/wile/environment"
+	"github.com/aalpar/wile/internal/syntax"
+)
+
+// ExpanderCtx abstracts the macro expansion context so that code needing
+// expansion capabilities can depend on this interface rather than the
+// concrete ExpanderContext. This enables the future machine/compilation
+// sub-package to provide ExpanderContext without circular imports back
+// to machine/.
+type ExpanderCtx interface {
+	Env() *environment.EnvironmentFrame
+	Expand(syntax.SyntaxValue) (syntax.SyntaxValue, error)
+	ExpandOnce(syntax.SyntaxValue) (syntax.SyntaxValue, bool, error)
+	IntroductionScope() *syntax.Scope
+	SetIntroductionScope(*syntax.Scope)
+	UseSiteScope() *syntax.Scope
+	SetUseSiteScope(*syntax.Scope)
+}
+
+// Compile-time check: *ExpanderContext satisfies ExpanderCtx.
+var _ ExpanderCtx = (*ExpanderContext)(nil)

--- a/machine/expander_lambda.go
+++ b/machine/expander_lambda.go
@@ -92,7 +92,7 @@ func (p *ExpanderTimeContinuation) expandLambdaForm(sym *syntax.SyntaxSymbol, ex
 	unwrappedExprs, wasBeginWrapped := unwrapBeginBodyWithFlag(bodyExprs)
 
 	// Expand body in the child environment, compiling define-syntax as encountered
-	childExpander := NewExpanderTimeContinuation(p.ctx, childEnv)
+	childExpander := NewExpanderTimeContinuation(p.ctx, childEnv, p.evaluator)
 	expandedExprs, err := childExpander.ExpandBodyWithDefineSyntax(unwrappedExprs)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "lambda: failed to expand body")

--- a/machine/expander_let.go
+++ b/machine/expander_let.go
@@ -237,7 +237,7 @@ func (p *ExpanderTimeContinuation) expandLetBindings(
 	var initExpander *ExpanderTimeContinuation
 	if scopeInits {
 		childEnv := p.createBindingEnv(scopedNames)
-		initExpander = NewExpanderTimeContinuation(p.ctx, childEnv)
+		initExpander = NewExpanderTimeContinuation(p.ctx, childEnv, p.evaluator)
 	} else {
 		initExpander = p
 	}
@@ -335,7 +335,7 @@ func (p *ExpanderTimeContinuation) expandLetStarBindings(
 		// Add scope to init so references can resolve to preceding bindings.
 		scopedInit := syntax.AddScopeToSyntax(initExpr, scope)
 
-		currentExpander := NewExpanderTimeContinuation(p.ctx, childEnv)
+		currentExpander := NewExpanderTimeContinuation(p.ctx, childEnv, p.evaluator)
 		expandedInit, err := currentExpander.ExpandExpression(scopedInit)
 		if err != nil {
 			return nil, nil, err
@@ -392,7 +392,7 @@ func (p *ExpanderTimeContinuation) expandBindingBody(
 		return nil, err
 	}
 
-	childExpander := NewExpanderTimeContinuation(p.ctx, env)
+	childExpander := NewExpanderTimeContinuation(p.ctx, env, p.evaluator)
 	expandedExprs, err := childExpander.ExpandBodyWithDefineSyntax(bodyExprs)
 	if err != nil {
 		return nil, err

--- a/machine/expander_let_syntax.go
+++ b/machine/expander_let_syntax.go
@@ -173,7 +173,7 @@ func (p *ExpanderTimeContinuation) expandLetSyntaxImpl(sym *syntax.SyntaxSymbol,
 		transformerExpr := transformerPair.SyntaxCar()
 
 		// Compile the transformer (supports syntax-rules, lambda, er-macro-transformer)
-		closure, err := compileTransformerToMachineClosure(p.ctx, p.env, transformerExpr, p.libraryScope)
+		closure, err := compileTransformerToMachineClosure(p.ctx, p.env, transformerExpr, p.libraryScope, p.evaluator)
 		if err != nil {
 			return nil, werr.WrapForeignErrorf(err, "%s: could not compile transformer for %s", formName, keyword.Key)
 		}
@@ -210,7 +210,7 @@ func (p *ExpanderTimeContinuation) expandLetSyntaxImpl(sym *syntax.SyntaxSymbol,
 	}
 
 	// Create expander with child expand environment for body expansion
-	childExpander := NewExpanderTimeContinuation(p.ctx, childExpandEnv)
+	childExpander := NewExpanderTimeContinuation(p.ctx, childExpandEnv, p.evaluator)
 
 	// Expand all body expressions and check for defines
 	var expandedExprs []syntax.SyntaxValue

--- a/machine/expander_primitive_forms.go
+++ b/machine/expander_primitive_forms.go
@@ -352,7 +352,7 @@ func (p *ExpanderTimeContinuation) expandImportForm(sym *syntax.SyntaxSymbol, ex
 
 	// Process each import set to load libraries and copy bindings
 	_, err := syntax.SyntaxForEach(p.ctx, importSets, func(ctx context.Context, _ int, _ bool, importSetExpr syntax.SyntaxValue) error {
-		return ResolveAndInstallImportSet(ctx, importSetExpr.UnwrapAll(), p.env, environment.PhaseExpand)
+		return ResolveAndInstallImportSet(ctx, importSetExpr.UnwrapAll(), p.env, environment.PhaseExpand, p.evaluator)
 	})
 
 	if err != nil {

--- a/machine/expander_primitive_forms.go
+++ b/machine/expander_primitive_forms.go
@@ -128,7 +128,7 @@ func (p *ExpanderTimeContinuation) expandWithBindingScope(_ *syntax.SyntaxSymbol
 		}
 
 		// Continue expansion with the child environment
-		childExpander := NewExpanderTimeContinuation(p.ctx, childExpandEnv)
+		childExpander := NewExpanderTimeContinuation(p.ctx, childExpandEnv, p.evaluator)
 		return childExpander.ExpandExpression(scopedBody)
 	}
 

--- a/machine/expander_time_continuation.go
+++ b/machine/expander_time_continuation.go
@@ -58,13 +58,17 @@ type ExpanderTimeContinuation struct {
 	// libraryScope is set when expanding inside a library body.
 	// Threaded to CompileSyntaxRules for cross-library macro hygiene.
 	libraryScope *syntax.Scope
+	// evaluator abstracts VM execution for transformer invocation
+	// so the expander can be tested without the concrete VM.
+	evaluator MacroEvaluator
 }
 
 // NewExpanderTimeContinuation creates a new ExpanderTimeContinuation.
-func NewExpanderTimeContinuation(ctx context.Context, env *environment.EnvironmentFrame) *ExpanderTimeContinuation {
+func NewExpanderTimeContinuation(ctx context.Context, env *environment.EnvironmentFrame, evaluator MacroEvaluator) *ExpanderTimeContinuation {
 	q := &ExpanderTimeContinuation{
-		ctx: ctx,
-		env: env,
+		ctx:       ctx,
+		env:       env,
+		evaluator: evaluator,
 	}
 	return q
 }
@@ -266,7 +270,7 @@ func (p *ExpanderTimeContinuation) ExpandSyntaxExpression(sym *syntax.SyntaxSymb
 // On success, the caller receives the MachineContext with the result in the
 // value register and must call ReleaseSubContext when done. On error, cleanup
 // is handled internally.
-func invokeTransformerClosure(ctx context.Context, cls Closure, inputForm syntax.SyntaxValue, expanderCtx *ExpanderContext) (*MachineContext, error) {
+func invokeTransformerClosure(ctx context.Context, cls Closure, inputForm syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error) {
 	var mc *MachineContext
 	switch c := cls.(type) {
 	case *MachineClosure:
@@ -328,7 +332,7 @@ func (p *ExpanderTimeContinuation) expandMacroInvocation(sym *syntax.SyntaxSymbo
 	// determine that it shouldn't match the literal => in cond's pattern.
 	expanderCtx := NewExpanderContext(p.env, p)
 
-	mc, err := invokeTransformerClosure(p.ctx, cls, inputForm, expanderCtx)
+	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, inputForm, expanderCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +504,7 @@ func (p *ExpanderTimeContinuation) ExpandOnce(expr syntax.SyntaxValue) (syntax.S
 
 	inputForm := syntax.NewSyntaxCons(sym, cdr, sym.SourceContext())
 
-	mc, err := invokeTransformerClosure(p.ctx, cls, inputForm, nil)
+	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, inputForm, nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/machine/expander_time_continuation.go
+++ b/machine/expander_time_continuation.go
@@ -264,13 +264,14 @@ func (p *ExpanderTimeContinuation) ExpandSyntaxExpression(sym *syntax.SyntaxSymb
 }
 
 // invokeTransformerClosure invokes a Closure (MachineClosure or ForeignClosure)
-// as a macro transformer with the given input form. If expanderCtx is non-nil,
-// it is set on the context for auxiliary syntax hygiene (R7RS §4.3.2).
+// as a macro transformer. If expanderCtx is non-nil, it is set on the context
+// for auxiliary syntax hygiene (R7RS §4.3.2). args are passed to Apply — one
+// arg for syntax-rules/lambda transformers, three for ER macros.
 //
 // On success, the caller receives the MachineContext with the result in the
 // value register and must call ReleaseSubContext when done. On error, cleanup
 // is handled internally.
-func invokeTransformerClosure(ctx context.Context, cls Closure, inputForm syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error) {
+func invokeTransformerClosure(ctx context.Context, cls Closure, expanderCtx ExpanderCtx, args ...values.Value) (*MachineContext, error) {
 	var mc *MachineContext
 	switch c := cls.(type) {
 	case *MachineClosure:
@@ -278,7 +279,7 @@ func invokeTransformerClosure(ctx context.Context, cls Closure, inputForm syntax
 		if expanderCtx != nil {
 			mc.SetExpanderContext(expanderCtx)
 		}
-		_, err := mc.Apply(c, inputForm)
+		_, err := mc.Apply(c, args...)
 		if err != nil {
 			ReleaseSubContext(mc)
 			return nil, werr.WrapForeignErrorf(err, "failed to apply transformer")
@@ -295,7 +296,7 @@ func invokeTransformerClosure(ctx context.Context, cls Closure, inputForm syntax
 		if expanderCtx != nil {
 			mc.SetExpanderContext(expanderCtx)
 		}
-		_, err := mc.applyForeign(c, inputForm)
+		_, err := mc.applyForeign(c, args...)
 		if err != nil {
 			ReleaseSubContext(mc)
 			return nil, werr.WrapForeignErrorf(err, "failed to apply transformer")
@@ -332,7 +333,7 @@ func (p *ExpanderTimeContinuation) expandMacroInvocation(sym *syntax.SyntaxSymbo
 	// determine that it shouldn't match the literal => in cond's pattern.
 	expanderCtx := NewExpanderContext(p.env, p)
 
-	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, inputForm, expanderCtx)
+	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, expanderCtx, inputForm)
 	if err != nil {
 		return nil, err
 	}
@@ -400,19 +401,9 @@ func (p *ExpanderTimeContinuation) invokeERTransformer(
 	expanderCtx := NewExpanderContext(p.env, p)
 
 	// Invoke the 3-arg transformer: (transformer form rename compare)
-	mc := acquireMacroContext(p.ctx, erTransformer.Closure())
-	mc.SetExpanderContext(expanderCtx)
-
-	_, err := mc.Apply(erTransformer.Closure(), rawForm, renameCls, compareCls)
+	mc, err := p.evaluator.InvokeTransformer(p.ctx, erTransformer.Closure(), expanderCtx, rawForm, renameCls, compareCls)
 	if err != nil {
-		ReleaseSubContext(mc)
-		return nil, werr.WrapForeignErrorf(err, "er-macro-transformer: failed to apply transformer")
-	}
-
-	err = mc.Run()
-	if err != nil {
-		ReleaseSubContext(mc)
-		return nil, werr.WrapForeignErrorf(err, "er-macro-transformer: transformer raised an error")
+		return nil, werr.WrapForeignErrorf(err, "er-macro-transformer: transformer failed")
 	}
 	defer ReleaseSubContext(mc)
 
@@ -504,7 +495,7 @@ func (p *ExpanderTimeContinuation) ExpandOnce(expr syntax.SyntaxValue) (syntax.S
 
 	inputForm := syntax.NewSyntaxCons(sym, cdr, sym.SourceContext())
 
-	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, inputForm, nil)
+	mc, err := p.evaluator.InvokeTransformer(p.ctx, cls, nil, inputForm)
 	if err != nil {
 		return nil, false, err
 	}
@@ -553,14 +544,4 @@ func (p *ExpanderTimeContinuation) ExpandSyntaxArgumentList(args syntax.SyntaxVa
 		return nil, werr.WrapForeignErrorf(werr.ErrNotASyntaxList, "expected a list of arguments, got %T", tail)
 	}
 	return q, nil
-}
-
-// ExpandQuasiquote handles the expansion of quasiquoted expressions.
-func (p *ExpanderTimeContinuation) ExpandQuasiquote(_ syntax.SyntaxValue) (syntax.SyntaxValue, error) {
-	return nil, nil
-}
-
-// ExpandQuote handles the expansion of quoted expressions.
-func (p *ExpanderTimeContinuation) ExpandQuote(_ syntax.SyntaxValue) (syntax.SyntaxValue, error) {
-	return nil, nil
 }

--- a/machine/expander_time_continuation_test.go
+++ b/machine/expander_time_continuation_test.go
@@ -31,7 +31,7 @@ type dummyExpandTimeCallContext struct{} //nolint:unused
 
 func TestExpandSymbol_ReturnsSymbol(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	sym := syntax.NewSyntaxSymbol("bindSymbolWithScopes", nil)
 	result, err := cont.ExpandSymbol(sym)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestExpandSymbol_ReturnsSymbol(t *testing.T) {
 
 func TestExpandSelfEvaluating_ReturnsExpr(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	num := syntax.NewSyntaxObject(values.NewInteger(42), nil)
 	result, err := cont.ExpandSelfEvaluating(num)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestExpandSelfEvaluating_ReturnsExpr(t *testing.T) {
 
 func TestExpandExpression_Symbol(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	sym := syntax.NewSyntaxSymbol("bar", nil)
 	result, err := cont.ExpandExpression(sym)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestExpandExpression_List(t *testing.T) {
 	})
 	err := env.SetOwnGlobalValue(gi, mcls)
 	qt.Assert(t, err, qt.IsNil)
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 	lst0 := syntax.SyntaxList(nil,
 		syntax.NewSyntaxSymbol("bar", nil),
 		syntax.NewSyntaxObject(values.NewInteger(10), nil),
@@ -125,7 +125,7 @@ func TestExpandExpression_List(t *testing.T) {
 
 func TestExpandCaseLambdaForm_Basic(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 
 	// (case-lambda ((x) x) ((x y) (+ x y)))
 	sym := syntax.NewSyntaxSymbol("case-lambda", nil)
@@ -164,7 +164,7 @@ func TestExpandCaseLambdaForm_Basic(t *testing.T) {
 
 func TestExpandCaseLambdaForm_Empty(t *testing.T) {
 	env := environment.NewNamespace().Runtime()
-	cont := NewExpanderTimeContinuation(context.Background(), env)
+	cont := NewExpanderTimeContinuation(context.Background(), env, NewVMMacroEvaluator())
 
 	sym := syntax.NewSyntaxSymbol("case-lambda", nil)
 	emptyClauses := syntax.SyntaxList(nil)

--- a/machine/hygiene_test.go
+++ b/machine/hygiene_test.go
@@ -71,7 +71,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 		     ((lambda (name ...) body) val ...))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, letMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -91,7 +91,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 	`)
 
 	// Compile the define-syntax for swap!
-	ctc = machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc = machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx = machine.NewCompileTimeCallContext(context.Background(), false)
 	args = extractDefineSyntaxArgs(t, defineSyntaxForm)
 	err = ctc.CompileDefineSyntax(ctctx, args)
@@ -108,7 +108,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 	`)
 
 	// Expand the macro
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	if err != nil {
 		t.Fatalf("failed to expand: %v", err)
@@ -117,7 +117,7 @@ func TestBasicHygiene_SwapMacro(t *testing.T) {
 	t.Logf("Expanded: %s", expanded.SchemeString())
 
 	// Compile the expanded form
-	ctc2 := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc2 := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx2 := machine.NewCompileTimeCallContext(context.Background(), false)
 	err = ctc2.CompileExpression(ctctx2, expanded)
 	if err != nil {
@@ -139,7 +139,7 @@ func TestLetMacroExpansion(t *testing.T) {
 		    ((my-list x ...) (list x ...))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -150,7 +150,7 @@ func TestLetMacroExpansion(t *testing.T) {
 	// Test: (my-list 1 2 3) -> (list 1 2 3)
 	testForm := parseString(t, env, `(my-list 1 2 3)`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	if err != nil {
 		t.Fatalf("failed to expand my-list: %v", err)
@@ -178,7 +178,7 @@ func TestLetMacroSimple(t *testing.T) {
 		     ((lambda (name ...) body) val ...))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -189,7 +189,7 @@ func TestLetMacroSimple(t *testing.T) {
 	// Test: (let1 ((x 1)) x) -> ((lambda (x) x) 1)
 	testForm := parseString(t, env, `(let1 ((x 1)) x)`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	if err != nil {
 		t.Fatalf("failed to expand let1: %v", err)
@@ -214,7 +214,7 @@ func TestMultipleElementsWithTrailingEllipsis(t *testing.T) {
 		     (begin e1 e2 ...))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, simpleMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -225,7 +225,7 @@ func TestMultipleElementsWithTrailingEllipsis(t *testing.T) {
 	// Test with just one expression: (begin-with-first x) -> (begin x)
 	testForm := parseString(t, env, `(begin-with-first x)`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	if err != nil {
 		t.Fatalf("failed to expand: %v", err)
@@ -263,7 +263,7 @@ func TestLetMacroFull(t *testing.T) {
 		     ((lambda (name ...) (begin body ...)) val ...))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, letMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -274,7 +274,7 @@ func TestLetMacroFull(t *testing.T) {
 	// Test: (my-let ((x 1)) x) -> ((lambda (x) (begin x)) 1)
 	testForm := parseString(t, env, `(my-let ((x 1)) x)`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	if err != nil {
 		t.Fatalf("failed to expand my-let: %v", err)
@@ -297,7 +297,7 @@ func TestScopeCreation(t *testing.T) {
 		    ((bindSymbolWithScopes) 'expanded)))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -325,7 +325,7 @@ func TestScopeCreation(t *testing.T) {
 	//    during expansion (tested in the implementation)
 
 	// Test that we can expand using the ExpanderTimeContinuation
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 
 	// Debug: Check what the binding actually contains
 	qt.Assert(t, binding.Value(), qt.Not(qt.IsNil))
@@ -490,7 +490,7 @@ func TestAuxiliarySyntaxShadowing(t *testing.T) {
 					}
 
 					// Expand and compile each setup form
-					etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+					etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 					expanded, err := etc.ExpandExpression(form)
 					if err != nil {
 						t.Fatalf("failed to expand setup: %v", err)
@@ -503,7 +503,7 @@ func TestAuxiliarySyntaxShadowing(t *testing.T) {
 						if car != nil {
 							sym, ok := car.(*syntax.SyntaxSymbol)
 							if ok && sym.Sym.Key == "define-syntax" {
-								ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+								ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 								ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 								args := extractDefineSyntaxArgs(t, expanded)
 								err := ctc.CompileDefineSyntax(ctctx, args)
@@ -520,7 +520,7 @@ func TestAuxiliarySyntaxShadowing(t *testing.T) {
 			testForm := parseString(t, env, tt.code)
 
 			// Expand the test form
-			etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+			etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 			expanded, err := etc.ExpandExpression(testForm)
 			if err != nil {
 				t.Fatalf("failed to expand: %v", err)
@@ -584,7 +584,7 @@ func TestBoundIdentifierHygieneInNestedSyntaxRules(t *testing.T) {
 		             (n z)))))
 	`)
 
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, outerMacro)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -593,7 +593,7 @@ func TestBoundIdentifierHygieneInNestedSyntaxRules(t *testing.T) {
 	// Test: (m k) should expand to 'bound-identifier=?
 	testForm := parseString(t, env, `(m k)`)
 
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	qt.Assert(t, err, qt.IsNil, qt.Commentf("failed to expand (m k)"))
 
@@ -625,7 +625,7 @@ func TestVectorInMacroTemplate(t *testing.T) {
 	`
 
 	macroForm := parseString(t, env, macroCode)
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, macroForm)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -640,7 +640,7 @@ func TestVectorInMacroTemplate(t *testing.T) {
 	testForm := parseString(t, env, testCode)
 
 	// Expand - this is the critical part that tests SyntaxVector.AddScope
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	c.Assert(err, qt.IsNil, qt.Commentf("failed to expand"))
 
@@ -678,7 +678,7 @@ func TestNestedVectorInMacroTemplate(t *testing.T) {
 	`
 
 	macroForm := parseString(t, env, macroCode)
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, macroForm)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -693,7 +693,7 @@ func TestNestedVectorInMacroTemplate(t *testing.T) {
 	testForm := parseString(t, env, testCode)
 
 	// Expand - this tests that nested vectors propagate scopes correctly
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	c.Assert(err, qt.IsNil, qt.Commentf("failed to expand"))
 
@@ -722,7 +722,7 @@ func TestVectorWithIdentifiers(t *testing.T) {
 	`
 
 	macroForm := parseString(t, env, macroCode)
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	args := extractDefineSyntaxArgs(t, macroForm)
 	err := ctc.CompileDefineSyntax(ctctx, args)
@@ -737,7 +737,7 @@ func TestVectorWithIdentifiers(t *testing.T) {
 	testForm := parseString(t, env, testCode)
 
 	// Expand - this tests that vector elements receive intro scope
-	etc := machine.NewExpanderTimeContinuation(context.Background(), env)
+	etc := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := etc.ExpandExpression(testForm)
 	c.Assert(err, qt.IsNil, qt.Commentf("failed to expand"))
 

--- a/machine/let_shadow_macro_test.go
+++ b/machine/let_shadow_macro_test.go
@@ -49,14 +49,14 @@ func runSchemeCodeWithEnvForShadowTest(t *testing.T, env *environment.Environmen
 	}
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, err
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/machine/library_bindings.go
+++ b/machine/library_bindings.go
@@ -161,13 +161,13 @@ type ResolvedImportSet struct {
 //
 // The env parameter is used only for library loading (to find the library
 // registry and resolve paths). It is NOT the target for binding installation.
-func resolveImportSet(ctx context.Context, datum values.Value, env *environment.EnvironmentFrame) (*ResolvedImportSet, error) {
+func resolveImportSet(ctx context.Context, datum values.Value, env *environment.EnvironmentFrame, evaluator MacroEvaluator) (*ResolvedImportSet, error) {
 	importSet, err := ParseImportSetFromDatum(ctx, datum)
 	if err != nil {
 		return nil, err
 	}
 
-	lib, err := LoadLibrary(ctx, importSet.LibraryName, env)
+	lib, err := LoadLibrary(ctx, importSet.LibraryName, env, evaluator)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "import: failed to load library %s",
 			importSet.LibraryName.SchemeString())
@@ -190,8 +190,8 @@ func resolveImportSet(ctx context.Context, datum values.Value, env *environment.
 // env at the appropriate phase. Used for top-level imports (both expander and
 // compiler). Library-internal imports share the resolution step (resolveImportSet)
 // but use copyLibraryBindingsDirect for installation.
-func ResolveAndInstallImportSet(ctx context.Context, datum values.Value, env *environment.EnvironmentFrame, phase int) error {
-	res, err := resolveImportSet(ctx, datum, env)
+func ResolveAndInstallImportSet(ctx context.Context, datum values.Value, env *environment.EnvironmentFrame, phase int, evaluator MacroEvaluator) error {
+	res, err := resolveImportSet(ctx, datum, env, evaluator)
 	if err != nil {
 		return err
 	}

--- a/machine/library_loader.go
+++ b/machine/library_loader.go
@@ -174,7 +174,7 @@ func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expec
 	tpl := NewNativeTemplate(0, 0, false)
 
 	// Expand the form
-	expanded, err := NewExpanderTimeContinuation(ctx, libEnv).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ctx, libEnv, NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "error expanding library")
 	}
@@ -182,7 +182,7 @@ func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expec
 	// Compile the form
 	// Use inTail=false for top-level expressions
 	cctx := NewCompileTimeCallContext(ctx, false)
-	compiler := NewCompiletimeContinuation(tpl, libEnv)
+	compiler := NewCompiletimeContinuation(tpl, libEnv, NewVMMacroEvaluator())
 
 	// Set up to capture the compiled library
 	var compiledLib *CompiledLibrary

--- a/machine/library_loader.go
+++ b/machine/library_loader.go
@@ -47,7 +47,7 @@ import (
 // 4. Parses and compiles the define-library form
 // 5. Executes the library to create runtime bindings
 // 6. Registers the library in the registry
-func LoadLibrary(ctx context.Context, name LibraryName, env *environment.EnvironmentFrame) (*CompiledLibrary, error) {
+func LoadLibrary(ctx context.Context, name LibraryName, env *environment.EnvironmentFrame, evaluator MacroEvaluator) (*CompiledLibrary, error) {
 	registryAny := env.LibraryRegistry()
 	if registryAny == nil {
 		return nil, werr.WrapForeignErrorf(werr.ErrLibraryConfiguration, "load-library: no library registry configured")
@@ -95,7 +95,7 @@ func LoadLibrary(ctx context.Context, name LibraryName, env *environment.Environ
 	}
 	defer f.Close() //nolint:errcheck
 
-	lib, err = loadLibraryFromReader(ctx, f, filePath, name, env)
+	lib, err = loadLibraryFromReader(ctx, f, filePath, name, env, evaluator)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err,
 			"error loading library %s from %s", name.SchemeString(), filePath)
@@ -111,7 +111,7 @@ func LoadLibrary(ctx context.Context, name LibraryName, env *environment.Environ
 }
 
 // loadLibraryFromReader parses, compiles, and executes a library from an open reader.
-func loadLibraryFromReader(ctx context.Context, r io.Reader, filePath string, expectedName LibraryName, callerEnv *environment.EnvironmentFrame) (*CompiledLibrary, error) {
+func loadLibraryFromReader(ctx context.Context, r io.Reader, filePath string, expectedName LibraryName, callerEnv *environment.EnvironmentFrame, evaluator MacroEvaluator) (*CompiledLibrary, error) {
 	// Push to stack after successful open, pop on exit.
 	stack := callerEnv.LoadPathStack()
 	if stack != nil {
@@ -160,7 +160,7 @@ func loadLibraryFromReader(ctx context.Context, r io.Reader, filePath string, ex
 		return nil, werr.WrapForeignErrorf(werr.ErrLibraryFormMalformed, "expected define-library, got %s", symName)
 	}
 
-	lib, err := compileAndExecuteLibrary(ctx, stx, expectedName, libEnv, filePath)
+	lib, err := compileAndExecuteLibrary(ctx, stx, expectedName, libEnv, filePath, evaluator)
 	if err != nil {
 		return nil, err
 	}
@@ -169,12 +169,12 @@ func loadLibraryFromReader(ctx context.Context, r io.Reader, filePath string, ex
 }
 
 // compileAndExecuteLibrary compiles a define-library form and executes it.
-func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expectedName LibraryName, libEnv *environment.EnvironmentFrame, filePath string) (*CompiledLibrary, error) {
+func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expectedName LibraryName, libEnv *environment.EnvironmentFrame, filePath string, evaluator MacroEvaluator) (*CompiledLibrary, error) {
 	// Create a template for the top-level compilation (will be empty after define-library)
 	tpl := NewNativeTemplate(0, 0, false)
 
 	// Expand the form
-	expanded, err := NewExpanderTimeContinuation(ctx, libEnv, NewVMMacroEvaluator()).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ctx, libEnv, evaluator).ExpandExpression(stx)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "error expanding library")
 	}
@@ -182,7 +182,7 @@ func compileAndExecuteLibrary(ctx context.Context, stx syntax.SyntaxValue, expec
 	// Compile the form
 	// Use inTail=false for top-level expressions
 	cctx := NewCompileTimeCallContext(ctx, false)
-	compiler := NewCompiletimeContinuation(tpl, libEnv, NewVMMacroEvaluator())
+	compiler := NewCompiletimeContinuation(tpl, libEnv, evaluator)
 
 	// Set up to capture the compiled library
 	var compiledLib *CompiledLibrary

--- a/machine/library_loader_test.go
+++ b/machine/library_loader_test.go
@@ -41,7 +41,7 @@ func TestLibraryLoaderNotFound(t *testing.T) {
 	env.SetLibraryRegistry(registry)
 
 	name := machine.NewLibraryName("no", "such", "library")
-	_, err = machine.LoadLibrary(context.Background(), name, env)
+	_, err = machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "not found")
 }
@@ -55,7 +55,7 @@ func TestLibraryLoaderNoRegistry(t *testing.T) {
 	// Intentionally NOT setting a library registry
 
 	name := machine.NewLibraryName("scheme", "base")
-	_, err := machine.LoadLibrary(context.Background(), name, env)
+	_, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "no library registry")
 }
@@ -85,7 +85,7 @@ func TestLibraryLoaderMalformedFile(t *testing.T) {
 	env.SetLibraryRegistry(registry)
 
 	name := machine.NewLibraryName("bad", "lib")
-	_, err = machine.LoadLibrary(context.Background(), name, env)
+	_, err = machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 }
 
@@ -111,7 +111,7 @@ func TestLibraryLoaderEmptyFile(t *testing.T) {
 	env.SetLibraryRegistry(registry)
 
 	name := machine.NewLibraryName("empty", "lib")
-	_, err = machine.LoadLibrary(context.Background(), name, env)
+	_, err = machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "empty")
 }
@@ -144,7 +144,7 @@ func TestLibraryLoaderNameMismatch(t *testing.T) {
 	env.SetLibraryRegistry(registry)
 
 	name := machine.NewLibraryName("wrong", "lib")
-	_, err = machine.LoadLibrary(context.Background(), name, env)
+	_, err = machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "mismatch")
 }
@@ -157,11 +157,11 @@ func TestLibraryLoaderCachedReturn(t *testing.T) {
 
 	name := machine.NewLibraryName("test", "simple")
 
-	lib1, err := machine.LoadLibrary(context.Background(), name, env)
+	lib1, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 	c.Assert(lib1, qt.IsNotNil)
 
-	lib2, err := machine.LoadLibrary(context.Background(), name, env)
+	lib2, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 
 	// Same pointer — returned from cache, not recompiled

--- a/machine/library_scheme_test.go
+++ b/machine/library_scheme_test.go
@@ -76,7 +76,7 @@ func compileAndRun(t *testing.T, env *environment.EnvironmentFrame, sv syntax.Sy
 	t.Helper()
 
 	// Expand the expression
-	econt := machine.NewExpanderTimeContinuation(context.Background(), env)
+	econt := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator())
 	expanded, err := econt.ExpandExpression(sv)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func compileAndRun(t *testing.T, env *environment.EnvironmentFrame, sv syntax.Sy
 
 	// Compile the expanded expression
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err = ctc.CompileExpression(ctctx, expanded)
 	if err != nil {
@@ -128,7 +128,7 @@ func TestSchemeLibraryImports(t *testing.T) {
 
 	// Compile the import
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -204,7 +204,7 @@ func TestSchemeLibraryImportsWithUsage(t *testing.T) {
 	args := importPair.Cdr().(syntax.SyntaxValue)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileImport(ctctx, args)
 	c.Assert(err, qt.IsNil)
@@ -256,12 +256,12 @@ func TestLibraryInternalMacroHygiene(t *testing.T) {
 
 	// Expand
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(sv)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(sv)
 	c.Assert(err, qt.IsNil, qt.Commentf("library expansion should succeed"))
 
 	// Compile with library callback to capture the CompiledLibrary
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	compiler := machine.NewCompiletimeContinuation(tpl, env)
+	compiler := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	var compiledLib *machine.CompiledLibrary
 	compiler.SetLibraryCallback(func(lib *machine.CompiledLibrary) {
 		compiledLib = lib
@@ -332,7 +332,7 @@ func TestIndividualSchemeLibraries(t *testing.T) {
 			args := importPair.Cdr().(syntax.SyntaxValue)
 
 			tpl := machine.NewNativeTemplate(0, 0, false)
-			ctc := machine.NewCompiletimeContinuation(tpl, env)
+			ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 			ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 			err := ctc.CompileImport(ctctx, args)
 			c.Assert(err, qt.IsNil, qt.Commentf("failed to import (scheme %s)", lib.name))
@@ -358,11 +358,11 @@ func compileAndRegisterLibrary(t *testing.T, env *environment.EnvironmentFrame, 
 	c := qt.New(t)
 
 	sv := parseSchemeExpr(t, env, libCode)
-	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env).ExpandExpression(sv)
+	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator()).ExpandExpression(sv)
 	c.Assert(err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	compiler := machine.NewCompiletimeContinuation(tpl, env)
+	compiler := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	var compiledLib *machine.CompiledLibrary
 	compiler.SetLibraryCallback(func(lib *machine.CompiledLibrary) {
 		compiledLib = lib

--- a/machine/library_test.go
+++ b/machine/library_test.go
@@ -200,7 +200,7 @@ func TestCompileDefineLibrary_Basic(t *testing.T) {
 
 	// Compile the library
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileDefineLibrary(ctctx, args)
@@ -219,7 +219,7 @@ func TestCompileDefineLibrary_Empty(t *testing.T) {
 
 	// Compile
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileDefineLibrary(ctctx, args)
@@ -274,7 +274,7 @@ func TestLibraryDescription(t *testing.T) {
 			args := libPair.Cdr().(*syntax.SyntaxPair)
 
 			tpl := machine.NewNativeTemplate(0, 0, false)
-			ctc := machine.NewCompiletimeContinuation(tpl, env)
+			ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 
 			var compiledLib *machine.CompiledLibrary
 			ctc.SetLibraryCallback(func(lib *machine.CompiledLibrary) {
@@ -314,7 +314,7 @@ func TestCompileImport_LibraryNotFound(t *testing.T) {
 
 	// Compile - should fail because (scheme base) doesn't exist
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -335,7 +335,7 @@ func TestCompileImport_NoRegistry(t *testing.T) {
 
 	// Compile - should fail because no registry is configured
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -355,7 +355,7 @@ func TestCompileExport_TopLevelError(t *testing.T) {
 
 	// Compile - should error at top level
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileExport(ctctx, args)
@@ -478,7 +478,7 @@ func TestImport_Simple(t *testing.T) {
 	args := importPair.Cdr().(syntax.SyntaxValue)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -506,7 +506,7 @@ func TestImport_OnlyModifier(t *testing.T) {
 	args := importPair.Cdr().(syntax.SyntaxValue)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -531,7 +531,7 @@ func TestImport_PrefixModifier(t *testing.T) {
 	args := importPair.Cdr().(syntax.SyntaxValue)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err := ctc.CompileImport(ctctx, args)
@@ -825,7 +825,7 @@ func TestLibraryForwardReferences(t *testing.T) {
 
 	// Create compiler and expand the library definition
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	c.Assert(err, qt.IsNil)
 
 	// Compile the library - this should succeed with forward references
@@ -833,7 +833,7 @@ func TestLibraryForwardReferences(t *testing.T) {
 	// "no such local or global binding \"callee\""
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	compiler := machine.NewCompiletimeContinuation(tpl, env)
+	compiler := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	err = compiler.CompileExpression(ctctx, expanded)
 	c.Assert(err, qt.IsNil, qt.Commentf("Forward references should work with letrec* semantics"))
 }
@@ -868,7 +868,7 @@ func TestLoadLibrary_IncludeStampsLibraryScope(t *testing.T) {
 	args := importPair.Cdr().(syntax.SyntaxValue)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ctc := machine.NewCompiletimeContinuation(tpl, env)
+	ctc := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
 	err = ctc.CompileImport(ctctx, args)
@@ -877,10 +877,10 @@ func TestLoadLibrary_IncludeStampsLibraryScope(t *testing.T) {
 	// Compile and run (double-base)
 	callExpr := parseLibrarySyntax(t, env, `(double-base)`)
 	callTpl := machine.NewNativeTemplate(0, 0, false)
-	callCtc := machine.NewCompiletimeContinuation(callTpl, env)
+	callCtc := machine.NewCompiletimeContinuation(callTpl, env, machine.NewVMMacroEvaluator())
 	callCtctx := machine.NewCompileTimeCallContext(context.Background(), false)
 
-	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env).ExpandExpression(callExpr)
+	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator()).ExpandExpression(callExpr)
 	c.Assert(err, qt.IsNil)
 
 	err = callCtc.CompileExpression(callCtctx, expanded)

--- a/machine/library_test.go
+++ b/machine/library_test.go
@@ -394,7 +394,7 @@ func TestLoadLibrary_Simple(t *testing.T) {
 
 	// Load the simple library
 	name := machine.NewLibraryName("test", "simple")
-	lib, err := machine.LoadLibrary(context.Background(), name, env)
+	lib, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 	c.Assert(lib, qt.IsNotNil)
 
@@ -414,10 +414,10 @@ func TestLoadLibrary_Cached(t *testing.T) {
 
 	// Load the same library twice
 	name := machine.NewLibraryName("test", "simple")
-	lib1, err := machine.LoadLibrary(context.Background(), name, env)
+	lib1, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 
-	lib2, err := machine.LoadLibrary(context.Background(), name, env)
+	lib2, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 
 	// Should return the same cached library
@@ -430,7 +430,7 @@ func TestLoadLibrary_WithImports(t *testing.T) {
 
 	// Load the importer library (which imports test/simple)
 	name := machine.NewLibraryName("test", "importer")
-	lib, err := machine.LoadLibrary(context.Background(), name, env)
+	lib, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 	c.Assert(lib, qt.IsNotNil)
 
@@ -451,7 +451,7 @@ func TestLoadLibrary_CircularDependency(t *testing.T) {
 
 	// Try to load a library with circular dependency
 	name := machine.NewLibraryName("test", "circular-a")
-	_, err := machine.LoadLibrary(context.Background(), name, env)
+	_, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "circular")
 }
@@ -462,7 +462,7 @@ func TestLoadLibrary_NotFound(t *testing.T) {
 
 	// Try to load a non-existent library
 	name := machine.NewLibraryName("nonexistent", "lib")
-	_, err := machine.LoadLibrary(context.Background(), name, env)
+	_, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "not found")
 }
@@ -849,7 +849,7 @@ func TestLoadLibrary_IncludeStampsLibraryScope(t *testing.T) {
 
 	// Load the library that uses (include "include-body.scm")
 	name := machine.NewLibraryName("test", "include-lib")
-	lib, err := machine.LoadLibrary(context.Background(), name, env)
+	lib, err := machine.LoadLibrary(context.Background(), name, env, machine.NewVMMacroEvaluator())
 	c.Assert(err, qt.IsNil)
 	c.Assert(lib, qt.IsNotNil)
 

--- a/machine/machine_context.go
+++ b/machine/machine_context.go
@@ -64,7 +64,7 @@ type MachineContext struct {
 	ctx context.Context
 	vmState
 	cont             *MachineContinuation // current continuation
-	expanderCtx      *ExpanderContext     // set during macro transformer execution for syntax-local-* access
+	expanderCtx      ExpanderCtx          // set during macro transformer execution for syntax-local-* access
 	exceptionHandler *ExceptionHandler    // current exception handler chain for R7RS exceptions
 	debugger         *Debugger            // optional debugger for breakpoints and stepping
 	parentMC         *MachineContext      // parent context for sub-contexts, enables call/cc escape tracking
@@ -820,12 +820,12 @@ func (p *MachineContext) Run() error {
 
 // SetExpanderContext sets the expander context for this machine context.
 // This is called when invoking macro transformers to enable syntax-local-* primitives.
-func (p *MachineContext) SetExpanderContext(ctx *ExpanderContext) {
+func (p *MachineContext) SetExpanderContext(ctx ExpanderCtx) {
 	p.expanderCtx = ctx
 }
 
 // ExpanderContext returns the expander context, or nil if not in expansion context.
-func (p *MachineContext) ExpanderContext() *ExpanderContext {
+func (p *MachineContext) ExpanderContext() ExpanderCtx {
 	return p.expanderCtx
 }
 

--- a/machine/macro_evaluator.go
+++ b/machine/macro_evaluator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/aalpar/wile/environment"
-	"github.com/aalpar/wile/internal/syntax"
 	"github.com/aalpar/wile/values"
 )
 
@@ -31,12 +30,14 @@ type MacroEvaluator interface {
 	// for define-syntax lambda transformers at compile time.
 	EvalTemplate(ctx context.Context, tpl *NativeTemplate, env *environment.EnvironmentFrame) (values.Value, error)
 
-	// InvokeTransformer calls a closure as a macro transformer with the given
-	// input form. expanderCtx is set on the VM context for auxiliary syntax
-	// hygiene (R7RS Section 4.3.2). On success, the caller receives the
-	// MachineContext with the result in the value register and must call
-	// ReleaseSubContext when done.
-	InvokeTransformer(ctx context.Context, cls Closure, input syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error)
+	// InvokeTransformer calls a closure as a macro transformer.
+	// expanderCtx is set on the VM context for auxiliary syntax
+	// hygiene (R7RS Section 4.3.2); nil is valid when no hygiene context
+	// is needed (e.g. ExpandOnce). args are passed to Apply — one arg for
+	// syntax-rules/lambda transformers, three for ER macros (form, rename,
+	// compare). On success, the caller receives the MachineContext with the
+	// result in the value register and must call ReleaseSubContext when done.
+	InvokeTransformer(ctx context.Context, cls Closure, expanderCtx ExpanderCtx, args ...values.Value) (*MachineContext, error)
 }
 
 // vmMacroEvaluator implements MacroEvaluator using the real VM execution path.
@@ -57,12 +58,15 @@ func (p *vmMacroEvaluator) EvalTemplate(ctx context.Context, tpl *NativeTemplate
 	mc := NewMachineContext(ctx, cont)
 	err := mc.Run()
 	if err != nil {
+		ReleaseSubContext(mc)
 		return nil, err
 	}
-	return mc.GetValue(), nil
+	q := mc.GetValue()
+	ReleaseSubContext(mc)
+	return q, nil
 }
 
 // InvokeTransformer delegates to invokeTransformerClosure.
-func (p *vmMacroEvaluator) InvokeTransformer(ctx context.Context, cls Closure, input syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error) {
-	return invokeTransformerClosure(ctx, cls, input, expanderCtx)
+func (p *vmMacroEvaluator) InvokeTransformer(ctx context.Context, cls Closure, expanderCtx ExpanderCtx, args ...values.Value) (*MachineContext, error) {
+	return invokeTransformerClosure(ctx, cls, expanderCtx, args...)
 }

--- a/machine/macro_evaluator.go
+++ b/machine/macro_evaluator.go
@@ -40,11 +40,16 @@ type MacroEvaluator interface {
 }
 
 // vmMacroEvaluator implements MacroEvaluator using the real VM execution path.
+// Stateless — all call sites share a single instance via NewVMMacroEvaluator.
 type vmMacroEvaluator struct{}
+
+// sharedVMEvaluator is the singleton instance. vmMacroEvaluator is stateless,
+// so a single allocation serves all callers.
+var sharedVMEvaluator MacroEvaluator = &vmMacroEvaluator{}
 
 // NewVMMacroEvaluator returns a MacroEvaluator backed by the real VM.
 func NewVMMacroEvaluator() MacroEvaluator {
-	return &vmMacroEvaluator{}
+	return sharedVMEvaluator
 }
 
 func (p *vmMacroEvaluator) EvalTemplate(ctx context.Context, tpl *NativeTemplate, env *environment.EnvironmentFrame) (values.Value, error) {

--- a/machine/macro_evaluator.go
+++ b/machine/macro_evaluator.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package machine
+
+import (
+	"context"
+
+	"github.com/aalpar/wile/environment"
+	"github.com/aalpar/wile/internal/syntax"
+	"github.com/aalpar/wile/values"
+)
+
+// MacroEvaluator abstracts VM execution for the compiler and expander so that
+// compile-time evaluation and transformer invocation can be tested and wired
+// without depending on the concrete MachineContext construction path.
+type MacroEvaluator interface {
+	// EvalTemplate evaluates a compiled template in the given environment
+	// and returns the resulting value. Used by compileAndEvalLambdaTransformer
+	// for define-syntax lambda transformers at compile time.
+	EvalTemplate(ctx context.Context, tpl *NativeTemplate, env *environment.EnvironmentFrame) (values.Value, error)
+
+	// InvokeTransformer calls a closure as a macro transformer with the given
+	// input form. expanderCtx is set on the VM context for auxiliary syntax
+	// hygiene (R7RS Section 4.3.2). On success, the caller receives the
+	// MachineContext with the result in the value register and must call
+	// ReleaseSubContext when done.
+	InvokeTransformer(ctx context.Context, cls Closure, input syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error)
+}
+
+// vmMacroEvaluator implements MacroEvaluator using the real VM execution path.
+type vmMacroEvaluator struct{}
+
+// NewVMMacroEvaluator returns a MacroEvaluator backed by the real VM.
+func NewVMMacroEvaluator() MacroEvaluator {
+	return &vmMacroEvaluator{}
+}
+
+func (p *vmMacroEvaluator) EvalTemplate(ctx context.Context, tpl *NativeTemplate, env *environment.EnvironmentFrame) (values.Value, error) {
+	cont := NewMachineContinuation(nil, tpl, env)
+	mc := NewMachineContext(ctx, cont)
+	err := mc.Run()
+	if err != nil {
+		return nil, err
+	}
+	return mc.GetValue(), nil
+}
+
+// InvokeTransformer delegates to invokeTransformerClosure.
+func (p *vmMacroEvaluator) InvokeTransformer(ctx context.Context, cls Closure, input syntax.SyntaxValue, expanderCtx ExpanderCtx) (*MachineContext, error) {
+	return invokeTransformerClosure(ctx, cls, input, expanderCtx)
+}

--- a/machine/record_test.go
+++ b/machine/record_test.go
@@ -51,13 +51,13 @@ func evalScheme(t *testing.T, code string) values.Value {
 
 		// Expand
 		ectx := context.Background()
-		expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+		expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 		qt.Assert(t, err, qt.IsNil)
 
 		// Compile
 		tpl := machine.NewNativeTemplate(0, 0, false)
 		cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-		err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+		err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 		qt.Assert(t, err, qt.IsNil)
 
 		// Run

--- a/machine/scope_resolution_test.go
+++ b/machine/scope_resolution_test.go
@@ -72,13 +72,13 @@ func evalScope(t *testing.T, env *environment.EnvironmentFrame, code string) (va
 
 // evalScopeSyntax runs a parsed syntax value through expand → compile → run.
 func evalScopeSyntax(env *environment.EnvironmentFrame, sv syntax.SyntaxValue) (values.Value, error) {
-	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env).ExpandExpression(sv)
+	expanded, err := machine.NewExpanderTimeContinuation(context.Background(), env, machine.NewVMMacroEvaluator()).ExpandExpression(sv)
 	if err != nil {
 		return nil, err
 	}
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(ctctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(ctctx, expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/machine/source_recording_test.go
+++ b/machine/source_recording_test.go
@@ -36,11 +36,11 @@ func compileScheme(t *testing.T, code string) *NativeTemplate {
 
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, err := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	return tpl
@@ -110,10 +110,10 @@ func TestSourceRecording_Call(t *testing.T) {
 	stx, _ := p.ReadSyntax(context.TODO())
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, err := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	// Now compile a call to that function
@@ -123,10 +123,10 @@ func TestSourceRecording_Call(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl2 := NewNativeTemplate(0, 0, false)
-	expanded, err = NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err = NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
-	err = NewCompiletimeContinuation(tpl2, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl2, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 }
 
@@ -140,9 +140,9 @@ func TestSourceRecording_SetBang(t *testing.T) {
 	stx, _ := p.ReadSyntax(context.TODO())
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, _ := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, _ := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	err := NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err := NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	// Now compile (set! x 2)
@@ -152,10 +152,10 @@ func TestSourceRecording_SetBang(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl2 := NewNativeTemplate(0, 0, false)
-	expanded, err = NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err = NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
-	err = NewCompiletimeContinuation(tpl2, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl2, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 }
 
@@ -179,11 +179,11 @@ func TestSourceRecording_SourceLocationPreserved(t *testing.T) {
 
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, err := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	// Source should point to the correct file

--- a/machine/source_tracking_coverage_test.go
+++ b/machine/source_tracking_coverage_test.go
@@ -454,9 +454,9 @@ func TestSourceRecording_Symbol(t *testing.T) {
 	stx, _ := p.ReadSyntax(context.TODO())
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, _ := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, _ := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	_ = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	_ = NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 
 	// Now reference x
 	rdr = strings.NewReader("x")
@@ -465,10 +465,10 @@ func TestSourceRecording_Symbol(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	tpl2 := NewNativeTemplate(0, 0, false)
-	expanded, err = NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err = NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	c.Assert(err, qt.IsNil)
 
-	err = NewCompiletimeContinuation(tpl2, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl2, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	c.Assert(err, qt.IsNil)
 
 	source := tpl2.SourceAt(0)
@@ -487,11 +487,11 @@ func TestSourceRecording_Literal(t *testing.T) {
 
 	tpl := NewNativeTemplate(0, 0, false)
 	ectx := context.Background()
-	expanded, err := NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := NewExpanderTimeContinuation(ectx, env, NewVMMacroEvaluator()).ExpandExpression(stx)
 	c.Assert(err, qt.IsNil)
 
 	cctx := NewCompileTimeCallContext(context.Background(), false)
-	err = NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = NewCompiletimeContinuation(tpl, env, NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	c.Assert(err, qt.IsNil)
 
 	source := tpl.SourceAt(0)

--- a/machine/syntax_rules_test.go
+++ b/machine/syntax_rules_test.go
@@ -71,7 +71,7 @@ func TestSyntaxRulesSimpleVariable(t *testing.T) {
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 	// Compile define-syntax
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -114,7 +114,7 @@ func TestSyntaxRulesWithLiteral(t *testing.T) {
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 	// Compile define-syntax
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestSyntaxRulesWithEllipsis(t *testing.T) {
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 	// Compile define-syntax
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestSyntaxRulesWithCustomEllipsis(t *testing.T) {
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 	// Compile define-syntax
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -232,7 +232,7 @@ func TestSyntaxRulesWithUnderscoreInLiterals(t *testing.T) {
 	args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 	// Compile define-syntax
-	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+	ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 	ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	err := ctc.CompileDefineSyntax(ctctx, args)
 	if err != nil {
@@ -270,7 +270,7 @@ func TestSyntaxRulesEllipsisInLiteralsAccepted(t *testing.T) {
 		args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 		// Compile should succeed - ellipsis in literals disables ellipsis functionality
-		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 		ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 		err := ctc.CompileDefineSyntax(ctctx, args)
 		if err != nil {
@@ -290,7 +290,7 @@ func TestSyntaxRulesEllipsisInLiteralsAccepted(t *testing.T) {
 		args := extractDefineSyntaxArgs(t, defineSyntaxForm)
 
 		// Compile should succeed - ellipsis in literals disables ellipsis functionality
-		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env)
+		ctc := machine.NewCompiletimeContinuation(machine.NewNativeTemplate(0, 0, false), env, machine.NewVMMacroEvaluator())
 		ctctx := machine.NewCompileTimeCallContext(context.Background(), false)
 		err := ctc.CompileDefineSyntax(ctctx, args)
 		if err != nil {

--- a/registry/core/prim_bench_test.go
+++ b/registry/core/prim_bench_test.go
@@ -108,14 +108,14 @@ func benchCompile(ctx context.Context, b *testing.B, env *environment.Environmen
 		b.Fatal(err)
 	}
 
-	expanded, err := machine.NewExpanderTimeContinuation(ctx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ctx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(ctx, false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/registry/core/prim_control_test.go
+++ b/registry/core/prim_control_test.go
@@ -619,12 +619,12 @@ func TestDynamicWindEscape(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))

--- a/registry/core/prim_io_test.go
+++ b/registry/core/prim_io_test.go
@@ -69,7 +69,7 @@ func TestDisplayWithBuffer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (display "hello")
@@ -96,7 +96,7 @@ func TestWriteWithBuffer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write 42)
@@ -123,7 +123,7 @@ func TestWriteCharWithBuffer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write-char #\A)
@@ -150,7 +150,7 @@ func TestNewlineWithBuffer(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (newline)
@@ -177,7 +177,7 @@ func TestReadToken(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (read-token)
@@ -206,7 +206,7 @@ func TestReadSyntax(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (read-syntax)
@@ -236,7 +236,7 @@ func TestRead(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (read)
@@ -265,7 +265,7 @@ func TestReadWithPort(t *testing.T) {
 	// We need to test read with an explicit port - use lambda to capture port
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// Create a program that reads from the port
@@ -298,7 +298,7 @@ func TestDisplayWithSymbol(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (display 'hello) - symbol
@@ -326,7 +326,7 @@ func TestWriteWithString(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write "hello") - string with quotes
@@ -353,7 +353,7 @@ func TestWriteCharWithUnicode(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write-char #\λ) - unicode character
@@ -382,7 +382,7 @@ func TestReadMultipleTokens(t *testing.T) {
 	// Read first token
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	prog := values.List(values.NewSymbol("read-token"))
@@ -409,7 +409,7 @@ func TestDisplayWithInteger(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (display 123) - integer
@@ -436,7 +436,7 @@ func TestDisplayWithBoolean(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (display #t)
@@ -463,7 +463,7 @@ func TestWriteWithSymbol(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write 'foo) - symbol
@@ -511,7 +511,7 @@ func TestDisplayWithList(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (display '(1 2 3)) - list
@@ -540,7 +540,7 @@ func TestWriteWithList(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 
 	// (write '(a b c)) - list
@@ -575,12 +575,12 @@ func TestStringPorts(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))
@@ -605,12 +605,12 @@ func TestStringInputPort(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))
@@ -638,12 +638,12 @@ func TestBytevectorPorts(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))
@@ -668,12 +668,12 @@ func TestBytevectorInputPort(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 
 	ectx := context.Background()
-	expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	qt.Assert(t, err, qt.IsNil)
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	qt.Assert(t, err, qt.IsNil)
 
 	mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))
@@ -750,12 +750,12 @@ func TestPortPredicates(t *testing.T) {
 			qt.Assert(t, err, qt.IsNil)
 
 			ectx := context.Background()
-			expanded, err := machine.NewExpanderTimeContinuation(ectx, env).ExpandExpression(stx)
+			expanded, err := machine.NewExpanderTimeContinuation(ectx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 			qt.Assert(t, err, qt.IsNil)
 
 			tpl := machine.NewNativeTemplate(0, 0, false)
 			cctx := machine.NewCompileTimeCallContext(context.Background(), false)
-			err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+			err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 			qt.Assert(t, err, qt.IsNil)
 
 			mc := machine.NewMachineContext(context.Background(), machine.NewMachineContinuation(nil, tpl, env))

--- a/registry/testhelpers/pipeline_helpers.go
+++ b/registry/testhelpers/pipeline_helpers.go
@@ -44,7 +44,7 @@ func RunProgramASTWithEnv(t *testing.T, env *environment.EnvironmentFrame, prog 
 	t.Helper()
 	cctx := machine.NewCompileTimeCallContext(context.Background(), false)
 	tpl := machine.NewNativeTemplate(0, 0, false)
-	ccnt := machine.NewCompiletimeContinuation(tpl, env)
+	ccnt := machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator())
 	sctx := syntax.NewZeroValueSourceContext()
 	err := ccnt.CompileExpression(cctx, schemeutil.DatumToSyntaxValue(context.Background(), sctx, prog))
 	if err != nil {
@@ -76,14 +76,14 @@ func RunSchemeCodeWithEnvAndContext(ctx context.Context, t *testing.T, env *envi
 		return nil, err
 	}
 
-	expanded, err := machine.NewExpanderTimeContinuation(ctx, env).ExpandExpression(stx)
+	expanded, err := machine.NewExpanderTimeContinuation(ctx, env, machine.NewVMMacroEvaluator()).ExpandExpression(stx)
 	if err != nil {
 		return nil, err
 	}
 
 	tpl := machine.NewNativeTemplate(0, 0, false)
 	cctx := machine.NewCompileTimeCallContext(ctx, false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -55,14 +55,14 @@ import (
 func Compile(ctx context.Context, env *environment.EnvironmentFrame, expr syntax.SyntaxValue) (*machine.NativeTemplate, error) {
 	tpl := machine.NewNativeTemplate(0, 0, false)
 
-	expanded, err := machine.NewExpanderTimeContinuation(ctx, env).ExpandExpression(expr)
+	expanded, err := machine.NewExpanderTimeContinuation(ctx, env, machine.NewVMMacroEvaluator()).ExpandExpression(expr)
 	if err != nil {
 		return nil, werr.WrapForeignErrorWithCause(werr.ErrExpansion, err, "expansion error")
 	}
 
 	// Use inTail=false for top-level expressions
 	cctx := machine.NewCompileTimeCallContext(ctx, false)
-	err = machine.NewCompiletimeContinuation(tpl, env).CompileExpression(cctx, expanded)
+	err = machine.NewCompiletimeContinuation(tpl, env, machine.NewVMMacroEvaluator()).CompileExpression(cctx, expanded)
 	if err != nil {
 		return nil, werr.WrapForeignErrorWithCause(werr.ErrCompilation, err, "compilation error")
 	}


### PR DESCRIPTION
## Summary

- Introduce `ExpanderCtx` interface in `machine/` to abstract `*ExpanderContext` on `MachineContext`, enabling the future `compilation/` sub-package to provide the concrete type without circular imports
- Introduce `MacroEvaluator` interface with `EvalTemplate` and `InvokeTransformer` methods, abstracting VM execution for compile-time evaluation and macro expansion. Default `vmMacroEvaluator` delegates to the real VM; consumers can provide a stub for compiler-only usage
- Thread `MacroEvaluator` through `CompileTimeContinuation` and `ExpanderTimeContinuation` constructors, replacing direct `NewMachineContext` + `Run()` calls in `compile_transformer.go` and `compile_helpers.go` with `evaluator.EvalTemplate()`

Phase 1 of `machine/` package decomposition (`plans/2026-03-30-machine-decomposition-design.md`). No behavioral change — all existing code passes `NewVMMacroEvaluator()`. Known gap: `expandERMacroInvocation` still calls VM directly (3-argument ER macro call convention).

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass
- [x] `go test ./integration/` — all pass (after `make build`)
- [x] Verified no direct VM calls remain in `compile_*.go`
- [x] Verified all `NewExpanderTimeContinuation` and `NewCompiletimeContinuation` callers updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)