### PR TITLE
fix(compilation,values,scheme): let-syntax/letrec-syntax exports, display no-bar-escape, r5rs manifest, drop dev path, for-meta overflow + cond-expand else-last (Phase 8)

### DIFF
--- a/pkg/machine/compilation/compile_cond_expand.go
+++ b/pkg/machine/compilation/compile_cond_expand.go
@@ -45,17 +45,27 @@ func (p *CompileTimeContinuation) resolveCondExpandClause(ctx context.Context, a
 	resolver := p.env.FileResolver()
 
 	var matchedClause syntax.SyntaxValue
-	_, err := syntax.SyntaxForEach(ctx, argsPair, func(_ context.Context, _ int, _ bool, clause syntax.SyntaxValue) error {
-		if matchedClause != nil {
-			return nil // Already found a match
-		}
-
+	_, err := syntax.SyntaxForEach(ctx, argsPair, func(_ context.Context, _ int, hasNext bool, clause syntax.SyntaxValue) error {
 		clausePair, ok := clause.(*syntax.SyntaxPair)
 		if !ok {
 			return p.wrapCompilationError(werr.WrapForeignErrorf(werr.ErrNotAPair, "cond-expand: clause must be a list"))
 		}
 
 		reqExpr := clausePair.SyntaxCar()
+
+		// R7RS §4.2.1: else, if present, must be the last clause. This is a
+		// structural constraint on the whole clause list, so it is checked on
+		// every clause — before the matched-clause short-circuit below, which
+		// would otherwise stop scanning once an earlier clause matches.
+		if isElseClause(reqExpr) && hasNext {
+			return p.wrapCompilationError(werr.WrapForeignErrorf(werr.ErrInvalidSyntax,
+				"cond-expand: else must be the last clause"))
+		}
+
+		if matchedClause != nil {
+			return nil // Already found a match; keep scanning to validate else position.
+		}
+
 		req, err := parseFeatureRequirement(ctx, reqExpr)
 		if err != nil {
 			return p.wrapCompilationError(werr.WrapForeignErrorf(err, "cond-expand: invalid feature requirement"))
@@ -157,6 +167,16 @@ func (p *CompileTimeContinuation) processCondExpand(ctctx CompileTimeCallContext
 		return p.processLibraryDeclaration(ctctx, lib, decl)
 	})
 	return err
+}
+
+// isElseClause reports whether a clause's feature-requirement expression is the
+// literal symbol else. Used to enforce R7RS §4.2.1's else-must-be-last constraint.
+func isElseClause(reqExpr syntax.SyntaxValue) bool {
+	sym, ok := reqExpr.(*syntax.SyntaxSymbol)
+	if !ok {
+		return false
+	}
+	return sym.Key() == "else"
 }
 
 // parseFeatureRequirement parses a feature requirement expression.

--- a/pkg/machine/compilation/compile_cond_expand_test.go
+++ b/pkg/machine/compilation/compile_cond_expand_test.go
@@ -120,11 +120,41 @@ func TestCompileCondExpand(t *testing.T) {
 func TestCompileCondExpandErrors(t *testing.T) {
 	tcs := []testhelpers.SchemeCodeErrorTestCase{
 		{Name: "no matching clause", Code: `(cond-expand (nonexistent 'no))`},
+		// Phase 8 Task 8G(ii): R7RS §4.2.1 — else must be the last clause. A
+		// non-final else is a malformed cond-expand and must error at compile time,
+		// not silently shadow the clauses after it.
+		{Name: "else not last", Code: `(cond-expand (else 'first) (r7rs 'second))`},
+		{Name: "else before another else", Code: `(cond-expand (else 'a) (else 'b))`},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			_, err := testhelpers.RunSchemeCode(t, tc.Code)
 			qt.Assert(t, err, qt.IsNotNil)
+		})
+	}
+}
+
+// TestCompileCondExpandElseLast pins that a final else clause is honored (the
+// complement of the else-not-last error): a present feature is selected before
+// else, and else is the fallback when no feature matches.
+func TestCompileCondExpandElseLast(t *testing.T) {
+	tcs := []testhelpers.SchemeCodeTestCase{
+		{
+			Name:     "feature before final else wins",
+			Code:     `(cond-expand (r7rs 'feature) (else 'fallback))`,
+			Expected: values.NewSymbol("feature"),
+		},
+		{
+			Name:     "final else is fallback",
+			Code:     `(cond-expand (nonexistent 'no) (else 'fallback))`,
+			Expected: values.NewSymbol("fallback"),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			result, err := testhelpers.RunSchemeCode(t, tc.Code)
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.Expected)
 		})
 	}
 }

--- a/pkg/machine/compilation/import_set_datum.go
+++ b/pkg/machine/compilation/import_set_datum.go
@@ -192,6 +192,22 @@ func parseImportSetRenameFromDatum(ctx context.Context, tuple values.Tuple) (*Im
 	return importSet, nil
 }
 
+// composePhaseShift composes an additional delta onto a nested import set's phase
+// shift, rejecting the composition if the accumulated result would overflow
+// environment.Phase (int8). Each individual operand may fit int8 yet a chain
+// (e.g. (for-meta 100 (for-meta 100 …))) compose to a value that does not. The sum
+// is computed in a wider int so the overflow is detectable rather than silently
+// truncated. keyword names the form for the error message.
+func composePhaseShift(keyword string, base environment.Phase, delta environment.Phase) (environment.Phase, error) {
+	sum := int(base) + int(delta)
+	if sum < math.MinInt8 || sum > math.MaxInt8 {
+		return 0, werr.WrapForeignErrorf(werr.ErrInvalidArgument,
+			"%s: composed phase %d out of range [%d, %d]",
+			keyword, sum, int64(math.MinInt8), int64(math.MaxInt8))
+	}
+	return environment.Phase(sum), nil
+}
+
 // parseImportSetPhaseShiftFromDatum parses (<keyword> <import-set>) and adds
 // delta to the nested import set's phase shift. Handles for-syntax (+1) and
 // for-template (-1).
@@ -204,7 +220,11 @@ func parseImportSetPhaseShiftFromDatum(ctx context.Context, keyword string, tupl
 	if err != nil {
 		return nil, err
 	}
-	importSet.PhaseShift += delta
+	composed, err := composePhaseShift(keyword, importSet.PhaseShift, delta)
+	if err != nil {
+		return nil, err
+	}
+	importSet.PhaseShift = composed
 	return importSet, nil
 }
 
@@ -225,17 +245,22 @@ func parseImportSetForMetaFromDatum(ctx context.Context, tuple values.Tuple) (*I
 		return nil, err
 	}
 
-	// Add n to phase shift (composable). environment.Phase is int8; reject
-	// values that would silently truncate. Composition with importSet's
-	// existing PhaseShift could still overflow int8 — guard the operand
-	// here; the composition guard belongs in callers that compose chains.
+	// Add n to phase shift (composable). environment.Phase is int8; reject a
+	// single operand that would not fit, then compose onto the nested set's
+	// existing shift — a chain (e.g. (for-meta 100 (for-meta 100 …))) can
+	// overflow int8 even when each operand fits, so the composition is guarded
+	// in composePhaseShift.
 	n := phaseInt.Value
 	if n < math.MinInt8 || n > math.MaxInt8 {
 		return nil, werr.WrapForeignErrorf(werr.ErrInvalidArgument,
 			"for-meta: phase %d out of range [%d, %d]",
 			n, int64(math.MinInt8), int64(math.MaxInt8))
 	}
-	importSet.PhaseShift += environment.Phase(n)
+	composed, err := composePhaseShift("for-meta", importSet.PhaseShift, environment.Phase(n))
+	if err != nil {
+		return nil, err
+	}
+	importSet.PhaseShift = composed
 	return importSet, nil
 }
 

