### PR TITLE
fix(math): expt of negative real base to non-integer power → complex; zero base, negative exponent → ErrDivisionByZero (C6/C7)

### DIFF
--- a/extensions/math/prim_transcendental.go
+++ b/extensions/math/prim_transcendental.go
@@ -309,7 +309,10 @@ func PrimExpt(mc machine.CallContext) error {
 		// (R7RS §6.2.6 — it is complex); math.Pow returns +nan.0 there (C6).
 		// An integer-valued exponent (e.g. (expt -2 3.0)) stays real, so guard
 		// on the exponent being non-integral, not merely on a negative base.
-		if baseF < 0 && expF != math.Trunc(expF) {
+		// A NaN exponent is excluded (math.Trunc(NaN)!=NaN would otherwise route
+		// it to the complex path); leave it on the real IEEE path, matching the
+		// prior real +nan.0 result for a degenerate input like (expt -2 +nan.0).
+		if baseF < 0 && !math.IsNaN(expF) && expF != math.Trunc(expF) {
 			mc.SetValue(values.NewComplex(cmplx.Pow(complex(baseF, 0), complex(expF, 0))))
 			return nil
 		}

--- a/extensions/math/prim_transcendental.go
+++ b/extensions/math/prim_transcendental.go
@@ -266,6 +266,14 @@ func PrimExpt(mc machine.CallContext) error {
 
 	e, ok := values.ExactInteger(expNum)
 	if ok {
+		// Exact zero base with a negative exponent is a true division by zero
+		// (1/0^|e|); exptExact would build big.Rat.SetFrac(_, 0) and panic,
+		// surfacing as a recovered "internal error" (C7). An INEXACT zero base
+		// is left to the IEEE path below, where 0.0^-1 = +inf.0 per R7RS §6.2.6.
+		if e < 0 && baseNum.IsExact() && baseNum.IsZero() {
+			return werr.WrapForeignErrorf(werr.ErrDivisionByZero,
+				"expt: zero base with negative exponent %d", e)
+		}
 		switch b := baseNum.(type) {
 		case *values.Integer:
 			mc.SetValue(exptExact(big.NewInt(b.Value), bigOne, e))
@@ -295,9 +303,17 @@ func PrimExpt(mc machine.CallContext) error {
 				values.NumberToComplex128Lossy(expNum))))
 			return nil
 		}
-		mc.SetValue(values.NewFloat(math.Pow(
-			values.NumberToFloat64(baseNum),
-			values.NumberToFloat64(expNum))))
+		baseF := values.NumberToFloat64(baseNum)
+		expF := values.NumberToFloat64(expNum)
+		// A negative real base raised to a NON-integer power has no real value
+		// (R7RS §6.2.6 — it is complex); math.Pow returns +nan.0 there (C6).
+		// An integer-valued exponent (e.g. (expt -2 3.0)) stays real, so guard
+		// on the exponent being non-integral, not merely on a negative base.
+		if baseF < 0 && expF != math.Trunc(expF) {
+			mc.SetValue(values.NewComplex(cmplx.Pow(complex(baseF, 0), complex(expF, 0))))
+			return nil
+		}
+		mc.SetValue(values.NewFloat(math.Pow(baseF, expF)))
 	}
 	return nil
 }

