### PR TITLE
fix(control): make call-with-values consumer a proper tail call (P0)

### DIFF
--- a/pkg/registry/core/prim_call_with_values_test.go
+++ b/pkg/registry/core/prim_call_with_values_test.go
@@ -16,6 +16,7 @@ package core_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aalpar/wile/pkg/registry/testhelpers"
 	"github.com/aalpar/wile/pkg/values"
@@ -80,10 +81,24 @@ func TestCallWithValuesErrors(t *testing.T) {
 // uncatchable "fatal error: stack overflow" rather than running in O(1) frames.
 //
 // Each case is a single named-let expression so the only non-constant frame
-// growth would come from the consumer call. If the fix regresses, these crash
-// the whole test binary (a Go stack overflow cannot be recovered) instead of
-// failing softly — that loud signal is intentional for a host-crash-class bug.
+// growth would come from the consumer call. If the fix regresses into renewed
+// Go-stack growth, these crash the whole test binary (a Go stack overflow
+// cannot be recovered) instead of failing softly — that loud signal is
+// intentional for a host-crash-class bug.
+//
+// The iteration count (2,000,000) is the meaningful assertion: it comfortably
+// exceeds the pre-fix host-stack-overflow point. The deadline is only a hang
+// guard for the other regression shape — a consumer call that loops without
+// terminating — so a future break fails with a clear per-test deadline instead
+// of stalling the whole CI job. Mirrors TestApplyTailRecursion_NoStackOverflow
+// (prim_apply_test.go): the race detector slows each VM step by roughly an
+// order of magnitude, so the deadline is widened under -race. The counts here
+// are 2x that test's, so the deadlines are scaled to match.
 func TestCallWithValuesTailCall(t *testing.T) {
+	timeout := 60 * time.Second
+	if raceEnabled {
+		timeout = 360 * time.Second
+	}
 	tcs := []testhelpers.SchemeCodeTestCase{
 		{
 			Name: "direct call-with-values tail loop runs in O(1) frames",
@@ -102,7 +117,7 @@ func TestCallWithValuesTailCall(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			result, err := testhelpers.RunSchemeCode(t, tc.Code)
+			result, err := testhelpers.RunSchemeCodeWithTimeout(t, tc.Code, timeout)
 			qt.Assert(t, err, qt.IsNil)
 			qt.Assert(t, result, valuestest.SchemeEquals, tc.Expected)
 		})

--- a/pkg/registry/core/prim_call_with_values_test.go
+++ b/pkg/registry/core/prim_call_with_values_test.go
@@ -70,3 +70,41 @@ func TestCallWithValuesErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestCallWithValuesTailCall is a regression test for proper tail recursion of
+// the call-with-values consumer (R7RS §3.5: "the call to consumer is a tail
+// call"). Before the fix, PrimCallWithValues ran the consumer in a sub-context
+// via sub2.Run(), nesting one Go stack frame per call. A deep tail loop through
+// call-with-values — directly, or via the let-values macro which expands to it —
+// therefore grew the host goroutine stack to its 1 GB limit and died with an
+// uncatchable "fatal error: stack overflow" rather than running in O(1) frames.
+//
+// Each case is a single named-let expression so the only non-constant frame
+// growth would come from the consumer call. If the fix regresses, these crash
+// the whole test binary (a Go stack overflow cannot be recovered) instead of
+// failing softly — that loud signal is intentional for a host-crash-class bug.
+func TestCallWithValuesTailCall(t *testing.T) {
+	tcs := []testhelpers.SchemeCodeTestCase{
+		{
+			Name: "direct call-with-values tail loop runs in O(1) frames",
+			Code: `(let loop ((n 2000000))
+			         (call-with-values (lambda () (values n))
+			           (lambda (m) (if (= m 0) 'done (loop (- m 1))))))`,
+			Expected: values.NewSymbol("done"),
+		},
+		{
+			Name: "let-values tail loop runs in O(1) frames",
+			Code: `(let loop ((n 2000000))
+			         (let-values (((a) (values n)))
+			           (if (= a 0) 'done (loop (- a 1)))))`,
+			Expected: values.NewSymbol("done"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			result, err := testhelpers.RunSchemeCode(t, tc.Code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.Expected)
+		})
+	}
+}

--- a/pkg/registry/core/prim_control.go
+++ b/pkg/registry/core/prim_control.go
@@ -274,19 +274,21 @@ func PrimCallWithValues(cc machine.CallContext) error {
 	// Get all values returned by producer
 	producedValues := sub.GetValues()
 
-	// Call consumer with all produced values as arguments
-	sub2 := mc.NewSubContext()
-	defer machine.ReleaseSubContext(sub2)
-	_, err = sub2.ApplyCallable(consumerCls, producedValues...)
+	// Apply the consumer in place on mc (not in a sub-context) so the consumer
+	// call is in tail position relative to call-with-values: it returns through
+	// mc.cont, mirroring PrimApply. Running it in a sub-context with sub2.Run()
+	// nested one Go stack frame per call, so a tail loop through call-with-values
+	// (directly, or via the let-values/let*-values macros) overflowed the host
+	// goroutine stack instead of running in O(1) frames. R7RS §3.5 requires the
+	// consumer call to be a tail call.
+	//
+	// Lifetime: ApplyCallable binds producedValues into the consumer's frame
+	// synchronously (Apply -> bindArgs), so the deferred ReleaseSubContext(sub)
+	// on return cannot corrupt them. The consumer's own result (including
+	// multiple values) flows back through mc naturally, exactly as in apply.
+	_, err = mc.ApplyCallable(consumerCls, producedValues...)
 	if err != nil {
 		return err
 	}
-	err = sub2.Run()
-	if err != nil {
-		return err
-	}
-
-	// Return what consumer returned
-	mc.SetValues(sub2.GetValues()...)
 	return nil
 }


### PR DESCRIPTION
## Severity: P0 (uncatchable host crash) / SPEC (R7RS §3.5, §6.10)

`PrimCallWithValues` ran the consumer in a fresh sub-context (`sub2.Run()`), nesting one Go stack frame per call. A tail loop through `call-with-values` — directly or via the `let-values`/`let*-values` macros — grew the host goroutine stack to its 1 GB limit and died with an uncatchable `fatal error: stack overflow` instead of running in O(1) frames, killing the embedding host.

## Fix
Apply the consumer in place on `mc` (mirroring `PrimApply`), so it returns through `mc.cont` and is a proper tail call. `ApplyCallable` binds the produced values into the consumer frame synchronously, so releasing the producer sub-context on return is safe.

## Test plan
- `TestCallWithValuesTailCall`: two named-let tail loops at 2,000,000 iterations (direct `call-with-values` and `let-values`) complete in O(1) frames; both crashed the host pre-fix.
- `make lint && make covercheck` green; `TestApplyWindingStackInheritance` + continuation suite stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-train -->

---

### 🚂 Part of a stacked PR train

This PR is the **base of the train** (off `master`) and merges **first**. The train merges bottom-up; each merge auto-retargets the next PR onto `master`.

Stack (bottom = merges first):

```
master
 └─ #785  P0    call-with-values consumer is a proper tail call  ◀ this PR
  └─ #786  SPEC  syntax-case ellipsis template expansion is hygienic
   └─ #787  SPEC  parameterize evaluates values in the outer dynamic extent
    └─ #788  CORR  import-gated fold inline stamp keyed on source library
     └─ #789  CORR  unary (- x) negates instead of subtracting from zero
      └─ #790  API   Location() keeps :line:col when File is empty
       └─ #791  STYLE fail loud on malformed branch offset
```

_Reviewing: this PR's diff is shown relative to its parent branch, so it contains only its own change._

