### PR TITLE
Potential fix for code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/internal/tokenizer/tokenizer_literals.go
+++ b/internal/tokenizer/tokenizer_literals.go
@@ -195,7 +195,7 @@ func (p *Tokenizer) readCharacterMnemonicOrCharacterEscapeOrCharacterHexEscape()
 		// R7RS: \x<hex scalar value>; where hex scalar value is any Unicode code point
 		// (0 to 0x10FFFF) except surrogates (0xD800-0xDFFF)
 		p.state = TokenizerStateCharHexEscape
-		x, n := p.readUnsignedBaseNInteger(16, 0) //nolint:errcheck
+		x, n := p.readUnsignedBaseNInteger(16, 32) //nolint:errcheck
 		if n == 0 {
 			p.err = NewTokenizerErrorWithWrap(p.err, MessageInvalidCharacterHexEscape)
 			return utf8.RuneError


### PR DESCRIPTION
Potential fix for [https://github.com/aalpar/wile/security/code-scanning/6](https://github.com/aalpar/wile/security/code-scanning/6)

General fix: avoid parsing into a wider integer type when the destination is narrower. Parse with a bit size aligned to the destination (or bounded domain), then convert.

Best fix here without changing behavior:
- In `internal/tokenizer/tokenizer_literals.go`, in the `#\x...` branch of `readCharacter`, replace the call to `readUnsignedBaseNInteger(16, 0)` with `readUnsignedBaseNInteger(16, 32)`.
- This ensures `strconv.ParseInt` is invoked with 32-bit size in this path, eliminating the problematic 64→32 narrowing risk while preserving existing validation (`validateCodePoint`) and error handling.
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
