### PR TITLE
fix(syntax-case): make ellipsis template expansion hygienic

### DIFF
--- a/pkg/machine/compilation/compile_syntax_case.go
+++ b/pkg/machine/compilation/compile_syntax_case.go
@@ -184,7 +184,12 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	// (unlike syntax-rules which always has the macro name as the first element)
 	// Use literalSyntax for scope-aware literal matching (R7RS bound-identifier=? semantics)
 	patternVars := make(map[string]struct{})
-	err := collectPatternVariablesWithEllipsis(pattern, literalSyntax, false, patternVars, nil, match.DefaultEllipsis)
+	// patternVarSyntax records each pattern variable's syntax symbol (with its
+	// scopes) so the ellipsis template-expansion path can do scope-aware
+	// substitution for nested-macro hygiene — the same data the syntax-rules
+	// path stores on SyntaxRulesClause.PatternVarSyntax.
+	patternVarSyntax := make(map[string]*syntax.SyntaxSymbol)
+	err := collectPatternVariablesWithEllipsis(pattern, literalSyntax, false, patternVars, patternVarSyntax, match.DefaultEllipsis)
 	if err != nil {
 		return err
 	}
@@ -196,6 +201,7 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	_, wildcardIsLiteral := literalSyntax["_"]
 	if !wildcardIsLiteral {
 		delete(patternVars, "_")
+		delete(patternVarSyntax, "_")
 	}
 
 	// Compile the pattern to bytecode.
