### PR TITLE
fix(libraries): Phase 1 crash-safety — cyclic vector, runaway continuation, registry race, library-name traversal

### DIFF
--- a/extensions/threads/library_load_race_test.go
+++ b/extensions/threads/library_load_race_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package threads_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/pkg/stdlib"
+	"github.com/aalpar/wile/pkg/wile"
+)
+
+// TestConcurrentLibraryLoadFromThreads is the end-to-end companion to the
+// registry-level TestLibraryRegistryConcurrentLoad (CC1): SRFI-18 threads that
+// share the engine's library registry each load a distinct, not-preloaded
+// library via (environment …) concurrently. Before LibraryRegistry was
+// synchronized this aborted the process with "concurrent map writes" (a Go map
+// is unsafe for concurrent writes even to different keys). Run under -race
+// (the threads package is on the -race CI job) to surface the data race even
+// when no crash happens.
+//
+// The authoritative proof of the synchronization fix is the registry unit test
+// run under -race; this is the realistic integration smoke that exercises the
+// same maps through the full (environment …) → LoadLibrary → Register path.
+func TestConcurrentLibraryLoadFromThreads(t *testing.T) {
+	// Synchronizing LibraryRegistry (Task 1C) removed the "concurrent map
+	// writes" fatal, but doing so unmasked a SEPARATE, pre-existing data race
+	// in the per-call apply path: LocalEnvironmentFrame.copyForApplyInto writes
+	// keysShared=true on the SHARED source frame, so concurrent foreign-closure
+	// applications from multiple threads (here, the `environment` primitive
+	// during library load) race on that copy-on-write flag. That race lives in
+	// the hot environment-frame apply path and is out of scope for the registry
+	// synchronization; the authoritative proof of the registry fix is the
+	// registry-level TestLibraryRegistryConcurrentLoad / LookupOrClaim run under
+	// -race. Re-enable this once the apply-frame CoW race is fixed.
+	// TODO(apply-frame-race): tracked in plans/2026-06-25-apply-frame-cow-race.local.md.
+	t.Skip("blocked by pre-existing copyForApplyInto keysShared race (separate from CC1)")
+
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx,
+		wile.WithProfile(wile.KitchenSink),
+		wile.WithLibraryPaths(),
+		wile.WithSourceFS(stdlib.FS),
+		wile.WithSourceOS(),
+	)
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	// Four distinct SRFI libraries, none auto-loaded at startup. Each thread
+	// loads one, so all four StartLoading/Register/FinishLoading sequences hit
+	// the shared registry maps simultaneously.
+	src := `(let ((t1 (make-thread (lambda () (environment '(srfi 1)))))
+	              (t2 (make-thread (lambda () (environment '(srfi 13)))))
+	              (t3 (make-thread (lambda () (environment '(srfi 14)))))
+	              (t4 (make-thread (lambda () (environment '(srfi 132))))))
+	          (thread-start! t1) (thread-start! t2)
+	          (thread-start! t3) (thread-start! t4)
+	          (thread-join! t1) (thread-join! t2)
+	          (thread-join! t3) (thread-join! t4)
+	          'done)`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "done")
+}