--- a/extensions/math/prim_transcendental_test.go
+++ b/extensions/math/prim_transcendental_test.go
@@ -193,6 +193,13 @@ func TestExptAdditionalCases(t *testing.T) {
 		{"expt neg base inexact-int exp real value", `(< (abs (- (expt -2 3.0) -8.0)) 1e-10)`, values.TrueValue},
 		{"expt neg base inexact-int exp not complex", `(real? (expt -2 3.0))`, values.TrueValue},
 		{"expt neg float base int exp real", `(< (abs (- (expt -2.0 3) -8.0)) 1e-10)`, values.TrueValue},
+		// NaN exponent on a negative base stays REAL +nan.0 (degenerate input;
+		// must not flip to a complex result via the Trunc(NaN) guard).
+		{"expt neg base nan exp is nan", `(nan? (expt -2 +nan.0))`, values.TrueValue},
+		{"expt neg base nan exp is real", `(real? (expt -2 +nan.0))`, values.TrueValue},
+		// Inexact zero base with a negative exponent is the IEEE +inf.0, NOT the
+		// exact-zero ErrDivisionByZero (which only applies to an exact 0 base).
+		{"expt inexact zero base neg exp inf", `(= (expt 0.0 -1) +inf.0)`, values.TrueValue},
 
 		// Complex exponentiation paths
 		{"complex base integer exp", `(< (magnitude (- (expt 1+1i 2) 0+2i)) 1e-10)`, values.TrueValue},

--- a/extensions/math/prim_transcendental_test.go
+++ b/extensions/math/prim_transcendental_test.go
@@ -15,9 +15,11 @@
 package math_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aalpar/wile/pkg/values"
+	"github.com/aalpar/wile/pkg/werr"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -177,6 +179,21 @@ func TestExptAdditionalCases(t *testing.T) {
 		// Zero base with positive exponent
 		{"expt 0 positive", `(= (expt 0 5) 0)`, values.TrueValue},
 
+		// Negative real base with non-integer exponent → complex (R7RS §6.2.6),
+		// not +nan.0 (C6). (expt -1 1/2) == i == (sqrt -1); (expt -8 1/3) has
+		// magnitude 2 (a genuine complex cube root, not NaN).
+		{"expt neg base half power is i", `(< (magnitude (- (expt -1 1/2) 0+1i)) 1e-10)`, values.TrueValue},
+		{"expt neg base half power equals sqrt", `(< (magnitude (- (expt -1 1/2) (sqrt -1))) 1e-10)`, values.TrueValue},
+		{"expt neg base cube root magnitude", `(< (abs (- (magnitude (expt -8 1/3)) 2)) 1e-10)`, values.TrueValue},
+		{"expt neg base cube root not nan", `(not (nan? (magnitude (expt -8 1/3))))`, values.TrueValue},
+		// Positive base + non-integer exponent stays real (unchanged).
+		{"expt pos base half power real", `(< (abs (- (expt 4 1/2) 2.0)) 1e-10)`, values.TrueValue},
+		// Negative base with an INTEGER-VALUED inexact exponent must stay REAL
+		// (regression guard for the non-integer-only complex routing).
+		{"expt neg base inexact-int exp real value", `(< (abs (- (expt -2 3.0) -8.0)) 1e-10)`, values.TrueValue},
+		{"expt neg base inexact-int exp not complex", `(real? (expt -2 3.0))`, values.TrueValue},
+		{"expt neg float base int exp real", `(< (abs (- (expt -2.0 3) -8.0)) 1e-10)`, values.TrueValue},
+
 		// Complex exponentiation paths
 		{"complex base integer exp", `(< (magnitude (- (expt 1+1i 2) 0+2i)) 1e-10)`, values.TrueValue},
 		{"complex base float exp", `(number? (expt 1+1i 0.5))`, values.TrueValue},
@@ -290,6 +307,19 @@ func TestTranscendentalErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			evalExpectError(t, engine, tc.code)
 		})
+	}
+}
+
+// TestExptZeroNegativeExponent verifies that (expt 0 <neg>) raises a clean,
+// catchable ErrDivisionByZero rather than surfacing as a recovered panic /
+// "internal error" from big.Rat.SetFrac(_, 0) (C7).
+func TestExptZeroNegativeExponent(t *testing.T) {
+	engine := newEngine(t)
+	for _, code := range []string{"(expt 0 -1)", "(expt 0 -2)", "(expt 0/1 -3)"} {
+		err := evalExpectError(t, engine, code)
+		if !errors.Is(err, werr.ErrDivisionByZero) {
+			t.Fatalf("%s: want ErrDivisionByZero, got %v", code, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Libraries-review Phase 4 (C6, C7).

- **C6:** `(expt <neg-real> <non-integer>)` returned `+nan.0` from `math.Pow`. Route a negative real base with a non-integer exponent through `cmplx.Pow`. `(expt -1 1/2)` → `i` == `(sqrt -1)`; `(expt -8 1/3)` is a complex cube root (magnitude 2).
- **C7:** `(expt 0 <neg>)` built `big.Rat.SetFrac(_,0)` → recovered "internal error". Guard the exact-integer-exponent path to raise `werr.ErrDivisionByZero`.

**Two plan-snippet corrections (locked by regression tests):**
- The negative-base routing guards on `baseF<0 && expF != Trunc(expF)`, not `baseF<0` alone — otherwise `(expt -2 3.0)` would regress from real `-8.0` to a complex `-8+0i`.
- The zero-base guard requires `baseNum.IsExact()` — otherwise `(expt 0.0 -1)` (inexact) would wrongly error instead of returning `+inf.0` per R7RS §6.2.6.

Tests: `TestExptAdditionalCases` (complex roots + real-stays-real guards), `TestExptZeroNegativeExponent`. Full `extensions/math` suite green.