--- a/pkg/machine/compilation/import_set_datum_test.go
+++ b/pkg/machine/compilation/import_set_datum_test.go
@@ -660,3 +660,56 @@ func TestParseImportSetFromDatum_ForMeta_MissingImportSet(t *testing.T) {
 	qt.Assert(t, err, qt.IsNotNil)
 	qt.Assert(t, errors.Is(err, werr.ErrNotAList), qt.IsTrue)
 }
+
+// forMetaDatum builds (for-meta <phase> <inner>) as a quoted datum.
+func forMetaDatum(phase int64, inner values.Value) values.Value {
+	return values.NewCons(
+		values.NewSymbol("for-meta"),
+		values.NewCons(
+			values.NewInteger(phase),
+			values.NewCons(inner, values.EmptyList),
+		),
+	)
+}
+
+// schemeBaseDatum builds (scheme base) as a quoted datum.
+func schemeBaseDatum() values.Value {
+	return values.NewCons(
+		values.NewSymbol("scheme"),
+		values.NewCons(values.NewSymbol("base"), values.EmptyList),
+	)
+}
+
+// TestParseImportSetFromDatum_ForMeta_CompositionOverflow pins Phase 8 Task 8G(i):
+// each for-meta operand individually fits int8, but a chain composes their phase
+// shifts. (for-meta 100 (for-meta 100 (scheme base))) accumulates to 200, which
+// overflows environment.Phase (int8). The composition guard must reject it cleanly
+// (wrapped ErrInvalidArgument), not silently truncate to a wrong phase.
+func TestParseImportSetFromDatum_ForMeta_CompositionOverflow(t *testing.T) {
+	// (for-meta 100 (for-meta 100 (scheme base))) → 100 + 100 = 200 > 127.
+	importSet := forMetaDatum(100, forMetaDatum(100, schemeBaseDatum()))
+
+	_, err := ParseImportSetFromDatum(context.Background(), importSet)
+	qt.Assert(t, err, qt.IsNotNil)
+	qt.Assert(t, errors.Is(err, werr.ErrInvalidArgument), qt.IsTrue)
+}
+
+// TestParseImportSetFromDatum_ForMeta_CompositionUnderflow pins the negative side:
+// (for-meta -100 (for-meta -100 (scheme base))) accumulates to -200 < -128.
+func TestParseImportSetFromDatum_ForMeta_CompositionUnderflow(t *testing.T) {
+	importSet := forMetaDatum(-100, forMetaDatum(-100, schemeBaseDatum()))
+
+	_, err := ParseImportSetFromDatum(context.Background(), importSet)
+	qt.Assert(t, err, qt.IsNotNil)
+	qt.Assert(t, errors.Is(err, werr.ErrInvalidArgument), qt.IsTrue)
+}
+
+// TestParseImportSetFromDatum_ForMeta_CompositionAtBoundary pins that a chain that
+// composes exactly to the int8 boundary still succeeds: 100 + 27 = 127.
+func TestParseImportSetFromDatum_ForMeta_CompositionAtBoundary(t *testing.T) {
+	importSet := forMetaDatum(100, forMetaDatum(27, schemeBaseDatum()))
+
+	result, err := ParseImportSetFromDatum(context.Background(), importSet)
+	qt.Assert(t, err, qt.IsNil)
+	qt.Assert(t, result.PhaseShift, qt.Equals, environment.Phase(127))
+}

