### PR TITLE
fix(machine): fail loud on malformed branch offset in fixSurvivingBranches

### DIFF
--- a/pkg/machine/edit_plan.go
+++ b/pkg/machine/edit_plan.go
@@ -208,6 +208,17 @@ func fixSurvivingBranches(code []Instruction, edits []edit, remap []int) {
 			continue
 		}
 		absTarget := i + int(code[i].Arg)
+		// remap has length len(code)+1 (the trailing sentinel is the only valid
+		// out-of-body target). An offset outside [0, len(remap)) means malformed
+		// compiler output. branchTargets (peephole.go) silently tolerates the same
+		// out-of-range value because it only consults in-range positions; here the
+		// value is dereferenced, so fail loudly with a wrapped error rather than a
+		// bare "index out of range" runtime panic (CLAUDE.md: never panic raw).
+		if absTarget < 0 || absTarget >= len(remap) {
+			panic(werr.WrapForeignErrorf(werr.ErrInternal,
+				"peephole: malformed branch offset at PC %d: target %d out of range [0,%d)",
+				i, absTarget, len(remap)))
+		}
 		code[i].Arg = int32(remap[absTarget] - remap[i])
 	}
 }

--- a/pkg/machine/edit_plan_test.go
+++ b/pkg/machine/edit_plan_test.go
@@ -15,9 +15,11 @@
 package machine
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aalpar/wile/pkg/values"
+	"github.com/aalpar/wile/pkg/werr"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -182,6 +184,30 @@ func TestEditPlan_Insert(t *testing.T) {
 }
 
 // --- Branch Fixup ---
+
+func TestFixSurvivingBranches_OutOfRangeOffsetWrapsError(t *testing.T) {
+	// A surviving branch whose target offset lands outside [0, len(remap)).
+	// Well-formed compiler output never produces this (the len(code) fall-through
+	// sentinel is the only edge case, and it is in range), but if it ever did the
+	// guard must fail with a wrapped werr — not a bare "index out of range"
+	// runtime panic — matching branchTargets' awareness of the same value.
+	code := []Instruction{
+		{Op: OpBranch, Arg: 100}, // 0: target 100, far past len(remap)
+	}
+	remap := make([]int, len(code)+1) // length 2; index 100 is out of range
+	var edits []edit
+
+	defer func() {
+		r := recover()
+		qt.Assert(t, r, qt.IsNotNil)
+		err, ok := r.(error)
+		qt.Assert(t, ok, qt.IsTrue)
+		qt.Assert(t, errors.Is(err, werr.ErrInternal), qt.IsTrue,
+			qt.Commentf("panic value should wrap werr.ErrInternal, got %v", r))
+	}()
+	fixSurvivingBranches(code, edits, remap)
+	t.Fatal("expected panic on out-of-range branch offset")
+}
 
 func TestEditPlan_BranchShrinks(t *testing.T) {
 	// Branch spans a deleted range; offset must shrink.


### PR DESCRIPTION
## Severity: STYLE (latent; unreachable on well-formed compiler output)

`fixSurvivingBranches` dereferenced `remap[absTarget]` without a bounds check, where `absTarget = i + branchArg`. The sibling `branchTargets` (peephole.go) computes the same `i+Arg` but guards it, silently tolerating out-of-range offsets. The two functions thus encoded opposite contracts for the same value: an out-of-range offset that `branchTargets` ignores would crash `fixSurvivingBranches` with a bare `index out of range` runtime panic.

## Fix
No reachable trigger exists on well-formed output (the `len(code)` fall-through sentinel is in range), so this is latent hardening. Guard `absTarget` against `[0, len(remap))` and, on violation, panic with a `werr.ErrInternal`-wrapped message (CLAUDE.md: never panic with a raw error).

## Test plan
- `TestFixSurvivingBranches_OutOfRangeOffsetWrapsError`: a synthetic out-of-range branch asserts a wrapped `werr` (via `errors.Is`), not a raw panic.
- Existing edit-plan tests unchanged; `make lint && make covercheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-train -->

---

### 🚂 Part of a stacked PR train

This PR is stacked on **#790** and must merge **after** it. The train merges bottom-up (#785 first); each merge auto-retargets the next PR onto `master`.

Stack (bottom = merges first):

```
master
 └─ #785  P0    call-with-values consumer is a proper tail call
  └─ #786  SPEC  syntax-case ellipsis template expansion is hygienic
   └─ #787  SPEC  parameterize evaluates values in the outer dynamic extent
    └─ #788  CORR  import-gated fold inline stamp keyed on source library
     └─ #789  CORR  unary (- x) negates instead of subtracting from zero
      └─ #790  API   Location() keeps :line:col when File is empty
       └─ #791  STYLE fail loud on malformed branch offset  ◀ this PR
```

_Reviewing: this PR's diff is shown relative to its parent branch, so it contains only its own change._
