### PR TITLE
fix(compile): gate import-gated fold inline stamp on source library identity

### DIFF
--- a/pkg/machine/compilation/inline_hof.go
+++ b/pkg/machine/compilation/inline_hof.go
@@ -45,6 +45,20 @@ type inlineHOFSpec struct {
 	//     this template for it would be unsound. So the import path stamps fold and
 	//     nothing else; the sealed-base names are stamped only at their real home.
 	importGated bool
+	// homeLib is the LibraryName.Key() of the library that actually DEFINES this
+	// import-gated HOF (e.g. "srfi/1" for fold). The import path stamps the
+	// template ONLY when the binding is imported from this exact library — the
+	// identity gate. A different library exporting a same-named procedure with
+	// different semantics (sourceLib != homeLib) is never stamped, so its own code
+	// runs. Empty for sealed-base specs (importGated false), which are stamped at
+	// their real home by StampInlineHOFs and need no source check.
+	//
+	// Soundness vs completeness: this gate is sound (never mis-inlines) but
+	// slightly incomplete — a re-export chain ((import (srfi 1)) then (export
+	// fold) from library B) presents sourceLib=B, so the REAL srfi-1 fold imported
+	// through B is no longer inlined. That is a safe deoptimization (correct
+	// result, lost optimization), strictly better than silent miscompilation.
+	homeLib string
 	// template is the procedure's single-sequence reclaiming loop as a lambda
 	// whose callbackParam-th parameter is the callback. Transcribed from the real
 	// definition (pkg/registry/core/bootstrap_procedures.scm for the sealed-base
@@ -104,7 +118,7 @@ var inlineHOFSpecs = map[string]inlineHOFSpec{
           (begin
             (f (string-ref s i))
             (loop (+ i 1)))))))`},
-	"fold": {callbackParam: 0, importGated: true, template: `(lambda (kons knil ls)
+	"fold": {callbackParam: 0, importGated: true, homeLib: "srfi/1", template: `(lambda (kons knil ls)
   (let lp ((ls ls) (acc knil))
     (if (pair? ls) (lp (cdr ls) (kons (car ls) acc)) acc)))`},
 }
@@ -119,15 +133,24 @@ func applyInlineHOFStamp(b *environment.Binding, callbackParam int) {
 }
 
 // stampImportedInlineHOF marks the import target b when name is a curated