--- a/pkg/machine/compilation/library_registry.go
+++ b/pkg/machine/compilation/library_registry.go
@@ -150,9 +150,13 @@ type LibraryRegistry struct {
 }
 
 // DefaultLibraryPaths are the default directories to search for libraries.
+//
+// Only the current directory is searched by default. The embedded standard
+// library is the real source of the stdlib (resolved via the FileResolver chain
+// over stdlib.FS); the former "./pkg/stdlib/lib" entry was a development-tree
+// convenience that resolves nothing in a deployed binary.
 var DefaultLibraryPaths = []string{
 	".",
-	"./pkg/stdlib/lib",
 }
 
 // NewLibraryRegistry creates a new library registry with default search paths.

--- a/pkg/machine/library_test.go
+++ b/pkg/machine/library_test.go
@@ -73,11 +73,12 @@ func TestLibraryRegistry(t *testing.T) {
 
 	registry := compilation.NewLibraryRegistry()
 
-	// Test that default search paths are set
+	// Test that default search paths are set. Only "." is searched by default;
+	// the stdlib is served by the embedded FileResolver chain, not a dev-tree path
+	// (the former "./pkg/stdlib/lib" entry was dropped in Phase 8 Task 8F).
 	paths := registry.GetSearchPaths()
-	c.Assert(len(paths), qt.Equals, 2)
+	c.Assert(len(paths), qt.Equals, 1)
 	c.Assert(paths[0], qt.Equals, ".")
-	c.Assert(paths[1], qt.Equals, "./pkg/stdlib/lib")
 
 	// Test SetSearchPaths
 	registry.SetSearchPaths([]string{"/custom/path"})

--- a/pkg/stdlib/lib/scheme/base.sld
+++ b/pkg/stdlib/lib/scheme/base.sld
@@ -9,6 +9,8 @@
     begin
     define
     define-syntax
+    let-syntax
+    letrec-syntax
     syntax-rules
     syntax-error
     quasiquote

--- a/pkg/stdlib/lib/scheme/r5rs.sld
+++ b/pkg/stdlib/lib/scheme/r5rs.sld
@@ -1,21 +1,67 @@
 (define-library (scheme r5rs)
-  (description "R5RS compatibility library: re-exports core R5RS bindings.")
+  (description "R5RS compatibility library: re-exports the bindings required by the Revised^5 Report on Scheme.")
   (import (scheme base)
+          (scheme inexact)
           (scheme complex)
+          (scheme char)
           (scheme cxr)
           (scheme read)
-          (scheme write))
+          (scheme write)
+          (scheme lazy)
+          (scheme eval)
+          (scheme repl)
+          (scheme load)
+          (scheme file))
+
+  ;; R5RS spells the exact/inexact converters exact->inexact and inexact->exact.
+  ;; R7RS renamed them to inexact and exact; the long names live only in (scheme r5rs).
+  ;; Defined here as aliases over the R7RS core converters imported from (scheme base).
+  (begin
+    (define exact->inexact inexact)
+    (define inexact->exact exact))
 
   (export
+    ;; Syntactic keywords (R5RS §7.1.3, §4.1-4.3)
+    quote
+    lambda
+    if
+    set!
+    begin
+    define
+    define-syntax
+    let-syntax
+    letrec-syntax
+    syntax-rules
+    quasiquote
+    unquote
+    unquote-splicing
+    cond
+    case
+    and
+    or
+    let
+    let*
+    letrec
+    do
+    delay
+    else
+    =>
+    ...
+    _
+    ;; Equivalence predicates
     eq?
     eqv?
     equal?
+    ;; Booleans
     boolean?
     not
+    ;; Pairs and lists
     pair?
     cons
     car
     cdr
+    set-car!
+    set-cdr!
     caar cadr cdar cddr
     caaar caadr cadar caddr cdaar cdadr cddar cdddr
     caaaar caaadr caadar caaddr cadaar cadadr caddar cadddr
@@ -34,9 +80,11 @@
     assq
     assv
     assoc
+    ;; Symbols
     symbol?
     symbol->string
     string->symbol
+    ;; Numbers
     number?
     complex?
     real?
@@ -66,35 +114,71 @@
     truncate
     round
     rationalize
+    exp
+    log
+    sin
+    cos
+    tan
+    asin
+    acos
+    atan
+    sqrt
     expt
-    number->string
-    string->number
     make-rectangular
     make-polar
     real-part
     imag-part
     magnitude
     angle
+    exact->inexact
+    inexact->exact
+    number->string
+    string->number
+    ;; Characters
     char?
     char=?
     char<?
     char>?
     char<=?
     char>=?
+    char-ci=?
+    char-ci<?
+    char-ci>?
+    char-ci<=?
+    char-ci>=?
+    char-alphabetic?
+    char-numeric?
+    char-whitespace?
+    char-upper-case?
+    char-lower-case?
     char->integer
     integer->char
+    char-upcase
+    char-downcase
+    ;; Strings
     string?
+    make-string
+    string
     string-length
     string-ref
+    string-set!
     string=?
+    string-ci=?
     string<?
     string>?
     string<=?
     string>=?
+    string-ci<?
+    string-ci>?
+    string-ci<=?
+    string-ci>=?
     substring
     string-append
     string->list
     list->string
+    string-copy
+    string-fill!
+    ;; Vectors
     vector?
     make-vector
     vector
@@ -103,18 +187,43 @@
     vector-set!
     vector->list
     list->vector
+    vector-fill!
+    ;; Control features
     procedure?
     apply
     map
     for-each
+    force
     call-with-current-continuation
     call/cc
     values
     call-with-values
     dynamic-wind
+    ;; Eval (R5RS §6.5)
+    eval
+    scheme-report-environment
+    null-environment
+    interaction-environment
+    ;; Input and output (R5RS §6.6)
+    call-with-input-file
+    call-with-output-file
+    input-port?
+    output-port?
     current-input-port
     current-output-port
+    with-input-from-file
+    with-output-to-file
+    open-input-file
+    open-output-file
+    close-input-port
+    close-output-port
     read
-    newline
+    read-char
+    peek-char
+    eof-object?
+    char-ready?
     write
-    display))
+    display
+    newline
+    write-char
+    load))