--- a/pkg/machine/captured_continuation.go
+++ b/pkg/machine/captured_continuation.go
@@ -104,8 +104,24 @@ func (p *MachineContext) applyCapturedContinuation(
 	val := args[0]
 	cc := capt.cc
 
+	// Bound the Go-stack nesting of continuation re-invocation. Restoring the
+	// captured chain runs it in a fresh sub-context whose Run() frame stays live
+	// until that chain completes; a continuation that re-invokes itself without
+	// converging (a call/cc loop) would nest Go frames until the runtime aborts
+	// the process with a stack overflow, bypassing the eval-stack maxCallDepth
+	// gate in SaveContinuation (each restored chain resets to the captured,
+	// shallow callDepth). Treat the nesting like ordinary recursion depth and
+	// surface a catchable error at the same bound.
+	depth := p.contInvokeDepth + 1
+	if p.maxCallDepth > 0 && depth > p.maxCallDepth {
+		return p, werr.WrapForeignErrorf(werr.ErrCallDepthExceeded,
+			"call/cc: continuation re-invocation depth %d exceeds limit %d",
+			depth, p.maxCallDepth)
+	}
+
 	sub := p.NewSubContext()
 	defer ReleaseSubContext(sub)
+	sub.contInvokeDepth = depth
 	// The composable continuation installs its own continuation chain via
 	// Restore, replacing whatever marks this sub-context might inherit.
 	// Prevent the parent's stale marks from bleeding through findParameterInMarks.

--- a/pkg/machine/compilation/import_set_datum.go
+++ b/pkg/machine/compilation/import_set_datum.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/aalpar/wile/pkg/environment"
 	"github.com/aalpar/wile/pkg/values"
@@ -38,17 +39,28 @@ func ParseLibraryNameFromDatum(ctx context.Context, expr values.Value) (LibraryN
 
 	var parts []string
 	err := values.ForEachProperList(ctx, tuple, "library name", func(_ context.Context, _ int, _ bool, partExpr values.Value) error {
-		sym, ok := partExpr.(*values.Symbol)
-		if ok {
-			parts = append(parts, sym.Key)
-			return nil
+		var part string
+		switch v := partExpr.(type) {
+		case *values.Symbol:
+			part = v.Key
+		case *values.Integer:
+			part = fmt.Sprintf("%d", v.Value)
+		default:
+			return werr.WrapForeignErrorf(werr.ErrInvalidArgument, "library name part must be identifier or integer, got %T", partExpr)
 		}
-		num, ok := partExpr.(*values.Integer)
-		if ok {
-			parts = append(parts, fmt.Sprintf("%d", num.Value))
-			return nil
+		// Reject parts that would let a library name escape the search root or
+		// otherwise denote a non-identifier path segment. ".."/"."/"" and any
+		// embedded path separator are not valid R7RS library-name identifiers,
+		// and ".." in particular builds an out-of-root path the OS resolver
+		// would traverse (S1). This is the single choke point for both
+		// compile-time and runtime-constructed names. Integers can never hit
+		// this, but the guard is total and cheap.
+		if part == ".." || part == "." || part == "" || strings.ContainsAny(part, "/\\") {
+			return werr.WrapForeignErrorf(werr.ErrInvalidArgument,
+				"library name part %q is not a valid identifier", part)
 		}
-		return werr.WrapForeignErrorf(werr.ErrInvalidArgument, "library name part must be identifier or integer, got %T", partExpr)
+		parts = append(parts, part)
+		return nil
 	})
 	if err != nil {
 		return LibraryName{}, err

--- a/pkg/machine/compilation/import_set_datum_test.go
+++ b/pkg/machine/compilation/import_set_datum_test.go
@@ -44,11 +44,18 @@ func TestParseLibraryNameFromDatum(t *testing.T) {
 // can never reach the OS resolver and escape the search root (S1).
 func TestParseLibraryNameRejectsTraversal(t *testing.T) {
 	for _, part := range []string{"..", ".", "", "a/b", "a\\b"} {
-		datum := values.List(values.NewSymbol(part), values.NewSymbol("foo"))
-		_, err := ParseLibraryNameFromDatum(context.Background(), datum)
-		if !errors.Is(err, werr.ErrInvalidArgument) {
-			t.Fatalf("part %q: want ErrInvalidArgument, got %v", part, err)
-		}
+		// Leading position.
+		first := values.List(values.NewSymbol(part), values.NewSymbol("foo"))
+		_, err := ParseLibraryNameFromDatum(context.Background(), first)
+		qt.Assert(t, errors.Is(err, werr.ErrInvalidArgument), qt.IsTrue,
+			qt.Commentf("part %q in leading position", part))
+
+		// Non-leading position: the guard runs on every part, so a bad part
+		// anywhere must be rejected (mirrors the (.. .. foo) threat shape).
+		second := values.List(values.NewSymbol("foo"), values.NewSymbol(part))
+		_, err = ParseLibraryNameFromDatum(context.Background(), second)
+		qt.Assert(t, errors.Is(err, werr.ErrInvalidArgument), qt.IsTrue,
+			qt.Commentf("part %q in non-leading position", part))
 	}
 }
 

--- a/pkg/machine/compilation/import_set_datum_test.go
+++ b/pkg/machine/compilation/import_set_datum_test.go
@@ -38,6 +38,38 @@ func TestParseLibraryNameFromDatum(t *testing.T) {
 	qt.Assert(t, result.Key(), qt.Equals, "scheme/base")
 }
 
+// TestParseLibraryNameRejectsTraversal verifies that path-traversal and empty
+// library-name parts are rejected at parse time — the single choke point for
+// both compile- and runtime-constructed names — so a name like (.. .. foo)
+// can never reach the OS resolver and escape the search root (S1).
+func TestParseLibraryNameRejectsTraversal(t *testing.T) {
+	for _, part := range []string{"..", ".", "", "a/b", "a\\b"} {
+		datum := values.List(values.NewSymbol(part), values.NewSymbol("foo"))
+		_, err := ParseLibraryNameFromDatum(context.Background(), datum)
+		if !errors.Is(err, werr.ErrInvalidArgument) {
+			t.Fatalf("part %q: want ErrInvalidArgument, got %v", part, err)
+		}
+	}
+}
+
+// TestParseLibraryNameAllowsLegitimate guards against over-rejection: ordinary
+// names with a dot inside an identifier and integer parts must still parse.
+func TestParseLibraryNameAllowsLegitimate(t *testing.T) {
+	cases := []struct {
+		datum values.Value
+		key   string
+	}{
+		{values.List(values.NewSymbol("srfi"), values.NewInteger(1)), "srfi/1"},
+		{values.List(values.NewSymbol("scheme"), values.NewSymbol("char")), "scheme/char"},
+		{values.List(values.NewSymbol("a.b")), "a.b"}, // dot inside an identifier is fine
+	}
+	for _, tc := range cases {
+		result, err := ParseLibraryNameFromDatum(context.Background(), tc.datum)
+		qt.Assert(t, err, qt.IsNil)
+		qt.Assert(t, result.Key(), qt.Equals, tc.key)
+	}
+}
+
 func TestParseLibraryNameFromDatum_WithNumbers(t *testing.T) {
 	// (srfi 1)
 	libName := values.NewCons(

--- a/pkg/machine/compilation/library_loader.go
+++ b/pkg/machine/compilation/library_loader.go
@@ -62,15 +62,24 @@ func LoadLibrary(ctx context.Context, name LibraryName, env *environment.Environ
 	// StartLoading sequence into one locked decision so two threads cannot both
 	// see "not loaded" and proceed to load+Register the same library (a TOCTOU
 	// that would otherwise surface as ErrDuplicateBinding). See LookupOrClaim.
-	cached, _, err := reg.LookupOrClaim(name)
+	cached, claimed, err := reg.LookupOrClaim(name)
 	if err != nil {
 		return nil, err
 	}
 	if cached != nil {
 		return cached, nil
 	}
-	// cached == nil and err == nil ⇒ we claimed the loading slot; release it on
-	// every exit path.
+	if !claimed {
+		// Defensive: today (cached==nil, err==nil) ⇒ claimed==true. Branch on the
+		// bool LookupOrClaim returns rather than reconstructing the decision, so a
+		// future "proceed but unclaimed" state (e.g. the TODO(1C-b) per-name latch)
+		// fails loudly here instead of silently running FinishLoading on a slot we
+		// never owned — which would delete another loader's loading mark.
+		return nil, werr.WrapForeignErrorf(werr.ErrLibraryConfiguration,
+			"load-library: %s: registry returned neither a cached library nor a loading claim",
+			name.SchemeString())
+	}
+	// We own the loading slot; release it on every exit path.
 	defer reg.FinishLoading(name)
 	var lib *CompiledLibrary
 

--- a/pkg/machine/compilation/library_loader.go
+++ b/pkg/machine/compilation/library_loader.go
@@ -58,17 +58,21 @@ func LoadLibrary(ctx context.Context, name LibraryName, env *environment.Environ
 		return nil, werr.WrapForeignErrorf(werr.ErrLibraryConfiguration, "load-library: invalid library registry type")
 	}
 
-	lib := reg.Lookup(name)
-	if lib != nil {
-		return lib, nil
+	// Atomic check-and-claim: collapses the former Lookup → IsLoading →
+	// StartLoading sequence into one locked decision so two threads cannot both
+	// see "not loaded" and proceed to load+Register the same library (a TOCTOU
+	// that would otherwise surface as ErrDuplicateBinding). See LookupOrClaim.
+	cached, _, err := reg.LookupOrClaim(name)
+	if err != nil {
+		return nil, err
 	}
-
-	if reg.IsLoading(name) {
-		return nil, werr.WrapForeignErrorf(werr.ErrCircularDependency,
-			"circular dependency detected while loading %s", name.SchemeString())
+	if cached != nil {
+		return cached, nil
 	}
-	reg.StartLoading(name)
+	// cached == nil and err == nil ⇒ we claimed the loading slot; release it on
+	// every exit path.
 	defer reg.FinishLoading(name)
+	var lib *CompiledLibrary
 
 	// Resolve and open via FileResolver (supports both OS and virtual FS).
 	resolver := env.FileResolver()

--- a/pkg/machine/compilation/library_registry.go
+++ b/pkg/machine/compilation/library_registry.go
@@ -173,18 +173,22 @@ func NewLibraryRegistry() *LibraryRegistry {
 	}
 }
 
-// SetSearchPaths sets the library search paths.
+// SetSearchPaths sets the library search paths. The slice is copied so the
+// registry owns its searchPaths memory: a caller mutating the slice it passed
+// in must not be able to race a concurrent reader of the registry's state.
 func (p *LibraryRegistry) SetSearchPaths(paths []string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.searchPaths = paths
+	p.searchPaths = append([]string(nil), paths...)
 }
 
-// GetSearchPaths returns the current library search paths.
+// GetSearchPaths returns a copy of the current library search paths. Returning
+// a copy keeps the registry's internal slice immutable from outside, so a
+// caller cannot mutate the backing array and race a concurrent reader.
 func (p *LibraryRegistry) GetSearchPaths() []string {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.searchPaths
+	return append([]string(nil), p.searchPaths...)
 }
 
 // PrependSearchPath adds a path to the beginning of the search path list.

--- a/pkg/machine/compilation/library_registry.go
+++ b/pkg/machine/compilation/library_registry.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/aalpar/wile/pkg/machine"
 	"github.com/aalpar/wile/pkg/machine/compilation/resolver"
@@ -142,7 +143,15 @@ type LibraryImportEvent struct {
 type LibraryImportObserver func(LibraryImportEvent)
 
 // LibraryRegistry manages loaded libraries and handles library loading.
+//
+// All fields are guarded by mu so the registry is safe for concurrent use by
+// SRFI-18 threads that load libraries via (environment …) / (eval '(import …)).
+// Read methods take RLock; methods that mutate a map, the search paths, or the
+// observer take Lock. mu is not reentrant — public methods must not call other
+// locking methods while holding the lock (AllNames uses the unlocked all()
+// helper for this reason).
 type LibraryRegistry struct {
+	mu             sync.RWMutex
 	libraries      map[string]*CompiledLibrary // key: library name as "scheme/base"
 	loading        map[string]bool             // libraries currently being loaded (cycle detection)
 	searchPaths    []string                    // directories to search for library files
@@ -166,16 +175,22 @@ func NewLibraryRegistry() *LibraryRegistry {
 
 // SetSearchPaths sets the library search paths.
 func (p *LibraryRegistry) SetSearchPaths(paths []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.searchPaths = paths
 }
 
 // GetSearchPaths returns the current library search paths.
 func (p *LibraryRegistry) GetSearchPaths() []string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.searchPaths
 }
 
 // PrependSearchPath adds a path to the beginning of the search path list.
 func (p *LibraryRegistry) PrependSearchPath(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.searchPaths = append([]string{path}, p.searchPaths...)
 }
 
@@ -183,11 +198,15 @@ func (p *LibraryRegistry) PrependSearchPath(path string) {
 // a library is imported. The observer is read-only and cannot influence
 // the import. Pass nil to remove the observer.
 func (p *LibraryRegistry) SetImportObserver(obs LibraryImportObserver) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.importObserver = obs
 }
 
 // ImportObserver returns the current import observer, or nil.
 func (p *LibraryRegistry) ImportObserver() LibraryImportObserver {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.importObserver
 }
 
@@ -201,7 +220,11 @@ func fireImportObserver(env *environment.EnvironmentFrame, lib *CompiledLibrary,
 		return
 	}
 	reg, ok := regAny.(*LibraryRegistry)
-	if !ok || reg.importObserver == nil {
+	if !ok {
+		return
+	}
+	obs := reg.ImportObserver()
+	if obs == nil {
 		return
 	}
 
@@ -217,7 +240,7 @@ func fireImportObserver(env *environment.EnvironmentFrame, lib *CompiledLibrary,
 	}
 	sort.Strings(imported)
 
-	reg.importObserver(LibraryImportEvent{
+	obs(LibraryImportEvent{
 		Library:    lib.Name,
 		SourceFile: lib.SourceFile,
 		Exports:    exports,
@@ -229,6 +252,8 @@ func fireImportObserver(env *environment.EnvironmentFrame, lib *CompiledLibrary,
 
 // Register adds a compiled library to the registry.
 func (p *LibraryRegistry) Register(lib *CompiledLibrary) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	key := lib.Name.Key()
 	_, exists := p.libraries[key]
 	if exists {
@@ -240,11 +265,15 @@ func (p *LibraryRegistry) Register(lib *CompiledLibrary) error {
 
 // Lookup returns a library by name, or nil if not found.
 func (p *LibraryRegistry) Lookup(name LibraryName) *CompiledLibrary {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.libraries[name.Key()]
 }
 
-// All returns all loaded libraries, sorted by name key for determinism.
-func (p *LibraryRegistry) All() []*CompiledLibrary {
+// all returns all loaded libraries sorted by key. Caller must hold at least
+// RLock. Exists so AllNames can reuse it without recursively locking (mu is
+// not reentrant).
+func (p *LibraryRegistry) all() []*CompiledLibrary {
 	libs := make([]*CompiledLibrary, 0, len(p.libraries))
 	for _, lib := range p.libraries {
 		libs = append(libs, lib)
@@ -255,9 +284,18 @@ func (p *LibraryRegistry) All() []*CompiledLibrary {
 	return libs
 }
 
+// All returns all loaded libraries, sorted by name key for determinism.
+func (p *LibraryRegistry) All() []*CompiledLibrary {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.all()
+}
+
 // AllNames returns the names of all registered libraries, sorted by key.
 func (p *LibraryRegistry) AllNames() []LibraryName {
-	libs := p.All()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	libs := p.all()
 	names := make([]LibraryName, len(libs))
 	for i, lib := range libs {
 		names[i] = lib.Name
@@ -268,17 +306,53 @@ func (p *LibraryRegistry) AllNames() []LibraryName {
 // IsLoading returns true if the library is currently being loaded.
 // Used to detect circular dependencies.
 func (p *LibraryRegistry) IsLoading(name LibraryName) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.loading[name.Key()]
 }
 
 // StartLoading marks a library as being loaded.
 func (p *LibraryRegistry) StartLoading(name LibraryName) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.loading[name.Key()] = true
 }
 
 // FinishLoading marks a library as finished loading.
 func (p *LibraryRegistry) FinishLoading(name LibraryName) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	delete(p.loading, name.Key())
+}
+
+// LookupOrClaim atomically resolves a library or claims the loading slot.
+// It is the single check-and-mark decision point that LoadLibrary uses so the
+// Lookup → IsLoading → StartLoading sequence cannot interleave across threads:
+//   - cached != nil  ⇒ already loaded; use it.
+//   - claimed == true ⇒ the caller now owns the loading slot and MUST load,
+//     Register, and FinishLoading.
+//   - otherwise err is a wrapped ErrCircularDependency: either a genuine
+//     import cycle, or (option (a), Task 1C) a second thread loading the SAME
+//     library concurrently. The latter is a rare false positive accepted for
+//     this phase; a per-name latch that blocks-then-reads the cache is the (b)
+//     alternative — see the TODO below.
+//
+// TODO(1C-b): distinguish concurrent same-library load (should wait) from a
+// genuine cycle (should error) via a per-name chan struct{} latch.
+func (p *LibraryRegistry) LookupOrClaim(name LibraryName) (cached *CompiledLibrary, claimed bool, err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := name.Key()
+	lib := p.libraries[key]
+	if lib != nil {
+		return lib, false, nil
+	}
+	if p.loading[key] {
+		return nil, false, werr.WrapForeignErrorf(werr.ErrCircularDependency,
+			"circular dependency detected while loading %s", name.SchemeString())
+	}
+	p.loading[key] = true
+	return nil, true, nil
 }
 
 // FilePathToLibraryName converts a forward-slash-separated file path with

--- a/pkg/machine/compilation/library_registry_race_test.go
+++ b/pkg/machine/compilation/library_registry_race_test.go
@@ -15,9 +15,12 @@
 package compilation
 
 import (
+	"errors"
 	"strconv"
 	"sync"
 	"testing"
+
+	"github.com/aalpar/wile/pkg/werr"
 )
 
 // TestLibraryRegistryConcurrentLoad exercises the registry from multiple
@@ -55,30 +58,74 @@ func TestLibraryRegistryLookupOrClaim(t *testing.T) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	claims := 0
+	cachedHits := 0
+	var loserErrs []error
 	for range n {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			cached, claimed, err := reg.LookupOrClaim(name)
-			if claimed {
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case claimed:
 				// Winner: register and release the slot.
+				claims++
 				_ = reg.Register(NewCompiledLibrary(name, nil))
 				reg.FinishLoading(name)
-				mu.Lock()
-				claims++
-				mu.Unlock()
-				return
+			case cached != nil:
+				cachedHits++
+			default:
+				loserErrs = append(loserErrs, err)
 			}
-			// Loser: either the lib was already cached, or a circular-dependency
-			// rejection while the winner held the slot. Both are acceptable; what
-			// must never happen is a second successful claim.
-			_ = cached
-			_ = err
 		}()
 	}
 	wg.Wait()
 
 	if claims != 1 {
 		t.Fatalf("want exactly 1 claim of the loading slot, got %d", claims)
+	}
+	// Every non-winner is either a cached hit (winner already registered) or a
+	// circular-dependency rejection (option (a): winner still held the slot) —
+	// never a second claim, never a different error.
+	for _, err := range loserErrs {
+		if !errors.Is(err, werr.ErrCircularDependency) {
+			t.Fatalf("loser error: want ErrCircularDependency, got %v", err)
+		}
+	}
+	if claims+cachedHits+len(loserErrs) != n {
+		t.Fatalf("outcomes do not sum to %d: claims=%d cached=%d losers=%d",
+			n, claims, cachedHits, len(loserErrs))
+	}
+}
+
+// TestLibraryRegistryLookupOrClaimCachedHit deterministically pins the
+// cached-hit path the LoadLibrary rewrite depends on: a second LookupOrClaim of
+// an already-registered name returns the cached library without re-claiming the
+// loading slot (idempotent re-load, no spurious ErrDuplicateBinding).
+func TestLibraryRegistryLookupOrClaimCachedHit(t *testing.T) {
+	reg := NewLibraryRegistry()
+	name := NewLibraryName("conc", "cached")
+
+	_, claimed, err := reg.LookupOrClaim(name)
+	if err != nil || !claimed {
+		t.Fatalf("first LookupOrClaim: claimed=%v err=%v", claimed, err)
+	}
+	lib := NewCompiledLibrary(name, nil)
+	err = reg.Register(lib)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	reg.FinishLoading(name)
+
+	cached, claimed, err := reg.LookupOrClaim(name)
+	if err != nil {
+		t.Fatalf("second LookupOrClaim: %v", err)
+	}
+	if claimed {
+		t.Fatal("second LookupOrClaim re-claimed an already-registered library")
+	}
+	if cached != lib {
+		t.Fatalf("want the cached library pointer, got %v", cached)
 	}
 }

--- a/pkg/machine/compilation/library_registry_race_test.go
+++ b/pkg/machine/compilation/library_registry_race_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compilation
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// TestLibraryRegistryConcurrentLoad exercises the registry from multiple
+// goroutines loading distinct libraries. Without synchronization the
+// libraries/loading maps race and the runtime aborts with "concurrent map
+// writes" (CC1). Run under -race to surface the data race even when no crash
+// occurs. Distinct from TODO.md D2 (a binding.go race).
+func TestLibraryRegistryConcurrentLoad(t *testing.T) {
+	reg := NewLibraryRegistry()
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := NewLibraryName("conc", strconv.Itoa(i))
+			reg.StartLoading(name)
+			reg.IsLoading(name)
+			_ = reg.Register(NewCompiledLibrary(name, nil))
+			reg.FinishLoading(name)
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestLibraryRegistryLookupOrClaim verifies the atomic check-and-claim:
+// exactly one of N concurrent claimants for the same name wins the loading
+// slot; the rest see either the cached library or a circular-dependency
+// rejection (option (a): concurrent same-library load is reported as a
+// circular dependency rather than blocking — see Task 1C).
+func TestLibraryRegistryLookupOrClaim(t *testing.T) {
+	reg := NewLibraryRegistry()
+	name := NewLibraryName("conc", "shared")
+
+	const n = 8
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	claims := 0
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cached, claimed, err := reg.LookupOrClaim(name)
+			if claimed {
+				// Winner: register and release the slot.
+				_ = reg.Register(NewCompiledLibrary(name, nil))
+				reg.FinishLoading(name)
+				mu.Lock()
+				claims++
+				mu.Unlock()
+				return
+			}
+			// Loser: either the lib was already cached, or a circular-dependency
+			// rejection while the winner held the slot. Both are acceptable; what
+			// must never happen is a second successful claim.
+			_ = cached
+			_ = err
+		}()
+	}
+	wg.Wait()
+
+	if claims != 1 {
+		t.Fatalf("want exactly 1 claim of the loading slot, got %d", claims)
+	}
+}

--- a/pkg/machine/machine_context.go
+++ b/pkg/machine/machine_context.go
@@ -79,11 +79,19 @@ type MachineContext struct {
 	// The numeric half (threadID) lives in vmState and propagates into
 	// continuations. See the comment on vmState.threadID for the full
 	// design and invariant.
-	thread        *values.Thread
-	maxCallDepth  int              // 0 = unlimited (default); negatives are clamped to 0 by SetMaxCallDepth
-	maxStackSize  uint64           // 0 = unlimited (default), otherwise max eval stack entries
-	restArgBuf    values.PairBlock // reusable buffer for variadic rest-arg list construction (ForeignClosure calls)
-	isolatedMarks bool             // when true, findParameterInMarks does not walk parentMC; set by applyCapturedContinuation
+	thread       *values.Thread
+	maxCallDepth int    // 0 = unlimited (default); negatives are clamped to 0 by SetMaxCallDepth
+	maxStackSize uint64 // 0 = unlimited (default), otherwise max eval stack entries
+	// contInvokeDepth counts nested captured-continuation re-invocations. Each
+	// re-invocation runs the restored chain in a fresh sub-context whose Run()
+	// frame stays live on the Go stack until that chain completes; a continuation
+	// that re-invokes itself without converging (a call/cc loop) nests Go frames
+	// without bound. The counter propagates through NewSubContext and is checked
+	// against maxCallDepth in applyCapturedContinuation so the pathology surfaces
+	// as a catchable ErrCallDepthExceeded instead of a Go stack-overflow fatal.
+	contInvokeDepth int
+	restArgBuf      values.PairBlock // reusable buffer for variadic rest-arg list construction (ForeignClosure calls)
+	isolatedMarks   bool             // when true, findParameterInMarks does not walk parentMC; set by applyCapturedContinuation
 
 	// reconfigured is set by Apply when it repoints the VM (template/env/pc) to
 	// execute a closure in place. The foreign-call dispatchers (applyForeign,

--- a/pkg/machine/machine_context_subcontext.go
+++ b/pkg/machine/machine_context_subcontext.go
@@ -58,6 +58,11 @@ func (p *MachineContext) NewSubContext() *MachineContext {
 	mc.exceptionHandler = p.exceptionHandler
 	mc.maxCallDepth = p.maxCallDepth
 	mc.maxStackSize = p.maxStackSize
+	// Inherit the captured-continuation re-invocation depth so a continuation
+	// invoked from inside an intermediate sub-context (e.g. a map/for-each body)
+	// still accumulates toward the maxCallDepth bound. applyCapturedContinuation
+	// increments past this inherited value on each re-invocation.
+	mc.contInvokeDepth = p.contInvokeDepth
 	mc.barrierValid = p.barrierValid // inherit barrier context
 	mc.windingStack = p.windingStack
 	return mc

--- a/pkg/values/byte_vector.go
+++ b/pkg/values/byte_vector.go
@@ -155,8 +155,10 @@ func (p *ByteVector) EqualTo(v Value) bool {
 }
 
 // SchemeString returns the Scheme representation of the bytevector.
+// Bytevector elements are bytes, never compound, so no cycle-detection set
+// is needed (nil visited).
 func (p *ByteVector) SchemeString() string {
 	return formatIndexable("#u8(", len(*p), func(i int) Value {
 		return (*p)[i]
-	})
+	}, nil)
 }

--- a/pkg/values/pair.go
+++ b/pkg/values/pair.go
@@ -376,11 +376,11 @@ func (p *Pair) SchemeString() string {
 	if p.IsVoid() {
 		return "#<void>"
 	}
-	visited := make(map[*Pair]bool)
+	visited := make(map[Value]bool)
 	return p.schemeStringWithVisited(visited)
 }
 
-func (p *Pair) schemeStringWithVisited(visited map[*Pair]bool) string {
+func (p *Pair) schemeStringWithVisited(visited map[Value]bool) string {
 	if visited[p] {
 		return "..."
 	}
@@ -394,24 +394,16 @@ func (p *Pair) schemeStringWithVisited(visited map[*Pair]bool) string {
 		if i > 0 {
 			q.WriteString(" ")
 		}
-		car := pr[0]
-		if IsVoid(car) {
-			q.WriteString("#<void>")
-		} else if carPair, ok := car.(*Pair); ok && carPair != nil {
-			q.WriteString(carPair.schemeStringWithVisited(visited))
-		} else {
-			q.WriteString(car.SchemeString())
-		}
+		// schemeStringChild dispatches nested *Pair/*Vector through the shared
+		// visited set, catching pair↔vector cross-cycles, and renders void/nil
+		// as "#<void>".
+		q.WriteString(schemeStringChild(pr[0], visited))
 		cdrPair, ok := pr[1].(*Pair)
 		if !ok || cdrPair == nil {
 			// Non-pair cdr, nil *Pair (void), or empty list
 			if !IsEmptyList(pr[1]) {
 				q.WriteString(" . ")
-				if IsVoid(pr[1]) {
-					q.WriteString("#<void>")
-				} else {
-					q.WriteString(pr[1].SchemeString())
-				}
+				q.WriteString(schemeStringChild(pr[1], visited))
 			}
 			break
 		}

--- a/pkg/values/pair.go
+++ b/pkg/values/pair.go
@@ -444,6 +444,12 @@ func (p *Pair) String() string {
 	return p.stringWithVisited(visited)
 }
 
+// stringWithVisited is the Stringer twin of schemeStringWithVisited. It keeps a
+// pair-only visited set (map[*Pair]bool): vector children are rendered via
+// stringValue → Vector.SchemeString, which carries its own shared visited set,
+// so a pair↔vector cross-cycle still terminates (the vector's set catches the
+// re-entry) even though this set tracks pairs only. The two paths deliberately
+// diverge on map type for now; Phase 3 unifies both onto path-scoped marking.
 func (p *Pair) stringWithVisited(visited map[*Pair]bool) string {
 	if visited[p] {
 		return "..."

--- a/pkg/values/utils.go
+++ b/pkg/values/utils.go
@@ -32,18 +32,48 @@ const (
 // formatIndexable builds the Scheme external representation for a
 // fixed-size indexable collection.  Format: prefix<elem1> <elem2> ... )
 // with elements separated by single spaces and no padding around elements.
-func formatIndexable(prefix string, length int, get func(int) Value) string {
+//
+// visited threads the cycle-detection set into nested Pair/Vector elements
+// so a self-referential or cross-referential structure renders a bounded
+// "..." marker instead of overflowing the Go stack. Callers whose elements
+// can never be compound (e.g. ByteVector, whose elements are bytes) may pass
+// nil; schemeStringChild only writes to the set for *Pair/*Vector children.
+func formatIndexable(prefix string, length int, get func(int) Value, visited map[Value]bool) string {
 	q := &strings.Builder{}
 	q.WriteString(prefix)
 	if length > 0 {
-		q.WriteString(get(0).SchemeString())
+		q.WriteString(schemeStringChild(get(0), visited))
 		for i := 1; i < length; i++ {
 			q.WriteString(" ")
-			q.WriteString(get(i).SchemeString())
+			q.WriteString(schemeStringChild(get(i), visited))
 		}
 	}
 	q.WriteString(")")
 	return q.String()
+}
+
+// schemeStringChild renders a single element of a compound structure,
+// threading the shared visited set through nested Pair/Vector so that
+// cross-collection cycles (vector→pair→vector and the like) are detected
+// exactly once. Non-compound elements render via SchemeString; void and nil
+// pointers render as "#<void>".
+func schemeStringChild(child Value, visited map[Value]bool) string {
+	switch c := child.(type) {
+	case *Pair:
+		if c != nil {
+			return c.schemeStringWithVisited(visited)
+		}
+		return "#<void>"
+	case *Vector:
+		if c != nil {
+			return c.schemeStringWithVisited(visited)
+		}
+		return "#<void>"
+	}
+	if IsVoid(child) {
+		return "#<void>"
+	}
+	return child.SchemeString()
 }
 
 // List constructs a proper list from the given values.

--- a/pkg/values/utils.go
+++ b/pkg/values/utils.go
@@ -57,18 +57,36 @@ func formatIndexable(prefix string, length int, get func(int) Value, visited map
 // cross-collection cycles (vector→pair→vector and the like) are detected
 // exactly once. Non-compound elements render via SchemeString; void and nil
 // pointers render as "#<void>".
+//
+// The visited set is keyed on pointer-identity Value types only (*Pair and
+// *Vector — the only types inserted). Never insert a value-equality or
+// non-comparable Value: the former would alias distinct nodes to one slot
+// (false cycles), the latter would panic on map insertion.
+//
+// A nil visited set means "no cycle tracking requested" — used by callers
+// whose elements can never be compound (e.g. ByteVector, whose elements are
+// bytes). Should a compound child be encountered anyway, a fresh set is
+// allocated lazily for that subtree, so a nil set can never cause a nil-map
+// write. This keeps the nil contract a safe "no tracking" rather than an
+// unchecked "I promise no compound children" caller obligation.
 func schemeStringChild(child Value, visited map[Value]bool) string {
 	switch c := child.(type) {
 	case *Pair:
-		if c != nil {
-			return c.schemeStringWithVisited(visited)
+		if c == nil {
+			return "#<void>"
 		}
-		return "#<void>"
+		if visited == nil {
+			visited = make(map[Value]bool)
+		}
+		return c.schemeStringWithVisited(visited)
 	case *Vector:
-		if c != nil {
-			return c.schemeStringWithVisited(visited)
+		if c == nil {
+			return "#<void>"
 		}
-		return "#<void>"
+		if visited == nil {
+			visited = make(map[Value]bool)
+		}
+		return c.schemeStringWithVisited(visited)
 	}
 	if IsVoid(child) {
 		return "#<void>"

--- a/pkg/values/vector.go
+++ b/pkg/values/vector.go
@@ -101,8 +101,25 @@ func (p *Vector) AsList() Tuple {
 // SchemeString returns the Scheme external representation of the vector.
 // Format: #( element1 element2 ... ) with elements separated by spaces.
 // Empty vectors are represented as #().
+// Cyclic and cross-referential structures render a bounded "..." marker
+// instead of overflowing the Go stack.
 func (p *Vector) SchemeString() string {
+	if p.IsVoid() {
+		return "#<void>"
+	}
+	return p.schemeStringWithVisited(make(map[Value]bool))
+}
+
+// schemeStringWithVisited renders the vector while threading a shared
+// cycle-detection set through nested Pair/Vector elements. A vector already
+// on the visited set renders as "..." (all-visited marking, matching Pair's
+// behavior; Phase 3 converts both to path-scoped marking).
+func (p *Vector) schemeStringWithVisited(visited map[Value]bool) string {
+	if visited[p] {
+		return "..."
+	}
+	visited[p] = true
 	return formatIndexable("#(", len(*p), func(i int) Value {
 		return (*p)[i]
-	})
+	}, visited)
 }

--- a/pkg/values/vector_test.go
+++ b/pkg/values/vector_test.go
@@ -15,7 +15,6 @@
 package values_test
 
 import (
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -249,31 +248,43 @@ func TestVectorSchemeString(t *testing.T) {
 	}
 }
 
-// TestVectorSchemeStringCyclic verifies a self-referential vector renders
-// with a bounded cycle marker rather than overflowing the Go stack (C3).
+// TestVectorSchemeStringCyclic verifies a self-referential vector renders a
+// bounded, correctly-placed cycle marker rather than overflowing the Go stack
+// (C3). Assert the exact rendering, not just that "..." appears, so a wrong
+// truncation (dropped element, marker in the wrong slot) is caught.
 func TestVectorSchemeStringCyclic(t *testing.T) {
 	v := values.NewVector(values.NewInteger(1), values.NewInteger(2), nil)
 	(*v)[2] = v // self-reference
 
-	got := v.SchemeString()
-	if !strings.Contains(got, "...") {
-		t.Fatalf("expected cycle marker in %q", got)
-	}
+	qt.Assert(t, v.SchemeString(), qt.Equals, "#(1 2 ...)")
 }
 
 // TestVectorSchemeStringCrossCycle verifies a vector→pair→vector cycle is
-// bounded. The shared visited set must be threaded across both Pair and
-// Vector rendering, otherwise each level allocates a fresh set and recurses
-// forever.
+// bounded from BOTH entry points. The shared visited set must be threaded
+// across Pair and Vector rendering, otherwise each level allocates a fresh set
+// and recurses forever.
 func TestVectorSchemeStringCrossCycle(t *testing.T) {
 	v := values.NewVector(values.NewInteger(1), nil)
 	p := values.NewCons(values.NewSymbol("a"), v)
 	(*v)[1] = p // vector -> pair -> vector
 
-	got := v.SchemeString()
-	if !strings.Contains(got, "...") {
-		t.Fatalf("expected cycle marker in %q", got)
-	}
+	// Entry from the vector root.
+	qt.Assert(t, v.SchemeString(), qt.Equals, "#(1 (a . ...))")
+	// Entry from the pair root (symmetric direction): pair -> vector -> pair.
+	qt.Assert(t, p.SchemeString(), qt.Equals, "(a . #(1 ...))")
+}
+
+// TestVectorSchemeStringSharedAcyclic pins the CURRENT (intended-for-now)
+// behavior for a non-cyclic shared vector: all-visited marking collapses the
+// second occurrence to "...". This is the documented Phase-1 tradeoff (see the
+// comment on Vector.schemeStringWithVisited); Phase 3 switches to path-scoped
+// marking and will render the diamond in full. This test is the tripwire that
+// must change when that happens.
+func TestVectorSchemeStringSharedAcyclic(t *testing.T) {
+	shared := values.NewVector(values.NewInteger(1))
+	dag := values.List(shared, shared) // (#(1) #(1)) — acyclic, shared
+
+	qt.Assert(t, dag.SchemeString(), qt.Equals, "(#(1) ...)")
 }
 
 func TestVectorAsList(t *testing.T) {

--- a/pkg/values/vector_test.go
+++ b/pkg/values/vector_test.go
@@ -15,6 +15,7 @@
 package values_test
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -245,6 +246,33 @@ func TestVectorSchemeString(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			qt.Assert(t, tc.in.SchemeString(), qt.Equals, tc.out)
 		})
+	}
+}
+
+// TestVectorSchemeStringCyclic verifies a self-referential vector renders
+// with a bounded cycle marker rather than overflowing the Go stack (C3).
+func TestVectorSchemeStringCyclic(t *testing.T) {
+	v := values.NewVector(values.NewInteger(1), values.NewInteger(2), nil)
+	(*v)[2] = v // self-reference
+
+	got := v.SchemeString()
+	if !strings.Contains(got, "...") {
+		t.Fatalf("expected cycle marker in %q", got)
+	}
+}
+
+// TestVectorSchemeStringCrossCycle verifies a vector→pair→vector cycle is
+// bounded. The shared visited set must be threaded across both Pair and
+// Vector rendering, otherwise each level allocates a fresh set and recurses
+// forever.
+func TestVectorSchemeStringCrossCycle(t *testing.T) {
+	v := values.NewVector(values.NewInteger(1), nil)
+	p := values.NewCons(values.NewSymbol("a"), v)
+	(*v)[1] = p // vector -> pair -> vector
+
+	got := v.SchemeString()
+	if !strings.Contains(got, "...") {
+		t.Fatalf("expected cycle marker in %q", got)
 	}
 }
 

--- a/pkg/wile/callcc_engine_test.go
+++ b/pkg/wile/callcc_engine_test.go
@@ -20,7 +20,9 @@ import (
 func TestRunawayContinuationIsBounded(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	// Explicit small limit: deterministic and fast (trips at depth limit+1
+	// rather than nesting to the default 10000), independent of DefaultMaxCallDepth.
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink), wile.WithMaxCallDepth(200))
 	c.Assert(err, qt.IsNil)
 	defer eng.Close()
 
@@ -44,7 +46,9 @@ func TestRunawayContinuationIsBounded(t *testing.T) {
 func TestContinuationLoopBoundedConverges(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()
-	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	// Explicit limit, well above this loop's ~100 re-invocations, so the test
+	// does not implicitly depend on DefaultMaxCallDepth.
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink), wile.WithMaxCallDepth(500))
 	c.Assert(err, qt.IsNil)
 	defer eng.Close()
 

--- a/pkg/wile/callcc_engine_test.go
+++ b/pkg/wile/callcc_engine_test.go
@@ -57,6 +57,39 @@ func TestContinuationLoopBoundedConverges(t *testing.T) {
 	c.Assert(result.SchemeString(), qt.Equals, "100")
 }
 
+// TestContinuationDepthBoundTracksMaxCallDepth pins that the continuation
+// re-invocation bound IS maxCallDepth — not a hardcoded constant, and not a
+// per-NewSubContext count (which would trip a 10-iteration loop far below the
+// limit). With an explicit small limit, a loop well under it converges and a
+// runaway trips at exactly limit+1.
+func TestContinuationDepthBoundTracksMaxCallDepth(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	const limit = 500
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink), wile.WithMaxCallDepth(limit))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	// ~10 re-invocations: well under the limit, must converge.
+	under := `(let ((n 0) (k #f))
+	            (call/cc (lambda (c) (set! k c)))
+	            (set! n (+ n 1))
+	            (if (< n 10) (k #f) n))`
+	result, err := eng.EvalMultiple(ctx, under)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "10")
+
+	// Non-converging: must trip the bound, not overflow the Go stack.
+	over := `(let ((n 0) (k #f))
+	           (+ 1 (call/cc (lambda (c) (set! k c) 0)))
+	           (set! n (+ n 1))
+	           (if (< n 100000) (k 0) n))`
+	_, err = eng.EvalMultiple(ctx, over)
+	if !errors.Is(err, werr.ErrCallDepthExceeded) {
+		t.Fatalf("want ErrCallDepthExceeded at maxCallDepth=%d, got %v", limit, err)
+	}
+}
+
 func TestCallCC_Procedure(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/pkg/wile/callcc_engine_test.go
+++ b/pkg/wile/callcc_engine_test.go
@@ -2,12 +2,60 @@ package wile_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/aalpar/wile/pkg/werr"
 	"github.com/aalpar/wile/pkg/wile"
 )
+
+// TestRunawayContinuationIsBounded verifies that re-invoking a captured
+// continuation in a non-converging loop surfaces a catchable
+// ErrCallDepthExceeded rather than overflowing the Go stack and aborting the
+// host process (C2). The continuation re-invocation nests a sub-context Run()
+// frame per iteration, bypassing SaveContinuation's eval-stack depth gate, so
+// applyCapturedContinuation enforces the same maxCallDepth bound on nesting.
+func TestRunawayContinuationIsBounded(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	// Classic non-tail call/cc loop that never converges: each (k 0) re-enters
+	// at the pending (+ 1 _) and immediately re-invokes k.
+	src := `(let ((n 0) (k #f))
+	          (+ 1 (call/cc (lambda (c) (set! k c) 0)))
+	          (set! n (+ n 1))
+	          (if (< n 100000000) (k 0) n))`
+	_, err = eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNotNil)
+	if !errors.Is(err, werr.ErrCallDepthExceeded) {
+		t.Fatalf("want ErrCallDepthExceeded, got %v", err)
+	}
+}
+
+// TestContinuationLoopBoundedConverges is the no-false-positive companion to
+// TestRunawayContinuationIsBounded: the same call/cc loop with a bound well
+// under maxCallDepth must complete and return its value, confirming the depth
+// guard does not reject legitimate (if unusual) bounded continuation loops.
+func TestContinuationLoopBoundedConverges(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	src := `(let ((n 0) (k #f))
+	          (call/cc (lambda (c) (set! k c)))
+	          (set! n (+ n 1))
+	          (if (< n 100) (k #f) n))`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "100")
+}
 
 func TestCallCC_Procedure(t *testing.T) {
 	c := qt.New(t)


### PR DESCRIPTION
Phase 1 (crash-safety) of the libraries-subsystem review remediation. Each of these makes a sandboxed script crash or escape the host; Wile's product promise is safe embedding, so they ship first. `make lint && make covercheck` both green locally; master CI green at branch point.

## Fixes

| Task | Defect | Fix | Proof |
|---|---|---|---|
| 1A | **C3** — self-referential / cross-referential vector overflows the Go stack in `Vector.SchemeString` | Thread a shared `map[Value]bool` across `Pair`/`Vector` rendering via a new `schemeStringChild` helper + widened `formatIndexable`; `ByteVector` passes nil | `TestVectorSchemeStringCyclic`, `TestVectorSchemeStringCrossCycle` |
| 1B | **C2** — runaway `call/cc` re-invocation overflows the Go stack, bypassing `maxCallDepth` | `contInvokeDepth` counter on `MachineContext`, propagated through `NewSubContext`, gated at `maxCallDepth` in `applyCapturedContinuation` → catchable `ErrCallDepthExceeded` | `TestRunawayContinuationIsBounded`, `TestContinuationLoopBoundedConverges` |
| 1C | **CC1** — `LibraryRegistry` maps race under concurrent thread loads (`fatal error: concurrent map writes`) | `sync.RWMutex` + atomic `LookupOrClaim` collapsing the `LoadLibrary` TOCTOU | `TestLibraryRegistryConcurrentLoad`, `TestLibraryRegistryLookupOrClaim` (under `-race`) |
| 1D | **S1** — `(import (.. .. foo))` escapes the search root | Reject `..`/`.`/empty/separator parts at `ParseLibraryNameFromDatum` (the single datum choke point) | `TestParseLibraryNameRejectsTraversal`, `TestParseLibraryNameAllowsLegitimate` |

## Notes for reviewers

- **1B plan correction:** the remediation plan attributed the overflow to `MachineContinuation.Copy/DeepCopy/AcquireSegment`. Those walks are iterative. The real recursion is `applyCapturedContinuation` nesting `NewSubContext`+`Run`, confirmed by reproducing the overflow. Fix is at the real site.
- **1C discovery (deferred):** synchronizing the registry maps **unmasks a separate, pre-existing race** in the hot env-frame apply path — `LocalEnvironmentFrame.copyForApplyInto` writes `keysShared=true` on the shared *source* frame, so concurrent foreign-closure application from threads races on that CoW flag. It was hidden behind the `concurrent map writes` fatal. It's out of scope for the registry sync and touches a delicate, perf-sensitive path; the end-to-end thread test (`extensions/threads/library_load_race_test.go`) is committed but `t.Skip`-ped and tracked for a follow-up PR. The registry-level `-race` tests are the authoritative proof of the CC1 fix.
- **1C option (a):** concurrent load of the *same* library is reported as `ErrCircularDependency` (a rare false positive); `TODO(1C-b)` left for a per-name latch that would block-then-read the cache.

## Test plan

- [x] `make lint`
- [x] `make covercheck` (all 41 packages ≥ 80%)
- [x] `go test -race ./pkg/machine/compilation/... ./extensions/threads/...`
- [x] full `pkg/values`, `pkg/machine/...`, `pkg/wile` suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)