-// IMPORT-GATED tail HOF (importGated true — currently only fold). A non-curated
-// name or a sealed-base name is a no-op. This is the soundness boundary for the
-// import path: a re-export of a sealed-base name (e.g. SRFI-13's string-map, a
-// different procedure from R7RS string-map) is NOT import-gated, so it is never
-// stamped here — only fold is. The sealed-base HOFs are stamped only at their
-// real home (StampInlineHOFs).
-func stampImportedInlineHOF(b *environment.Binding, name string) {
+// IMPORT-GATED tail HOF (importGated true — currently only fold) imported from
+// the library that actually defines it. A non-curated name, a sealed-base name,
+// or an import from a DIFFERENT library is a no-op. This is the soundness
+// boundary for the import path on two axes:
+//   - name: a re-export of a sealed-base name (e.g. SRFI-13's string-map, a
+//     different procedure from R7RS string-map) is NOT import-gated, so it is
+//     never stamped here. The sealed-base HOFs are stamped only at their real
+//     home (StampInlineHOFs).
+//   - identity (sourceLib vs spec.homeLib): a library exporting its own `fold`
+//     with non-SRFI-1 semantics presents sourceLib != "srfi/1" and is not
+//     stamped, so the user's code runs instead of the SRFI-1 inline template.
+func stampImportedInlineHOF(b *environment.Binding, name string, sourceLib LibraryName) {
 	spec, ok := inlineHOFSpecs[name]
 	if !ok || !spec.importGated {
+		return
+	}
+	// Identity gate: only the library that defines this HOF may stamp it.
+	if sourceLib.Key() != spec.homeLib {
 		return
 	}
 	applyInlineHOFStamp(b, spec.callbackParam)

--- a/pkg/machine/compilation/library_bindings.go
+++ b/pkg/machine/compilation/library_bindings.go
@@ -65,7 +65,7 @@ import (
 // The sealed-base HOFs are stamped only at their real home (StampInlineHOFs). The
 // import path is also the only library seam, so a user's own (define …) of a HOF
 // name is never stamped here.
-func markBindingImported(target, source *environment.Binding, exportName string) {
+func markBindingImported(target, source *environment.Binding, exportName string, sourceLib LibraryName) {
 	if target == nil {
 		return
 	}
@@ -82,7 +82,9 @@ func markBindingImported(target, source *environment.Binding, exportName string)
 			m.Doc = doc
 		}
 	}
-	stampImportedInlineHOF(target, exportName)
+	// sourceLib is the library being imported FROM; the inline-HOF stamp is gated
+	// on it (identity), not just the export name — see stampImportedInlineHOF.
+	stampImportedInlineHOF(target, exportName, sourceLib)
 }
 
 // ImportSet represents a parsed import specification.
@@ -318,7 +320,7 @@ func CopyLibraryBindingsToEnvAtPhase(lib *CompiledLibrary, bindings map[string]s
 				return werr.WrapForeignErrorf(err, "failed to set binding for %s at phase %s", localName, targetPhase)
 			}
 		}
-		markBindingImported(phaseEnv.GetBinding(localSym, nil), libBinding, externalName)
+		markBindingImported(phaseEnv.GetBinding(localSym, nil), libBinding, externalName, lib.Name)
 
 		// Propagate to the source phase in the target so the binding is available
 		// in the same phase it originated from. Syntax bindings (phase 1) need to
@@ -332,7 +334,7 @@ func CopyLibraryBindingsToEnvAtPhase(lib *CompiledLibrary, bindings map[string]s
 			if propagateIdx != nil {
 				_ = propagateEnv.SetOwnGlobalValue(propagateIdx, libBinding.Value())
 			}
-			markBindingImported(propagateEnv.GetBinding(propagateSym, nil), libBinding, externalName)
+			markBindingImported(propagateEnv.GetBinding(propagateSym, nil), libBinding, externalName, lib.Name)
 		}
 	}
 	return nil
@@ -397,7 +399,7 @@ func copyLibraryBindingsDirect(lib *CompiledLibrary, bindings map[string]string,
 				return werr.WrapForeignErrorf(err, "import: failed to set binding for %s", localName)
 			}
 		}
-		markBindingImported(targetEnv.GetBinding(localSym, nil), importedBinding, externalName)
+		markBindingImported(targetEnv.GetBinding(localSym, nil), importedBinding, externalName, lib.Name)
 
 		// Syntax bindings must also be available in the expand phase.
 		if importedBinding.BindingType() == environment.BindingTypeSyntax {
@@ -407,7 +409,7 @@ func copyLibraryBindingsDirect(lib *CompiledLibrary, bindings map[string]string,
 			if expandIdx != nil {
 				_ = expandEnv.SetOwnGlobalValue(expandIdx, importedBinding.Value())
 			}
-			markBindingImported(expandEnv.GetBinding(localSym, nil), importedBinding, externalName)
+			markBindingImported(expandEnv.GetBinding(localSym, nil), importedBinding, externalName, lib.Name)
 		}
 	}
 	return nil

--- a/pkg/wile/inline_hof_reclaim_test.go
+++ b/pkg/wile/inline_hof_reclaim_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/fstest"
 
 	"github.com/aalpar/wile/pkg/stdlib"
 )