--- a/pkg/values/scheme_writer.go
+++ b/pkg/values/scheme_writer.go
@@ -323,6 +323,16 @@ func (p *SchemeWriter) write(sb *strings.Builder, v Value) {
 		} else {
 			sb.WriteString(val.SchemeString())
 		}
+	case *Symbol:
+		// In display mode, symbols are printed without |…| bar-escaping
+		// (R7RS §6.13.3: display emits the human-readable representation).
+		// write uses the re-readable external representation via SchemeString,
+		// which bars names that cannot be written bare.
+		if p.displayMode {
+			sb.WriteString(val.Key)
+		} else {
+			sb.WriteString(val.SchemeString())
+		}
 	default:
 		// For non-compound types, just use SchemeString
 		if v != nil {

--- a/pkg/values/scheme_writer_test.go
+++ b/pkg/values/scheme_writer_test.go
@@ -208,6 +208,40 @@ func TestDisplayValueToString_List(t *testing.T) {
 	qt.Assert(t, result, qt.Equals, "(hello !)")
 }
 
+// TestSymbolDisplayVsWriteBars pins R7RS §6.13.3: display writes a symbol with no
+// bar-escaping (the human-readable representation), whereas write produces the
+// re-readable external representation, which bars a symbol whose name cannot be
+// written bare. Previously both went through Symbol.SchemeString() and so display
+// incorrectly emitted |a b| for (string->symbol "a b").
+func TestSymbolDisplayVsWriteBars(t *testing.T) {
+	tcs := []struct {
+		name        string
+		sym         values.Value
+		wantDisplay string
+		wantWrite   string
+	}{
+		{"space needs bars", values.NewSymbol("a b"), "a b", "|a b|"},
+		{"empty needs bars", values.NewSymbol(""), "", "||"},
+		{"bare identifier unbarred either way", values.NewSymbol("foo"), "foo", "foo"},
+		{"bar in name escaped only by write", values.NewSymbol("a|b"), "a|b", `|a\|b|`},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			qt.Assert(t, mustRender(t, values.DisplayValueToString, tc.sym), qt.Equals, tc.wantDisplay)
+			qt.Assert(t, mustRender(t, values.WriteValueToString, tc.sym), qt.Equals, tc.wantWrite)
+		})
+	}
+}
+
+// TestSymbolDisplayInList pins that the no-bar display rule applies recursively:
+// a barring symbol nested inside a list is still un-barred under display, barred
+// under write.
+func TestSymbolDisplayInList(t *testing.T) {
+	l := values.List(values.NewSymbol("a b"), values.NewSymbol("c"))
+	qt.Assert(t, mustRender(t, values.DisplayValueToString, l), qt.Equals, "(a b c)")
+	qt.Assert(t, mustRender(t, values.WriteValueToString, l), qt.Equals, "(|a b| c)")
+}
+
 func TestWriteValueToString_NilPair(t *testing.T) {
 	result := mustRender(t, values.WriteValueToString, (*values.Pair)(nil))
 	qt.Assert(t, result, qt.Equals, "#<void>")

--- a/pkg/wile/library_manifests_test.go
+++ b/pkg/wile/library_manifests_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aalpar/wile/pkg/stdlib"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// manifestEngine builds an engine that can import the sealed stdlib libraries
+// (Phase 8 manifest-completeness tests). Mirrors compositionEngine.
+func manifestEngine(t *testing.T) *Engine {
+	t.Helper()
+	eng, err := NewEngine(context.Background(),
+		WithProfile(KitchenSink),
+		WithSourceFS(stdlib.FS),
+		WithLibraryPaths())
+	qt.Assert(t, err, qt.IsNil)
+	return eng
+}
+
+// TestSchemeBaseExportsLetSyntax pins Phase 8 Task 8A (R7RS §4.3.1 / §7.3): both
+// let-syntax and letrec-syntax are part of (scheme base) and MUST be importable by
+// name. Before the fix, (only (scheme base) let-syntax …) failed with
+// "identifier not exported by (scheme base)".
+func TestSchemeBaseExportsLetSyntax(t *testing.T) {
+	testCases := []struct {
+		name    string
+		program string
+		want    string
+	}{
+		{
+			name: "let-syntax importable and usable",
+			program: `(import (only (scheme base) let-syntax))
+                      (let-syntax ((m (syntax-rules () ((_ x) (+ x 1))))) (m 41))`,
+			want: "42",
+		},
+		{
+			name: "letrec-syntax importable and usable",
+			program: `(import (only (scheme base) letrec-syntax))
+                      (letrec-syntax ((m (syntax-rules () ((_ x) (+ x 1))))) (m 41))`,
+			want: "42",
+		},
+		{
+			name: "both importable together",
+			program: `(import (only (scheme base) let-syntax letrec-syntax))
+                      (+ (let-syntax ((a (syntax-rules () ((_) 1)))) (a))
+                         (letrec-syntax ((b (syntax-rules () ((_) 2)))) (b)))`,
+			want: "3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			eng := manifestEngine(t)
+			result, err := eng.EvalMultiple(context.Background(), tc.program)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.want)
+		})
+	}
+}
+
+// TestSchemeR5RSManifestCompleteness pins Phase 8 Task 8D: (scheme r5rs) must export
+// the full set of R5RS-required bindings. Before the fix the manifest omitted the
+// derived syntax (cond/case/let/…), the transcendental math procedures, char
+// predicates, file ops, eval/force, and the R5RS exactness aliases.
+//
+// Each row imports the tested names via (only (scheme r5rs) …). The (only …) modifier
+// validates every requested identifier against r5rs's export manifest at import time —
+// a name not in the manifest raises "identifier not exported by (scheme r5rs)". That is
+// the discriminating step: under KitchenSink the core syntax/primitives are also bound
+// ambiently, so a bare (import (scheme r5rs)) would let unexported names resolve anyway.
+// Using (only …) forces resolution through the manifest, then exercising the binding
+// proves it is both exported and functional.
+func TestSchemeR5RSManifestCompleteness(t *testing.T) {
+	testCases := []struct {
+		name    string
+		program string
+		want    string
+	}{
+		// Derived syntax.
+		{"cond", `(import (only (scheme r5rs) cond else)) (cond (#t 7) (else 0))`, "7"},
+		{"case", `(import (only (scheme r5rs) case else)) (case 2 ((1) 'a) ((2) 'b) (else 'c))`, "b"},
+		{"and", `(import (only (scheme r5rs) and)) (and 1 2 3)`, "3"},
+		{"or", `(import (only (scheme r5rs) or)) (or #f 5)`, "5"},
+		{"let", `(import (only (scheme r5rs) let)) (let ((x 4)) x)`, "4"},
+		{"let-star", `(import (only (scheme r5rs) let*)) (let* ((x 1) (y (+ x 1))) y)`, "2"},
+		{"letrec", `(import (only (scheme r5rs) letrec lambda if)) (letrec ((f (lambda (n) (if (= n 0) 1 (* n (f (- n 1))))))) (f 4))`, "24"},
+		{"named-let", `(import (only (scheme r5rs) let if)) (let loop ((i 0) (s 0)) (if (= i 5) s (loop (+ i 1) (+ s i))))`, "10"},
+		{"do", `(import (only (scheme r5rs) do)) (do ((i 0 (+ i 1)) (s 0 (+ s i))) ((= i 5) s))`, "10"},
+		{"delay-force", `(import (only (scheme r5rs) delay force)) (force (delay (+ 1 2)))`, "3"},
+		{"quasiquote", "(import (only (scheme r5rs) quasiquote unquote)) `(1 ,(+ 1 1) 3)", "(1 2 3)"},
+		{"define-syntax", `(import (only (scheme r5rs) define-syntax syntax-rules)) (define-syntax inc (syntax-rules () ((_ x) (+ x 1)))) (inc 5)`, "6"},
+		{"let-syntax", `(import (only (scheme r5rs) let-syntax syntax-rules)) (let-syntax ((m (syntax-rules () ((_) 9)))) (m))`, "9"},
+		{"letrec-syntax", `(import (only (scheme r5rs) letrec-syntax syntax-rules)) (letrec-syntax ((m (syntax-rules () ((_) 9)))) (m))`, "9"},
+		// Exactness aliases (R5RS spelling).
+		{"exact->inexact", `(import (only (scheme r5rs) exact->inexact)) (exact->inexact 1/2)`, "0.5"},
+		{"inexact->exact", `(import (only (scheme r5rs) inexact->exact)) (inexact->exact 0.5)`, "1/2"},
+		// Transcendental math.
+		{"sqrt", `(import (only (scheme r5rs) sqrt)) (sqrt 16)`, "4"},
+		{"exp-log", `(import (only (scheme r5rs) exp log round)) (round (log (exp 1)))`, "1.0"},
+		{"atan", `(import (only (scheme r5rs) atan)) (atan 0)`, "0.0"},
+		// Char predicates / case.
+		{"char-upcase", `(import (only (scheme r5rs) char-upcase)) (char-upcase #\a)`, "#\\A"},
+		{"char-alphabetic?", `(import (only (scheme r5rs) char-alphabetic?)) (char-alphabetic? #\z)`, "#t"},
+		{"char-ci=?", `(import (only (scheme r5rs) char-ci=?)) (char-ci=? #\A #\a)`, "#t"},
+		// Strings.
+		{"make-string", `(import (only (scheme r5rs) make-string)) (make-string 3 #\x)`, `"xxx"`},
+		{"string-ci=?", `(import (only (scheme r5rs) string-ci=?)) (string-ci=? "ABC" "abc")`, "#t"},
+		{"string-copy", `(import (only (scheme r5rs) string-copy)) (string-copy "hello")`, `"hello"`},
+		{"string-set!", `(import (only (scheme r5rs) string-set! make-string string-ref)) (let ((s (make-string 2 #\a))) (string-set! s 0 #\z) (string-ref s 0))`, "#\\z"},
+		// Mutation.
+		{"set-car!", `(import (only (scheme r5rs) set-car! list car)) (let ((p (list 1 2))) (set-car! p 9) (car p))`, "9"},
+		{"vector-fill!", `(import (only (scheme r5rs) vector-fill! make-vector vector-ref)) (let ((v (make-vector 3 0))) (vector-fill! v 7) (vector-ref v 1))`, "7"},
+		// eval / environments.
+		{"eval", `(import (only (scheme r5rs) eval scheme-report-environment)) (eval '(+ 2 3) (scheme-report-environment 5))`, "5"},
+		{"interaction-environment", `(import (only (scheme r5rs) eval interaction-environment)) (eval '(* 3 4) (interaction-environment))`, "12"},
+		{"null-environment", `(import (only (scheme r5rs) null-environment)) (procedure? null-environment)`, "#t"},
+		// Ports / input. The string-port constructor (open-input-string) is an
+		// R7RS-only helper, so we pull it from (scheme base); the binding under test
+		// (input-port? / read-char / eof-object?) is the R5RS name resolved through
+		// (only (scheme r5rs) …) — exercised against a base-provided string port.
+		{"input-port?", `(import (only (scheme r5rs) input-port? current-input-port)) (input-port? (current-input-port))`, "#t"},
+		{"read-char-from-string", `(import (only (scheme r5rs) read-char) (only (scheme base) open-input-string)) (read-char (open-input-string "Q"))`, "#\\Q"},
+		{"eof-object?", `(import (only (scheme r5rs) eof-object? read-char) (only (scheme base) open-input-string)) (eof-object? (read-char (open-input-string "")))`, "#t"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			eng := manifestEngine(t)
+			result, err := eng.EvalMultiple(context.Background(), tc.program)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.want)
+		})
+	}
+}
+
+// TestSchemeR5RSBareImportNoConflict pins that (scheme r5rs)'s expanded import list
+// (base + inexact + complex + char + cxr + read + write + lazy + eval + repl + load +
+// file) carries no cross-library import conflict — a bare (import (scheme r5rs)) must
+// load and a re-exported name must resolve. Guards against the strict R7RS §5.6
+// conflict check (PR #793) firing on a diamond among r5rs's own imports.
+func TestSchemeR5RSBareImportNoConflict(t *testing.T) {
+	c := qt.New(t)
+	eng := manifestEngine(t)
+	result, err := eng.EvalMultiple(context.Background(),
+		`(import (scheme r5rs)) (exact->inexact (sqrt 4))`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "2.0")
+}

