### PR TITLE
fix(expander): match nested-sublist patterns with improper-tail in syntax-rules (C12/C13)

### DIFF
--- a/pkg/internal/match/match.go
+++ b/pkg/internal/match/match.go
@@ -346,7 +346,20 @@ func (p *Matcher) MatchSyntaxWithLiterals(ctx context.Context, target *syntax.Sy
 			lcs := len(p.captureStack)
 			vsv := p.syntaxStack[lvs-1].pr
 			if syntax.IsSyntaxEmptyList(vsv) {
-				return ErrNotAMatch
+				// The `. rest` tail follows a preceding ellipsis that already
+				// consumed every element of a PROPER list (e.g. (a ... . rest)
+				// matching (1 2 3)). The rest of an exhausted proper list is the
+				// empty list, so bind `rest` to () rather than failing.
+				// (CaptureCar guards the empty-input case for the leading
+				// element, so reaching here with an empty position can only mean
+				// an exhausted-list tail, never a missing required element.)
+				captured := syntax.SyntaxEmptyList
+				bv, ok := p.captureStack[lcs-1].bindings[cd.Binding]
+				if ok && !syntaxValuesEqualForMatch(captured, bv) {
+					return ErrNotAMatch
+				}
+				p.captureStack[lcs-1].bindings[cd.Binding] = captured
+				break
 			}
 			capturedSyntax := vsv.SyntaxCdr()
 			bv, ok := p.captureStack[lcs-1].bindings[cd.Binding]

--- a/pkg/internal/match/nested_sublist_dotted_tail_test.go
+++ b/pkg/internal/match/nested_sublist_dotted_tail_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package match
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aalpar/wile/pkg/syntax"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestNestedSublistDottedTail covers C12/C13: a pattern with a nested sub-list
+// in NON-FINAL position followed by an improper `. rest` tail must match a
+// multi-element input. Per R7RS §4.3.2, `(P1 ... Pn . Px)` matches an input of
+// n-or-more elements where the first n elements match P1..Pn and the nth cdr
+// matches Px.
+//
+// Pattern: `((x) . body)`  — element 0 is the nested sublist `(x)`; the improper
+// tail `body` is a pattern variable that must capture the rest of the input.
+// Input:   `((1) 9)`       — `(1)` matches `(x)` (binding x=1); `body` = `(9)`.
+func TestNestedSublistDottedTail(t *testing.T) {
+	c := qt.New(t)
+
+	variables := map[string]struct{}{"x": {}, "body": {}}
+
+	// Build pattern ((x) . body): a pair whose car is the sublist (x) and
+	// whose cdr (improper tail) is the bare symbol body.
+	pattern := syntax.NewSyntaxCons(
+		testSyntaxList(testSyntaxSym("x")), // car: (x)
+		testSyntaxSym("body"),              // improper tail: body
+		nil,
+	)
+
+	compiler := NewSyntaxCompiler()
+	compiler.variables = variables
+	err := compiler.Compile(context.TODO(), pattern)
+	c.Assert(err, qt.IsNil)
+
+	// Input ((1) 9): proper list whose first element is (1) and whose rest is (9).
+	target := testSyntaxList(
+		testSyntaxList(testSyntaxInt(1)),
+		testSyntaxInt(9),
+	)
+
+	matcher := NewMatcher(variables, compiler.codes)
+	err = matcher.MatchSyntax(context.Background(), target)
+	c.Assert(err, qt.IsNil, qt.Commentf("pattern ((x) . body) must match input ((1) 9)"))
+
+	bindings := matcher.GetBindings()
+	// x binds to 1 (the element inside the sublist).
+	c.Assert(syntaxValuesEqualForMatch(bindings["x"], testSyntaxInt(1)), qt.IsTrue,
+		qt.Commentf("x = %v, want 1", bindings["x"]))
+	// body binds to the rest of the input after the first element: (9).
+	wantBody := testSyntaxList(testSyntaxInt(9))
+	c.Assert(syntaxValuesEqualForMatch(bindings["body"], wantBody), qt.IsTrue,
+		qt.Commentf("body = %v, want (9)", bindings["body"]))
+}
+
+// TestEllipsisThenImproperTail covers the companion matcher bug that also
+// blocks (chibi optional): an ellipsis followed by an improper `. rest` tail,
+// e.g. `(a ... . rest)`. Per R7RS §4.3.2 this matches any list; the ellipsis
+// greedily consumes leading elements and `rest` binds to the trailing cdr —
+// `()` for a proper list, or the dotted tail for an improper one. The chibi
+// `let-optionals` macro relies on this: `(var&default ... . rest)`.
+//
+// Before the fix, after the ellipsis consumed every element the matcher
+// position was the empty list and ByteCodeCaptureCdr rejected it as no-match,
+// so a proper-list input never matched.
+func TestEllipsisThenImproperTail(t *testing.T) {
+	c := qt.New(t)
+
+	variables := map[string]struct{}{"a": {}, "rest": {}}
+
+	// Pattern (a ... . rest):
+	//   (a . (... . rest))  — a, then ellipsis, then improper tail rest.
+	pattern := syntax.NewSyntaxCons(
+		testSyntaxSym("a"),
+		syntax.NewSyntaxCons(
+			testSyntaxSym("..."),
+			testSyntaxSym("rest"),
+			nil,
+		),
+		nil,
+	)
+
+	compileAndMatch := func(target *syntax.SyntaxPair) (*Matcher, error) {
+		compiler := NewSyntaxCompiler()
+		compiler.variables = variables
+		err := compiler.Compile(context.TODO(), pattern)
+		c.Assert(err, qt.IsNil)
+		m := NewMatcher(variables, compiler.codes, WithEllipsisVars(compiler.ellipsisVars))
+		matchErr := m.MatchSyntax(context.Background(), target)
+		return m, matchErr
+	}
+
+	// Proper list (1 2 3): ellipsis consumes 1 2 3; rest = ().
+	c.Run("proper list", func(c *qt.C) {
+		target := testSyntaxList(testSyntaxInt(1), testSyntaxInt(2), testSyntaxInt(3))
+		m, err := compileAndMatch(target)
+		c.Assert(err, qt.IsNil, qt.Commentf("(a ... . rest) must match (1 2 3)"))
+		rest := m.GetBindings()["rest"]
+		c.Assert(syntax.IsSyntaxEmptyList(rest), qt.IsTrue,
+			qt.Commentf("rest = %v, want ()", rest))
+	})
+
+	// Single element (7): ellipsis consumes 7; rest = ().
+	c.Run("single element", func(c *qt.C) {
+		target := testSyntaxList(testSyntaxInt(7))
+		m, err := compileAndMatch(target)
+		c.Assert(err, qt.IsNil, qt.Commentf("(a ... . rest) must match (7)"))
+		rest := m.GetBindings()["rest"]
+		c.Assert(syntax.IsSyntaxEmptyList(rest), qt.IsTrue,
+			qt.Commentf("rest = %v, want ()", rest))
+	})
+}

--- a/pkg/internal/match/nested_sublist_dotted_tail_test.go
+++ b/pkg/internal/match/nested_sublist_dotted_tail_test.go
@@ -72,14 +72,20 @@ func TestNestedSublistDottedTail(t *testing.T) {
 
 // TestEllipsisThenImproperTail covers the companion matcher bug that also
 // blocks (chibi optional): an ellipsis followed by an improper `. rest` tail,
-// e.g. `(a ... . rest)`. Per R7RS §4.3.2 this matches any list; the ellipsis
-// greedily consumes leading elements and `rest` binds to the trailing cdr —
-// `()` for a proper list, or the dotted tail for an improper one. The chibi
-// `let-optionals` macro relies on this: `(var&default ... . rest)`.
+// e.g. `(a ... . rest)`. The ellipsis greedily consumes the leading elements of
+// a PROPER-list input and `rest` binds to `()` (the cdr of the exhausted list).
+// The chibi `let-optionals` macro relies on exactly this over a proper argument
+// list: `(var&default ... . rest)`.
+//
+// KNOWN LIMITATION (pinned by the "improper input" subtest below): a genuinely
+// improper input like `(1 2 . 5)` does NOT match — the ellipsis loop's VisitCdr
+// cannot traverse a dotted input tail (verified identical on master). This is
+// outside C12/C13's scope (nested-sublist + improper-PATTERN-tail), and chibi
+// feeds only proper lists, so it does not block the libraries.
 //
 // Before the fix, after the ellipsis consumed every element the matcher
 // position was the empty list and ByteCodeCaptureCdr rejected it as no-match,
-// so a proper-list input never matched.
+// so even a proper-list input never matched.
 func TestEllipsisThenImproperTail(t *testing.T) {
 	c := qt.New(t)
 
@@ -125,5 +131,20 @@ func TestEllipsisThenImproperTail(t *testing.T) {
 		rest := m.GetBindings()["rest"]
 		c.Assert(syntax.IsSyntaxEmptyList(rest), qt.IsTrue,
 			qt.Commentf("rest = %v, want ()", rest))
+	})
+
+	// Improper input (1 2 . 5): does NOT match — known limitation, pinned so
+	// the docstring's claim stays honest. The ellipsis loop cannot traverse a
+	// dotted input tail; this is verified identical on master and is outside
+	// C12/C13's scope (chibi feeds only proper lists).
+	c.Run("improper input not matched", func(c *qt.C) {
+		target := syntax.NewSyntaxCons(
+			testSyntaxInt(1),
+			syntax.NewSyntaxCons(testSyntaxInt(2), testSyntaxInt(5), nil),
+			nil,
+		)
+		_, err := compileAndMatch(target)
+		c.Assert(err, qt.IsNotNil,
+			qt.Commentf("(a ... . rest) does not match improper input (1 2 . 5)"))
 	})
 }

--- a/pkg/internal/match/syntax_compiler.go
+++ b/pkg/internal/match/syntax_compiler.go
@@ -221,6 +221,14 @@ func compileElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, eleme
 func compilePairElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry, pr *syntax.SyntaxPair, element syntax.SyntaxValue, elementStart int) ([]syntaxCompilerStackEntry, bool) {
 	l := len(stack)
 
+	// C12/C13: a nested sub-list in NON-FINAL position can be followed by an
+	// improper `. rest` tail, e.g. `((x) . body)`. The descent paths below skip
+	// advanceToNextElement (they return shouldContinue=true), so the improper
+	// tail must be captured here — and BEFORE the descent op, because at runtime
+	// CaptureCdr/CompareCdr read the parent pair's cdr at the current position;
+	// the descent op then operates on the car, which CaptureCdr preserves.
+	emitImproperTailIfPresent(vis, &stack[l-1])
+
 	if syntax.IsSyntaxEmptyList(pr) {
 		// Empty pair pattern () - verify input car is also empty
 		vis.codes = append(vis.codes, ByteCodeRequireCarEmpty{})
@@ -251,6 +259,11 @@ func compileVectorElement(vis *SyntaxCompiler, stack []syntaxCompilerStackEntry,
 	vec *syntax.SyntaxVector, element syntax.SyntaxValue, elementStart int,
 ) ([]syntaxCompilerStackEntry, bool) {
 	l := len(stack)
+
+	// C12/C13: a vector sub-pattern in non-final position can be followed by an
+	// improper `. rest` tail; capture it before the descent op (same rationale
+	// as compilePairElement).
+	emitImproperTailIfPresent(vis, &stack[l-1])
 
 	if len(vec.Values) == 0 {
 		// Empty vector pattern #() — verify input car is an empty vector.
@@ -540,21 +553,38 @@ func advanceToNextElement(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry, 
 		return true
 	}
 
-	// Check for improper list pattern: (_ a . rest) where rest is a pattern variable
-	sym, ok := cdr.(*syntax.SyntaxSymbol)
-	if ok {
-		_, isVar := vis.variables[sym.Key()]
-		if isVar {
-			// The CDR is a pattern variable - emit CaptureCdr to capture the rest
-			vis.codes = append(vis.codes, ByteCodeCaptureCdr{Binding: sym.Key()})
-			entry.variables[sym.Key()] = struct{}{}
-		} else {
-			// The CDR is a literal symbol - compare it
-			vis.codes = append(vis.codes, ByteCodeCompareCdr{Value: syntax.NewSyntaxSymbol(sym.Key(), nil)})
-		}
-	}
-
+	// Improper list pattern: (_ a . rest) where rest is a pattern variable
+	// or a literal symbol.
+	emitImproperTailIfPresent(vis, entry)
 	return false
+}
+
+// emitImproperTailIfPresent emits bytecode for an improper `. rest` tail at the
+// current list level. The cdr of entry.pr is an improper tail when it is a bare
+// symbol (not a pair and not the empty list). A pattern variable becomes
+// CaptureCdr (binds the rest of the input); a literal symbol becomes CompareCdr
+// (matches it exactly). Does nothing when the cdr is a pair or the empty list.
+//
+// Shared by advanceToNextElement (symbol/literal preceding element) and by the
+// pair/vector descent paths (compilePairElement, compileVectorElement), which
+// otherwise skip advanceToNextElement and would drop the tail (C12/C13). In the
+// descent paths it must run BEFORE the descent op so CaptureCdr reads the parent
+// pair's cdr at the current position rather than the already-advanced sibling.
+func emitImproperTailIfPresent(vis *SyntaxCompiler, entry *syntaxCompilerStackEntry) {
+	cdr := entry.pr.SyntaxCdr()
+	sym, ok := cdr.(*syntax.SyntaxSymbol)
+	if !ok {
+		return
+	}
+	_, isVar := vis.variables[sym.Key()]
+	if isVar {
+		// The CDR is a pattern variable - emit CaptureCdr to capture the rest
+		vis.codes = append(vis.codes, ByteCodeCaptureCdr{Binding: sym.Key()})
+		entry.variables[sym.Key()] = struct{}{}
+		return
+	}
+	// The CDR is a literal symbol - compare it
+	vis.codes = append(vis.codes, ByteCodeCompareCdr{Value: syntax.NewSyntaxSymbol(sym.Key(), nil)})
 }
 
 // insert inserts codes into target at index i, adjusting jump offsets as needed.

--- a/pkg/wile/syntax_rules_dotted_tail_engine_test.go
+++ b/pkg/wile/syntax_rules_dotted_tail_engine_test.go
@@ -1,0 +1,113 @@
+package wile_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/pkg/stdlib"
+	"github.com/aalpar/wile/pkg/wile"
+)
+
+// dottedTailEngine builds an engine that can import the sealed stdlib
+// libraries (chibi optional/diff live there).
+func dottedTailEngine(t *testing.T) *wile.Engine {
+	t.Helper()
+	eng, err := wile.NewEngine(context.Background(),
+		wile.WithProfile(wile.KitchenSink),
+		wile.WithSourceFS(stdlib.FS),
+		wile.WithLibraryPaths())
+	qt.Assert(t, err, qt.IsNil)
+	return eng
+}
+
+// TestSyntaxRulesNestedSublistDottedTail is the end-to-end guard for C12/C13:
+// a syntax-rules clause whose pattern has a nested sub-list in NON-FINAL
+// position AND an improper `. body` tail must match a multi-arg call.
+// Per R7RS §4.3.2, `(P1 ... Pn . Px)` matches an input of n-or-more elements
+// where the first n match P1..Pn and the nth cdr matches Px.
+//
+// Before the fix the matcher dropped the improper tail of a pair/vector
+// sub-pattern, so `(m (1) 9)` raised "no matching clause for input".
+func TestSyntaxRulesNestedSublistDottedTail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	src := `(define-syntax m (syntax-rules () ((m (x) . body) (list x (quote ->) (quote body)))))
+	        (m (1) 9)`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil, qt.Commentf("(m (1) 9) must expand and not error"))
+	c.Assert(result.SchemeString(), qt.Equals, "(1 -> (9))")
+}
+
+// TestSyntaxRulesNestedSublistDottedTailMultiArg covers the same shape with a
+// longer improper tail: the captured `body` collects every element after the
+// nested sub-list.
+func TestSyntaxRulesNestedSublistDottedTailMultiArg(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	src := `(define-syntax m (syntax-rules () ((m (x) . body) (list x (quote ->) (quote body)))))
+	        (m (5) 7 8 9)`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "(5 -> (7 8 9))")
+}
+
+// TestSyntaxRulesEllipsisDottedTail covers the companion matcher fix: an
+// ellipsis followed by an improper `. rest` tail (`(a ... . rest)`). This shape
+// is what (chibi optional)'s let-optionals macro depends on. A proper-list
+// input drives the ellipsis to exhaustion, after which `rest` binds to ().
+func TestSyntaxRulesEllipsisDottedTail(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	defer eng.Close()
+
+	src := `(define-syntax m (syntax-rules () ((m (a ... . rest)) (list (list a ...) rest))))
+	        (m (1 2 3))`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil, qt.Commentf("(a ... . rest) must match a proper list, rest=()"))
+	c.Assert(result.SchemeString(), qt.Equals, "((1 2 3) ())")
+}
+
+// TestChibiOptionalLoads verifies (chibi optional) — previously dead because of
+// the C12/C13 matcher bug in its let-optionals/let*-to-let macros — now loads
+// and its opt-lambda works for both the defaulted and the supplied-argument
+// cases.
+func TestChibiOptionalLoads(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng := dottedTailEngine(t)
+	defer eng.Close()
+
+	src := `(import (chibi optional))
+	        (define f (opt-lambda ((x 1)) x))
+	        (list (f) (f 42))`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil, qt.Commentf("(chibi optional) must load and opt-lambda must work"))
+	c.Assert(result.SchemeString(), qt.Equals, "(1 42)")
+}
+
+// TestChibiDiffLoads verifies (chibi diff) — which imports (chibi optional) —
+// now loads, and its lcs procedure computes the longest common subsequence.
+func TestChibiDiffLoads(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	eng := dottedTailEngine(t)
+	defer eng.Close()
+
+	src := `(import (chibi diff))
+	        (lcs '(1 2 3) '(1 9 3) =)`
+	result, err := eng.EvalMultiple(ctx, src)
+	c.Assert(err, qt.IsNil, qt.Commentf("(chibi diff) must load and lcs must work"))
+	c.Assert(result.SchemeString(), qt.Equals, "(1 3)")
+}


