### PR TITLE
fix(values): Location() keeps :line:col when File is empty

### DIFF
--- a/pkg/values/source_context.go
+++ b/pkg/values/source_context.go
@@ -84,12 +84,23 @@ func (p *SourceContext) Clone() *SourceContext {
 }
 
 // Location returns the source location formatted as "file:line:col".
-// Returns empty string if the receiver is nil or has no file.
+// Returns empty string if the receiver is nil or carries no location at all.
+//
+// When File is empty (e.g. a nameless EvalMultiple program) but a position is
+// present, the ":line:col" form is still returned so provenance is not lost —
+// mirroring machine.StackFrame.String, which prints :Line:Col unconditionally.
+// A truly position-less context (File=="" and Line==0) still yields "".
 func (p *SourceContext) Location() string {
-	if p == nil || p.File == "" {
+	if p == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%d:%d", p.File, p.Start.Line(), p.Start.Column())
+	if p.File != "" {
+		return fmt.Sprintf("%s:%d:%d", p.File, p.Start.Line(), p.Start.Column())
+	}
+	if p.Start.Line() > 0 {
+		return fmt.Sprintf(":%d:%d", p.Start.Line(), p.Start.Column())
+	}
+	return ""
 }
 
 // SchemeString returns the Scheme representation of the source context.

--- a/pkg/wile/location_source_test.go
+++ b/pkg/wile/location_source_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wile
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestRuntimeErrorSourceProvenance verifies that a runtime error carries
+// :line:col provenance in RuntimeError.Source whether or not the program has a
+// file name. A nameless EvalMultiple program (File == "") previously got an empty
+// Source even though the position survived in the stack trace; a named program
+// must keep its "file:line:col" form unchanged.
+func TestRuntimeErrorSourceProvenance(t *testing.T) {
+	tcs := []struct {
+		name       string
+		source     string // "" => EvalMultiple (nameless); else EvalMultipleWithSource
+		wantPrefix string
+	}{
+		{
+			name:       "nameless eval emits :line:col",
+			source:     "",
+			wantPrefix: ":1:",
+		},
+		{
+			name:       "named source keeps file:line:col",
+			source:     "prog.scm",
+			wantPrefix: "prog.scm:1:",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			eng, err := NewEngine(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer eng.Close()
+
+			// car of a non-pair compiles fine but raises at runtime.
+			const code = "(car 5)"
+			if tc.source == "" {
+				_, err = eng.EvalMultiple(ctx, code)
+			} else {
+				_, err = eng.EvalMultipleWithSource(ctx, code, tc.source)
+			}
+			if err == nil {
+				t.Fatal("expected runtime error")
+			}
+			var re *RuntimeError
+			if !errors.As(err, &re) {
+				t.Fatalf("expected *RuntimeError, got %T: %v", err, err)
+			}
+			if !strings.HasPrefix(re.Source, tc.wantPrefix) {
+				t.Errorf("RuntimeError.Source = %q, want prefix %q", re.Source, tc.wantPrefix)
+			}
+		})
+	}
+}

--- a/pkg/wile/with_source_test.go
+++ b/pkg/wile/with_source_test.go
@@ -57,13 +57,15 @@ func TestParseWithSource_RuntimeError(t *testing.T) {
 			wantHasTrace:  true,
 		},
 		{
-			name:          "raise without source",
+			// No filename, but the position must survive as ":line:col"
+			// (provenance losslessness — see SourceContext.Location).
+			name:          "raise without filename keeps position",
 			source:        "",
 			code:          `(raise "boom")`,
-			wantSourcePfx: "",
+			wantSourcePfx: ":",
 			wantCondition: `"boom"`,
-			wantHasSource: false,
-			wantHasTrace:  false,
+			wantHasSource: true,
+			wantHasTrace:  true,
 		},
 		{
 			name:          "nested call error with source",
@@ -279,9 +281,11 @@ func TestWithSource_DistinctSources(t *testing.T) {
 	}
 }
 
-// TestWithSource_SourcelessEvalHasEmptySource is a negative test: errors
-// from the sourceless Eval/EvalMultiple/Compile should have empty Source.
-func TestWithSource_SourcelessEvalHasEmptySource(t *testing.T) {
+// TestWithSource_SourcelessEvalCarriesPosition verifies that errors from the
+// sourceless Eval/EvalMultiple/Compile paths still carry ":line:col" provenance.
+// There is no filename to report, but the position must not be dropped — see
+// SourceContext.Location and the "Error Chains: Lossless" invariant.
+func TestWithSource_SourcelessEvalCarriesPosition(t *testing.T) {
 	c := qt.New(t)
 
 	tcs := []struct {
@@ -325,7 +329,9 @@ func TestWithSource_SourcelessEvalHasEmptySource(t *testing.T) {
 
 			var rtErr *RuntimeError
 			c.Assert(errors.As(err, &rtErr), qt.IsTrue)
-			c.Assert(rtErr.Source, qt.Equals, "")
+			// No filename, but the position survives as ":line:col".
+			c.Assert(strings.HasPrefix(rtErr.Source, ":"), qt.IsTrue,
+				qt.Commentf("sourceless error Source=%q, want :line:col", rtErr.Source))
 		})
 	}
 }


### PR DESCRIPTION
## Severity: API (error-chain provenance — CLAUDE "Error Chains: Lossless and Traversable")

`SourceContext.Location()` returned `""` whenever `File` was empty, blanking real positional provenance for nameless eval (`EvalMultiple` without a source name): a runtime error's `RuntimeError.Source` came back empty even though `:line:col` still appeared in the stack trace — dropping provenance the lossless-error-chain invariant requires survive.

## Fix
Emit `":line:col"` when `File==""` but a position is present (`Start.Line() > 0`), mirroring `machine.StackFrame.String` which prints `:Line:Col` unconditionally. The `File`-present `"file:line:col"` format is unchanged; a truly position-less context still yields `""`.

## Test plan
- New `TestRuntimeErrorSourceProvenance`: nameless eval emits `:line:col`; named source keeps `file:line:col`.
- Two existing tests codified the old empty-Source behavior (the provenance loss) and are updated to assert the corrected form (`TestWithSource_SourcelessEvalHasEmptySource` → `...CarriesPosition`; the "raise without source" case of `TestParseWithSource_RuntimeError`).
- `make lint && make covercheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-train -->

---

### 🚂 Part of a stacked PR train

This PR is stacked on **#789** and must merge **after** it. The train merges bottom-up (#785 first); each merge auto-retargets the next PR onto `master`.

Stack (bottom = merges first):

```
master
 └─ #785  P0    call-with-values consumer is a proper tail call
  └─ #786  SPEC  syntax-case ellipsis template expansion is hygienic
   └─ #787  SPEC  parameterize evaluates values in the outer dynamic extent
    └─ #788  CORR  import-gated fold inline stamp keyed on source library
     └─ #789  CORR  unary (- x) negates instead of subtracting from zero
      └─ #790  API   Location() keeps :line:col when File is empty  ◀ this PR
       └─ #791  STYLE fail loud on malformed branch offset
```

_Reviewing: this PR's diff is shown relative to its parent branch, so it contains only its own change._