--- a/pkg/wile/options.go
+++ b/pkg/wile/options.go
@@ -267,16 +267,17 @@ func WithInlineThreshold(n int) EngineOption {
 //
 // Without this option, (import ...) raises a configuration error.
 //
-// Paths are searched in order: user-supplied paths first, then the defaults
-// ("." and "./pkg/stdlib/lib"). An empty call WithLibraryPaths() enables library support
-// with defaults only.
+// Paths are searched in order: user-supplied paths first, then the default
+// ("."). The embedded standard library is served by the FileResolver chain
+// (e.g. WithSourceFS(stdlib.FS)), not a search path. An empty call
+// WithLibraryPaths() enables library support with the default only.
 //
 // Example:
 //
 //	eng, err := wile.NewEngine(ctx,
 //	    wile.WithLibraryPaths("/app/libs", "./vendor"),
 //	)
-//	// search order: /app/libs, ./vendor, ., ./pkg/stdlib/lib
+//	// search order: /app/libs, ./vendor, .
 func WithLibraryPaths(paths ...string) EngineOption {
 	return func(cfg *engineConfig) {
 		cfg.libraryEnabled = true


### PR DESCRIPTION
Libraries-review Phase 8 (SPEC/manifest/convention), autonomous subset. **Deferred** 8C (`real?` of complex-with-inexact-zero-imag flips `#t`→`#f` — a predicate-result change for you to confirm) and 8E (`current-second` TAI — user decision).

| Task | Fix |
|---|---|
| **8A** | `scheme/base.sld` exports `let-syntax` + `letrec-syntax` (P7). |
| **8B** | `display` no longer bar-escapes symbols (R7RS §6.13.3) — new `*Symbol` case in `values/scheme_writer.go` gates `|…|` on write-mode. `(display (string->symbol "a b"))`→`a b`; `(write …)`→`|a b|`. |
| **8D** | `scheme/r5rs.sld` completed (+83 exports, +12 imports; in-library `exact->inexact`/`inexact->exact` aliases). Every R5RS-required binding verified to resolve in Wile (none missing). |
| **8F** | dropped dev-only `./pkg/stdlib/lib` from `DefaultLibraryPaths`; updated `library_test.go` assertion + a stale `WithLibraryPaths` doc. |
| **8G(i)** | `import_set_datum.go` `composePhaseShift` guards int8 overflow at the for-meta/for-syntax/for-template composition. |
| **8G(ii)** | `compile_cond_expand.go` enforces `else` as the last clause: `(cond-expand (else 1) (r7rs 2))` → clean compile error. |

Tests: `library_manifests_test.go` + `compile_cond_expand_test.go` + `import_set_datum_test.go` + `scheme_writer_test.go`. Full `go test ./...` + integration (fresh dist) + `make lint` green. Added `TestSchemeR5RSBareImportNoConflict` to guard the §5.6 conflict check (PR #793) doesn't fire on r5rs's import diamond.

Note: 8F touches `library_registry.go` and 8G(i) touches `import_set_datum.go` — both also touched by Phase 1 (#794, mutex + traversal guard) in disjoint regions; expect a trivial merge alignment if both land.

🤖 Implemented via worktree-isolated agent; integrated + re-verified (dist rebuild for integration).