### PR DESCRIPTION
Libraries-review Phase 7. Fixes the `syntax-rules` matcher bug that kept `(chibi optional)` and `(chibi diff)` entirely dead.

## The bug(s)
A `syntax-rules` clause with a nested sub-list pattern in NON-final position **and** an improper `. body` tail never matched a multi-arg call (`(m (x) . body)` vs `(m (1) 9)`). Investigation found **two** distinct defects (the review named one):

1. **Compiler (`syntax_compiler.go`):** `compilePairElement`/`compileVectorElement` returned `shouldContinue=true`, skipping `advanceToNextElement` where improper tails are emitted — so the `. rest` of a nested-sublist element was silently dropped. Fixed via a shared `emitImproperTailIfPresent` helper called *before* the descent op (CaptureCdr must read the parent's cdr before the descent advances past it).
2. **Matcher (`match.go`):** `ByteCodeCaptureCdr` rejected an empty-list position, so `(a ... . rest)` (ellipsis-then-tail) never matched a *proper* list — exactly what `(chibi optional)`'s `let-optionals` `(var&default ... . rest)` depends on. Without this, chibi stayed dead even with fix #1. Fixed to bind `rest` to `()` for an exhausted proper list.

## Verification
- `(import (chibi optional))` → `(opt-lambda ((x 1)) x)` works; `(import (chibi diff))` → `(lcs '(1 2 3) '(1 9 3) =)` → `(1 3)`. Both had **zero** prior coverage; added engine-level tests.
- New tests: `pkg/internal/match/nested_sublist_dotted_tail_test.go` (matcher-level), `pkg/wile/syntax_rules_dotted_tail_engine_test.go` (end-to-end).
- `make lint` clean; whole-repo `go test ./...` green (high-blast-radius change — bounded against match/machine/wile/integration/syntax/registry suites).

## Honest caveat (out of scope, not a regression)
`(a ... . rest)` still does not match a *truly improper input* like `(1 2 . 9)` — the ellipsis loop's `VisitCdr` cannot traverse a dotted input tail. **Verified identical on master**; outside C12/C13 (nested-sublist + improper-*pattern*-tail), and chibi feeds only proper lists. Candidate follow-up if full `(P ... . Px)`-against-dotted-input conformance is wanted.

🤖 Implemented via a worktree-isolated agent under the macro-system skill; integrated + re-verified on a clean branch.