@@ -245,6 +251,13 @@ func (p *CompileTimeContinuation) compileSyntaxCaseClause(
 	bodyEnv := p.createPatternVarEnvironment(patternVars)
 	bodyCompiler := NewCompileTimeContinuation(p.template, bodyEnv, p.evaluator)
 	bodyCompiler.SetInlineThreshold(p.inlineThreshold)
+	// Carry the clause's hygiene context into CompileSyntax so that ellipsis
+	// templates expand hygienically. libraryScope is not on bodyEnv (it is a
+	// separate field on CompileTimeContinuation), so propagate it explicitly for
+	// cross-library free-id resolution.
+	bodyCompiler.libraryScope = p.libraryScope
+	bodyCompiler.patternVars = patternVars
+	bodyCompiler.patternVarSyntax = patternVarSyntax
 	// Inherit the parent compiler's current source so that operations emitted
 	// by bodyCompiler (like BindPatternVars) are tagged with the syntax-case
 	// form's source location.

--- a/pkg/machine/compilation/compile_syntax_form.go
+++ b/pkg/machine/compilation/compile_syntax_form.go
@@ -15,6 +15,7 @@
 package compilation
 
 import (
+	"github.com/aalpar/wile/pkg/internal/match"
 	"github.com/aalpar/wile/pkg/machine"
 	"github.com/aalpar/wile/pkg/syntax"
 	"github.com/aalpar/wile/pkg/values"
@@ -40,10 +41,18 @@ func (p *CompileTimeContinuation) CompileSyntax(_ CompileTimeCallContext, expr s
 
 	// Check if template contains ellipsis - if so, use runtime expansion
 	if templateContainsEllipsis(template) {
-		// Store template in literals and emit runtime expansion operation
+		// Compute hygiene data at compile time, mirroring CompileSyntaxRules:
+		// which template identifiers are free (resolve at the definition site)
+		// vs. pattern variables (substituted from the match). This is what makes
+		// the runtime ellipsis expansion hygienic. p.patternVars,
+		// p.patternVarSyntax, and p.libraryScope are set on the body compiler by
+		// compileSyntaxCaseClause; outside syntax-case they are nil (and a
+		// captureless (syntax ...) errors at runtime regardless).
+		freeIds := make(map[string]*FreeIdResolution)
+		collectFreeIdentifiersWithEllipsis(p.env, template, p.patternVars, freeIds, match.DefaultEllipsis, p.libraryScope)
 		litIdx := p.template.MaybeAppendLiteral(template)
 		p.AppendOperations(machine.NewOperationLoadLiteralByLiteralIndexImmediate(litIdx))
-		p.AppendOperations(NewOperationSyntaxTemplateExpand())
+		p.AppendOperations(NewOperationSyntaxTemplateExpand(freeIds, p.patternVarSyntax))
 		return nil
 	}
 

--- a/pkg/machine/compilation/compile_time_continuation.go
+++ b/pkg/machine/compilation/compile_time_continuation.go
@@ -47,6 +47,17 @@ type CompileTimeContinuation struct {
 	// Threaded to CompileSyntaxRules so free identifiers in macro templates
 	// can carry the library scope for cross-library hygiene.
 	libraryScope *syntax.Scope
+	// patternVars and patternVarSyntax carry the enclosing syntax-case clause's
+	// pattern context into CompileSyntax so that (syntax template) forms with
+	// ellipsis can be expanded hygienically (the runtime ellipsis path mirrors
+	// the syntax-rules transformer). Set on the body compiler by
+	// compileSyntaxCaseClause; nil for (syntax ...) outside syntax-case (which
+	// has no captures and errors at runtime anyway). patternVars distinguishes
+	// pattern variables (substituted) from free identifiers (resolved at the
+	// definition site); patternVarSyntax carries each pattern variable's scopes
+	// for nested-macro scope comparison.
+	patternVars      map[string]struct{}
+	patternVarSyntax map[string]*syntax.SyntaxSymbol
 	// fileResolver controls how include/load resolves files.
 	// Defaults to the resolver stored on Namespace (usually
 	// OSFileResolver); set to EmbedFileResolver for bootstrap.

--- a/pkg/machine/compilation/operation_syntax_case.go
+++ b/pkg/machine/compilation/operation_syntax_case.go
@@ -288,11 +288,21 @@ func (p *OperationSyntaxCaseNoMatch) EqualTo(other values.Value) bool {
 // The result is the expanded syntax object, left in the value register.
 type OperationSyntaxTemplateExpand struct {
 	machine.OperationBase
+	// FreeIds and PatternVarSyntax carry the enclosing syntax-case clause's
+	// hygiene data, computed once at compile time by CompileSyntax. They mirror
+	// the SyntaxRulesClause fields the syntax-rules transformer uses, so the
+	// ellipsis template-expansion path is hygienic (R7RS §4.3): free template
+	// identifiers resolve at the macro definition site and template-introduced
+	// binders carry a fresh intro scope rather than capturing use-site identifiers.
+	FreeIds          map[string]*FreeIdResolution
+	PatternVarSyntax map[string]*syntax.SyntaxSymbol
 }
 
-func NewOperationSyntaxTemplateExpand() *OperationSyntaxTemplateExpand {
+func NewOperationSyntaxTemplateExpand(freeIds map[string]*FreeIdResolution, patternVarSyntax map[string]*syntax.SyntaxSymbol) *OperationSyntaxTemplateExpand {
 	return &OperationSyntaxTemplateExpand{
-		OperationBase: machine.NewOperationBaseWithGoName("operation:syntax-template-expand", "SyntaxTemplateExpand"),
+		OperationBase:    machine.NewOperationBaseWithGoName("operation:syntax-template-expand", "SyntaxTemplateExpand"),
+		FreeIds:          freeIds,
+		PatternVarSyntax: patternVarSyntax,
 	}
 }
 
@@ -312,9 +322,23 @@ func (p *OperationSyntaxTemplateExpand) Apply(mc *machine.MachineContext) (*mach
 		return nil, mc.WrapError(werr.ErrInternal, fmt.Sprintf("syntax: expected syntax template, got %T", templateVal))
 	}
 
-	// Expand the template using the matcher (handles ellipsis)
-	// Use nil for intro scope and freeIds for now - hygiene can be added later
-	expanded, err := sc.matcher.Expand(template, match.ExpandOptions{})
+	// Expand the template using the matcher (handles ellipsis). Mirror the
+	// syntax-rules transformer (OperationSyntaxRulesTransform.Apply): a fresh
+	// intro scope per expansion, plus the compile-time free-id and pattern-var
+	// hygiene data. This makes the ellipsis path hygienic (R7RS §4.3) — the
+	// non-ellipsis path achieves the same by emitting template symbols as
+	// def-site-scoped literals. UseSiteCtx/Origin are intentionally nil:
+	// syntax-case has no single macro-invocation use-site.
+	introScope := syntax.NewScopeWithLabel("intro")
+	freeIds := make(map[string]match.FreeIdResolver, len(p.FreeIds))
+	for k, v := range p.FreeIds {
+		freeIds[k] = v
+	}
+	expanded, err := sc.matcher.Expand(template, match.ExpandOptions{
+		IntroScope:       introScope,
+		FreeIds:          freeIds,
+		PatternVarSyntax: p.PatternVarSyntax,
+	})
 	if err != nil {
 		return nil, mc.WrapError(err, "syntax: template expansion error")
 	}

--- a/pkg/machine/compilation/operation_syntax_case_test.go
+++ b/pkg/machine/compilation/operation_syntax_case_test.go
@@ -231,29 +231,29 @@ func TestOperationSyntaxCaseNoMatch_Apply_IncludesInput(t *testing.T) {
 func TestNewOperationSyntaxTemplateExpand(t *testing.T) {
 	c := qt.New(t)
 
-	op := NewOperationSyntaxTemplateExpand()
+	op := NewOperationSyntaxTemplateExpand(nil, nil)
 	c.Assert(op, qt.IsNotNil)
 }
 
 func TestOperationSyntaxTemplateExpand_String(t *testing.T) {
 	c := qt.New(t)
 
-	op := NewOperationSyntaxTemplateExpand()
+	op := NewOperationSyntaxTemplateExpand(nil, nil)
 	c.Assert(op.String(), qt.Equals, "SyntaxTemplateExpand")
 }
 
 func TestOperationSyntaxTemplateExpand_SchemeString(t *testing.T) {
 	c := qt.New(t)
 
-	op := NewOperationSyntaxTemplateExpand()
+	op := NewOperationSyntaxTemplateExpand(nil, nil)
 	c.Assert(op.SchemeString(), qt.Equals, "#<operation:syntax-template-expand>")
 }
 
 func TestOperationSyntaxTemplateExpand_EqualTo(t *testing.T) {
 	c := qt.New(t)
 
-	op1 := NewOperationSyntaxTemplateExpand()
-	op2 := NewOperationSyntaxTemplateExpand()
+	op1 := NewOperationSyntaxTemplateExpand(nil, nil)
+	op2 := NewOperationSyntaxTemplateExpand(nil, nil)
 
 	c.Assert(op1.EqualTo(op2), qt.IsTrue)
 	c.Assert(op1.EqualTo(values.NewInteger(1)), qt.IsFalse)
@@ -262,7 +262,7 @@ func TestOperationSyntaxTemplateExpand_EqualTo(t *testing.T) {
 func TestOperationSyntaxTemplateExpand_IsVoid(t *testing.T) {
 	c := qt.New(t)
 
-	op := NewOperationSyntaxTemplateExpand()
+	op := NewOperationSyntaxTemplateExpand(nil, nil)
 	c.Assert(op.IsVoid(), qt.IsFalse)
 }
 

--- a/pkg/machine/compilation/syntax_case_scheme_test.go
+++ b/pkg/machine/compilation/syntax_case_scheme_test.go
@@ -144,3 +144,85 @@ func TestSyntaxCaseErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestSyntaxCaseEllipsisHygiene checks that templates containing ellipsis are
+// expanded hygienically (R7RS §4.3), matching the already-correct non-ellipsis
+// path. Two failure modes:
+//   - capture: a template-introduced binder must not swallow user identifiers
+//     that arrive through an ellipsis pattern variable.
+//   - referential transparency: a free template identifier must resolve at the
+//     macro definition site, not the use site.
+//
+// Each ellipsis case is paired with its non-ellipsis control, which exercises
+// the compile-time template path (compileSyntaxTemplateToOps) and was already
+// hygienic — the fix makes the runtime ellipsis path (OperationSyntaxTemplateExpand)
+// behave identically.
+func TestSyntaxCaseEllipsisHygiene(t *testing.T) {
+	tcs := []testhelpers.SchemeCodeTestCase{
+		{
+			// Introduced `tmp`=0 must not capture the user's `tmp`=99 spliced via `x ...`.
+			Name: "capture: ellipsis-spliced ids not captured by introduced binder",
+			Code: `(begin
+				(define-syntax m
+					(lambda (stx)
+						(syntax-case stx ()
+							((_ (x ...)) (syntax (let ((tmp 0)) (list tmp x ...)))))))
+				(let ((tmp 99)) (m (tmp tmp))))`,
+			Expected: values.List(values.NewInteger(0), values.NewInteger(99), values.NewInteger(99)),
+		},
+		{
+			Name: "capture control: non-ellipsis sibling is hygienic",
+			Code: `(begin
+				(define-syntax mc
+					(lambda (stx)
+						(syntax-case stx ()
+							((_ a b) (syntax (let ((tmp 0)) (list tmp a b)))))))
+				(let ((tmp 99)) (mc tmp tmp)))`,
+			Expected: values.List(values.NewInteger(0), values.NewInteger(99), values.NewInteger(99)),
+		},
+		{
+			// Free template id `list` must resolve to the definition-site global,
+			// not the use-site shadowing binding.
+			Name: "referential transparency: free id resolves at definition site (ellipsis)",
+			Code: `(begin
+				(define-syntax m2
+					(lambda (stx)
+						(syntax-case stx ()
+							((_ (x ...)) (syntax (list x ...))))))
+				(let ((list (lambda args 'shadowed))) (m2 (1 2 3))))`,
+			Expected: values.List(values.NewInteger(1), values.NewInteger(2), values.NewInteger(3)),
+		},
+		{
+			Name: "referential transparency control: non-ellipsis sibling",
+			Code: `(begin
+				(define-syntax m2c
+					(lambda (stx)
+						(syntax-case stx ()
+							((_ a b) (syntax (list a b))))))
+				(let ((list (lambda args 'shadowed))) (m2c 1 2)))`,
+			Expected: values.List(values.NewInteger(1), values.NewInteger(2)),
+		},
+		{
+			// Nested ellipsis must remain hygienic at every depth.
+			Name: "capture: nested ellipsis not captured",
+			Code: `(begin
+				(define-syntax mn
+					(lambda (stx)
+						(syntax-case stx ()
+							((_ ((x ...) ...)) (syntax (let ((tmp 0)) (list tmp (list x ...) ...)))))))
+				(let ((tmp 99)) (mn ((tmp tmp) (tmp)))))`,
+			Expected: values.List(
+				values.NewInteger(0),
+				values.List(values.NewInteger(99), values.NewInteger(99)),
+				values.List(values.NewInteger(99)),
+			),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			result, err := testhelpers.RunSchemeCode(t, tc.Code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.Expected)
+		})
+	}
+}

--- a/pkg/machine/library_scheme_test.go
+++ b/pkg/machine/library_scheme_test.go
@@ -301,6 +301,45 @@ func TestLibraryInternalMacroHygiene(t *testing.T) {
 	c.Assert(result, valuestest.SchemeEquals, values.NewInteger(6))
 }
 
+// TestLibraryInternalSyntaxCaseEllipsisHygiene verifies that a syntax-case macro
+// with an ellipsis template, exported from a library, resolves a free identifier
+// (a non-exported helper) at the library definition site — not the use site. This
+// exercises the libraryScope / free-id hygiene threaded into the ellipsis
+// template-expansion path (CompileSyntax → OperationSyntaxTemplateExpand). The
+// use site deliberately shadows `helper` with a different definition; referential
+// transparency requires the macro to ignore that shadow.
+func TestLibraryInternalSyntaxCaseEllipsisHygiene(t *testing.T) {
+	c := qt.New(t)
+	env := setupSchemeLibraryTest(t)
+
+	libCode := `(define-library (test sc-ellipsis-hygiene)
+	  (export bump-all)
+	  (import (scheme base))
+	  (begin
+	    (define (helper x) (+ x 1))
+	    (define-syntax bump-all
+	      (lambda (stx)
+	        (syntax-case stx ()
+	          ((_ x ...) (syntax (list (helper x) ...))))))))`
+	compileAndRegisterLibrary(t, env, libCode)
+
+	importCode := `(import (test sc-ellipsis-hygiene))`
+	sv := parseSchemeExpr(t, env, importCode)
+	_, err := compileAndRun(t, env, sv)
+	c.Assert(err, qt.IsNil, qt.Commentf("import should succeed"))
+
+	// Use site shadows `helper`; the macro's free `helper` must still resolve to
+	// the library's (+ x 1), giving (6 7 8), not the use-site (* x 1000).
+	useCode := `(begin
+	  (define (helper n) (* n 1000))
+	  (bump-all 5 6 7))`
+	sv = parseSchemeExpr(t, env, useCode)
+	result, err := compileAndRun(t, env, sv)
+	c.Assert(err, qt.IsNil, qt.Commentf("syntax-case ellipsis macro using non-exported helper should work"))
+	c.Assert(result, valuestest.SchemeEquals, values.List(
+		values.NewInteger(6), values.NewInteger(7), values.NewInteger(8)))
+}
+
 // TestIndividualSchemeLibraries tests each scheme library can be imported individually
 func TestIndividualSchemeLibraries(t *testing.T) {
 	libraries := []struct {


### PR DESCRIPTION
## Severity: SPEC (R7RS §4.3 hygiene + referential transparency)

`syntax-case` templates containing ellipsis were expanded via `OperationSyntaxTemplateExpand`, which called `matcher.Expand(template, ExpandOptions{})` — every hygiene field nil, with a literal `// hygiene can be added later` comment. Two violations followed, both absent from the already-correct non-ellipsis sibling path:

- **Capture:** a template-introduced binder captured user identifiers arriving through an ellipsis pattern variable. `((_ (x ...)) -> (let ((tmp 0)) (list tmp x ...)))` at a use site binding `tmp` returned `(0 0 0)` instead of `(0 99 99)`.
- **Referential transparency:** a free template identifier resolved at the use site. `((_ (x ...)) -> (list x ...))` under a shadowed `list` returned `'shadowed` instead of `(1 2 3)`.

## Fix
Mirror the syntax-rules transformer: compute `FreeIds` (free vs pattern-variable identifiers) and `PatternVarSyntax` at compile time in `CompileSyntax`, carry them on the operation, and mint a fresh intro scope per expansion in `Apply`. The matcher's `Expand`/`applyHygieneToSymbol` already implemented full hygiene — syntax-case simply never passed it the data. Threading: new `patternVars`/`patternVarSyntax` fields on `CompileTimeContinuation`, set on the body compiler by `compileSyntaxCaseClause` along with `libraryScope` (cross-library free-id resolution).

## Test plan
- `TestSyntaxCaseEllipsisHygiene`: capture, referential transparency, nested ellipsis — each with a non-ellipsis control that was already hygienic.
- `TestLibraryInternalSyntaxCaseEllipsisHygiene`: cross-library referential transparency (a library macro's free `helper` resolves to the library, not a use-site shadow).
- Full macro-system + `syntax-rules` suites unaffected; `make lint && make covercheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-train -->

---

### 🚂 Part of a stacked PR train

This PR is stacked on **#785** and must merge **after** it. The train merges bottom-up (#785 first); each merge auto-retargets the next PR onto `master`.

Stack (bottom = merges first):

```
master
 └─ #785  P0    call-with-values consumer is a proper tail call
  └─ #786  SPEC  syntax-case ellipsis template expansion is hygienic  ◀ this PR
   └─ #787  SPEC  parameterize evaluates values in the outer dynamic extent
    └─ #788  CORR  import-gated fold inline stamp keyed on source library
     └─ #789  CORR  unary (- x) negates instead of subtracting from zero
      └─ #790  API   Location() keeps :line:col when File is empty
       └─ #791  STYLE fail loud on malformed branch offset
```

_Reviewing: this PR's diff is shown relative to its parent branch, so it contains only its own change._