@@ -152,5 +153,60 @@ acc)`
 	if got != "(4 3 2 1)" {
 		t.Errorf("for-each with a call/cc callback = %s, want (4 3 2 1) "+
 			"(must fall through to the real for-each, traversal intact)", got)
+	}
+}
+
+// TestInlineFoldIdentityStamp is the soundness gate for the import-gated `fold`
+// inline stamp: it must key on the SOURCE LIBRARY, not just the export name. A
+// library that exports its own `fold` with non-SRFI-1 semantics must run the
+// user's code, never Wile's SRFI-1 element-first inline template.
+//
+// The library's fold is a LEFT fold — (fold f acc lst) calls (f acc elem) — so
+// (fold - 0 '(1 2 3)) = (- (- (- 0 1) 2) 3) = -6. The SRFI-1 template's
+// (kons elem acc) order would instead give 2, the symptom of mis-inlining a
+// same-named but different procedure.
+func TestInlineFoldIdentityStamp(t *testing.T) {
+	ctx := context.Background()
+	fsys := fstest.MapFS{
+		"my/badfold.sld": &fstest.MapFile{Data: []byte(`(define-library (my badfold)
+  (export fold)
+  (import (scheme base))
+  (begin
+    (define (fold f acc lst)
+      (if (null? lst) acc (fold f (f acc (car lst)) (cdr lst))))))`)},
+	}
+	eng, err := NewEngine(ctx, WithProfile(KitchenSink), WithSourceFS(stdlib.FS),
+		WithSourceFS(fsys), WithLibraryPaths(), WithImmutableTopLevel())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := eng.EvalMultiple(ctx, `(import (my badfold)) (fold - 0 (list 1 2 3))`)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	got := result.SchemeString()
+	if got != "-6" {
+		t.Errorf("imported non-SRFI-1 fold mis-inlined: got %s, want -6 "+
+			"(SRFI-1 inline template gives 2)", got)
+	}
+}
+
+// TestInlineFoldRealSRFI1StillInlines guards against an over-broad fix: Wile's
+// real (srfi 1) fold must still be inlined (element-first), so (fold cons '()
+// '(1 2 3)) = (3 2 1).
+func TestInlineFoldRealSRFI1StillInlines(t *testing.T) {
+	ctx := context.Background()
+	eng, err := NewEngine(ctx, WithProfile(KitchenSink), WithSourceFS(stdlib.FS),
+		WithLibraryPaths(), WithImmutableTopLevel())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := eng.EvalMultiple(ctx, `(import (srfi 1)) (fold cons (list) (list 1 2 3))`)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	got := result.SchemeString()
+	if got != "(3 2 1)" {
+		t.Errorf("real srfi-1 fold = %s, want (3 2 1)", got)
 	}
 }


### PR DESCRIPTION
## Severity: CORRECTNESS

`stampImportedInlineHOF` stamped the SRFI-1 element-first `fold` inline template onto ANY imported binding named `fold`, keyed purely by export name. A library exporting its own `fold` with non-SRFI-1 semantics was therefore silently replaced by Wile's template at every capture-safe call site — a silent miscompilation. A left fold `(fold f acc lst)` calling `(f acc elem)`, imported, evaluated `(fold - 0 '(1 2 3))` as `2` (SRFI-1's `(kons elem acc)` order) instead of the user's `-6`.

## Fix
Add an identity gate: thread the source `LibraryName` through `markBindingImported` into `stampImportedInlineHOF` and stamp the import-gated template only when the binding is imported from the library that actually defines it (`homeLib "srfi/1"` for fold). A library exporting a same-named procedure runs the user's code. The gate is sound but slightly incomplete: a re-export chain loses the inlining (a safe deoptimization — correct result, lost optimization), strictly better than silent miscompilation.

## Test plan
- `TestInlineFoldIdentityStamp` (full engine, builds the inline-HOF template store): an imported non-SRFI-1 fold runs the user's code (`-6`, was `2`).
- `TestInlineFoldRealSRFI1StillInlines`: the real `(srfi 1)` fold still inlines (`(3 2 1)`) — over-broad-fix guard.
- `make lint && make covercheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-train -->

---

### 🚂 Part of a stacked PR train

This PR is stacked on **#787** and must merge **after** it. The train merges bottom-up (#785 first); each merge auto-retargets the next PR onto `master`.

Stack (bottom = merges first):

```
master
 └─ #785  P0    call-with-values consumer is a proper tail call
  └─ #786  SPEC  syntax-case ellipsis template expansion is hygienic
   └─ #787  SPEC  parameterize evaluates values in the outer dynamic extent
    └─ #788  CORR  import-gated fold inline stamp keyed on source library  ◀ this PR
     └─ #789  CORR  unary (- x) negates instead of subtracting from zero
      └─ #790  API   Location() keeps :line:col when File is empty
       └─ #791  STYLE fail loud on malformed branch offset
```

_Reviewing: this PR's diff is shown relative to its parent branch, so it contains only its own change._
