### PR TITLE
fix(compilation): rename-of-non-exported errors; validate exports at definition time; implement include-ci (Phase 5)

### DIFF
--- a/pkg/machine/compilation/compile_library_forms.go
+++ b/pkg/machine/compilation/compile_library_forms.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/aalpar/wile/pkg/machine"
 
@@ -113,6 +115,17 @@ func (p *CompileTimeContinuation) CompileDefineLibrary(ctctx CompileTimeCallCont
 	})
 	if err != nil {
 		return p.wrapCompilationError(werr.WrapForeignErrorf(err, "define-library: error processing declarations"))
+	}
+
+	// R7RS §5.6: every exported identifier must be defined or imported by the library.
+	// Declarations have all been processed (begin/include predeclare their defines into
+	// libEnv, imports install their bindings there), so every export's internal name must
+	// now resolve. Validate eagerly here — collecting ALL gaps — rather than deferring to
+	// the per-name copy at each import site, which both misses unreferenced bad exports
+	// (under (only ...)) and reports only the first gap.
+	err = validateLibraryExports(lib)
+	if err != nil {
+		return p.wrapCompilationError(err)
 	}
 
 	// Peephole optimization on the library template.
@@ -261,6 +274,36 @@ func parseExportSpec(lib *CompiledLibrary, spec syntax.SyntaxValue) error {
 	default:
 		return wrapSourcedError(spec.SourceContext(), werr.WrapForeignErrorf(werr.ErrInvalidSyntax, "export: expected symbol or rename form"))
 	}
+}
+
+// validateLibraryExports verifies that every export's internal name resolves to a
+// binding in the library's environment (R7RS §5.6). It collects ALL unresolved names
+// and reports them once, sorted for a deterministic message, naming the library. This
+// runs at library finalization — after all begin/include/import declarations have
+// installed their bindings — so an export of a name the library never defines or imports
+// fails eagerly here rather than lazily (and partially) at a downstream import site.
+func validateLibraryExports(lib *CompiledLibrary) error {
+	var missing []string
+	for externalName, internalName := range lib.Exports {
+		_, _, found := findLibraryBinding(lib, internalName)
+		if found {
+			continue
+		}
+		// Report the external name (what the user wrote in the export list); include the
+		// internal name when a rename made them differ, so the gap is unambiguous.
+		if internalName == externalName {
+			missing = append(missing, externalName)
+		} else {
+			missing = append(missing, externalName+" (rename of "+internalName+")")
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	return werr.WrapForeignErrorf(werr.ErrUnexportedIdentifier,
+		"define-library: %s exports undefined identifier(s): %s",
+		lib.Name.SchemeString(), strings.Join(missing, ", "))
 }
 
 // CompileExport handles top-level (export <export-spec> ...).

--- a/pkg/machine/compilation/compile_time_continuation_include.go
+++ b/pkg/machine/compilation/compile_time_continuation_include.go
@@ -39,10 +39,12 @@ func (p *CompileTimeContinuation) CompileInclude(ctctx CompileTimeCallContext, e
 
 // compileIncludeImpl is the shared implementation for include and include-ci.
 // It uses letrec* semantics so that forward references work within included files.
+// When foldCase is true (include-ci), the included file is read with R7RS §2.1
+// case folding enabled, as if it began with #!fold-case.
 //
 // R7RS §5.3.2: Internal definitions use letrec* semantics where all defined
 // variables are in scope at the start of the body.
-func (p *CompileTimeContinuation) compileIncludeImpl(ctctx CompileTimeCallContext, expr syntax.SyntaxValue, _ bool) error {
+func (p *CompileTimeContinuation) compileIncludeImpl(ctctx CompileTimeCallContext, expr syntax.SyntaxValue, foldCase bool) error {
 	rest, ok := expr.(*syntax.SyntaxPair)
 	if !ok {
 		return werr.WrapForeignErrorf(werr.ErrNotAPair, "include: expected a list of filenames, got %T", expr)
@@ -75,6 +77,9 @@ func (p *CompileTimeContinuation) compileIncludeImpl(ctctx CompileTimeCallContex
 			// Create parser for the file
 			reader := bufio.NewReader(file)
 			fileParser := parser.NewParserWithFile(p.env, true, reader, filePath)
+			// include-ci reads the file case-insensitively (R7RS §2.1 fold-case),
+			// folding identifiers to lowercase as they are read.
+			fileParser.SetFoldCase(foldCase)
 
 			// Read all forms from the file first, then process them with letrec* semantics
 			var forms []syntax.SyntaxValue
@@ -177,8 +182,9 @@ func (p *CompileTimeContinuation) predeclareDefineBinding(v syntax.SyntaxValue) 
 	predeclareBinding(p.env, name, nameSym.Scopes(), nameSym.SourceContext())
 }
 
-// CompileIncludeCi compiles an include-ci expression.
-func (p *CompileTimeContinuation) CompileIncludeCi(_ CompileTimeCallContext, _ syntax.SyntaxValue) error {
-	return werr.WrapForeignErrorf(werr.ErrInvalidSyntax,
-		"include-ci: case-insensitive includes not yet supported")
+// CompileIncludeCi compiles an include-ci expression (R7RS §4.1.7 / §5.6).
+// It is identical to include except that each included file is read with case
+// folding enabled, as if the file began with a #!fold-case directive.
+func (p *CompileTimeContinuation) CompileIncludeCi(ctctx CompileTimeCallContext, expr syntax.SyntaxValue) error {
+	return p.compileIncludeImpl(ctctx, expr, true)
 }

--- a/pkg/machine/compilation/coverage_improvement_test.go
+++ b/pkg/machine/compilation/coverage_improvement_test.go
@@ -387,7 +387,10 @@ func TestCompileInclude_LibraryRegistryPaths(t *testing.T) {
 	qt.Assert(t, cont, qt.IsNotNil)
 }
 
-// TestCompileIncludeCi tests that include-ci returns an unsupported error.
+// TestCompileIncludeCi tests that include-ci is wired to the include splice path
+// (it resolves the named file rather than rejecting the form outright). With no
+// file resolver configured for a missing file, it fails at file resolution — the
+// same path as include — not with a "not yet supported" stub error.
 func TestCompileIncludeCi(t *testing.T) {
 	env := newNamespace(environment.NewNamespace().Runtime())
 	err := RegisterSyntaxCompilers(env)
@@ -400,8 +403,10 @@ func TestCompileIncludeCi(t *testing.T) {
 
 	_, err = newTopLevelThunk(schemeutil.DatumToSyntaxValue(context.Background(), sctx, prog), env)
 	qt.Assert(t, err, qt.IsNotNil)
-	qt.Assert(t, err.Error(), qt.Contains, "include-ci")
-	qt.Assert(t, err.Error(), qt.Contains, "not yet supported")
+	// include-ci now behaves like include: it tries to open the file and fails with a
+	// resolution error, not the old "not yet supported" stub.
+	qt.Assert(t, err.Error(), qt.Contains, "include")
+	qt.Assert(t, err.Error(), qt.Not(qt.Contains), "not yet supported")
 }
 
 // TestParseFeatureRequirementList tests parsing lists of feature requirements

--- a/pkg/machine/compilation/include_ci_test.go
+++ b/pkg/machine/compilation/include_ci_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compilation_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/pkg/registry/testhelpers"
+	"github.com/aalpar/wile/pkg/values"
+	"github.com/aalpar/wile/pkg/values/valuestest"
+)
+
+// TestIncludeCi pins R7RS §4.1.7 / §5.6 Task 5E: include-ci splices the referenced
+// file with case folding enabled, so identifiers in the included file are read
+// case-insensitively (folded to lowercase). The includer (parsed normally) can then
+// reference a folded identifier in lowercase even though the file wrote it uppercase.
+func TestIncludeCi(t *testing.T) {
+	tcs := []struct {
+		name     string
+		fs       fstest.MapFS
+		code     string
+		expected values.Value
+	}{
+		{
+			// Top-level include-ci: file defines FOO; includer references foo.
+			name: "top-level include-ci folds identifiers",
+			fs: fstest.MapFS{
+				"ci/defs.scm": &fstest.MapFile{
+					Data: []byte(`(define FOO 42)
+(define (Square X) (* X X))`),
+				},
+			},
+			code:     `(import (scheme base)) (include-ci "ci/defs.scm") (+ foo (square 5))`,
+			expected: values.NewInteger(67),
+		},
+		{
+			// Library-level include-ci: the library body includes a case-folded file and
+			// exports the (lowercased) name it defines.
+			name: "library include-ci folds and exports",
+			fs: fstest.MapFS{
+				"ci/lib-defs.scm": &fstest.MapFile{
+					Data: []byte(`(define ANSWER 42)`),
+				},
+				"test/ci-lib.sld": &fstest.MapFile{
+					Data: []byte(`(define-library (test ci-lib)
+  (export answer)
+  (import (scheme base))
+  (include-ci "ci/lib-defs.scm"))`),
+				},
+			},
+			code:     `(import (test ci-lib)) answer`,
+			expected: values.NewInteger(42),
+		},
+		{
+			// Regression guard: plain include must NOT fold — uppercase stays uppercase.
+			// Including a file that defines BAR and referencing BAR (same case) works;
+			// this confirms include-ci's folding is the only difference from include.
+			name: "plain include preserves case",
+			fs: fstest.MapFS{
+				"ci/case.scm": &fstest.MapFile{
+					Data: []byte(`(define BAR 9)`),
+				},
+			},
+			code:     `(import (scheme base)) (include "ci/case.scm") BAR`,
+			expected: values.NewInteger(9),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testhelpers.SetupEngineTest(t, tc.fs)
+			result := testhelpers.EvalSchemeInEnv(t, env, tc.code)
+			qt.Assert(t, result, valuestest.SchemeEquals, tc.expected)
+		})
+	}
+}

--- a/pkg/machine/compilation/library_bindings.go
+++ b/pkg/machine/compilation/library_bindings.go
@@ -230,6 +230,17 @@ func (p *importModifier) apply(result map[string]string, lib *CompiledLibrary) (
 		}
 		return result, nil
 	case importModRename:
+		// Validate that every rename SOURCE name is in the current name set, mirroring
+		// the only/except checks. R7RS §5.6: rename maps an exported (post-prior-modifier)
+		// identifier to a new name; a source name that is absent denotes nothing, so
+		// silently no-op'ing it would mask a user error. Reject instead.
+		for oldName := range p.renames {
+			_, ok := result[oldName]
+			if !ok {
+				return nil, werr.WrapForeignErrorf(werr.ErrUnexportedIdentifier,
+					"applyToExports: rename source %q not exported by %s", oldName, lib.Name.SchemeString())
+			}
+		}
 		renamed := make(map[string]string)
 		for localName, externalName := range result {
 			newName, ok := p.renames[localName]

--- a/pkg/machine/compilation/library_export_validation_test.go
+++ b/pkg/machine/compilation/library_export_validation_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compilation_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/pkg/registry/testhelpers"
+	"github.com/aalpar/wile/pkg/werr"
+)
+
+// TestLibraryExportValidation pins R7RS §5.6 Task 5D: a (define-library ...) that
+// exports a name it never defines or imports must error at definition time (when
+// the library is loaded/compiled), with the diagnostic naming the missing identifier
+// and the library — NOT lazily at the per-name import site.
+func TestLibraryExportValidation(t *testing.T) {
+	tcs := []struct {
+		name        string
+		fs          fstest.MapFS
+		code        string
+		wantErr     bool
+		mustContain []string // substrings the error message must include (when wantErr)
+	}{
+		{
+			// Exports both a defined name and an undefined one. The library must
+			// fail to load, naming the missing name (not the defined one), even
+			// though the import only references the defined name.
+			name: "export-of-undefined-name-errors-eagerly",
+			fs: fstest.MapFS{
+				"test/bad-export.sld": &fstest.MapFile{
+					Data: []byte(`(define-library (test bad-export)
+  (export defined-name undefined-name)
+  (import (scheme base))
+  (begin (define defined-name 1)))`),
+				},
+			},
+			code:        `(import (only (test bad-export) defined-name)) defined-name`,
+			wantErr:     true,
+			mustContain: []string{"undefined-name", "(test bad-export)"},
+		},
+		{
+			// Two undefined exports: the error collects ALL missing names in one report.
+			name: "export-collects-all-missing-names",
+			fs: fstest.MapFS{
+				"test/multi-missing.sld": &fstest.MapFile{
+					Data: []byte(`(define-library (test multi-missing)
+  (export ok-one missing-a missing-b)
+  (import (scheme base))
+  (begin (define ok-one 1)))`),
+				},
+			},
+			code:        `(import (test multi-missing))`,
+			wantErr:     true,
+			mustContain: []string{"missing-a", "missing-b"},
+		},
+		{
+			// An export that names an IMPORTED binding (not locally defined) is valid:
+			// car is imported from (scheme base).
+			name: "export-of-imported-name-is-valid",
+			fs: fstest.MapFS{
+				"test/reexport.sld": &fstest.MapFile{
+					Data: []byte(`(define-library (test reexport)
+  (export my-car)
+  (import (scheme base))
+  (export (rename car my-car)))`),
+				},
+			},
+			code:    `(import (test reexport)) (my-car '(7 8 9))`,
+			wantErr: false,
+		},
+		{
+			// Sanity: a fully-defined export list loads and works.
+			name: "all-exports-defined-is-valid",
+			fs: fstest.MapFS{
+				"test/good.sld": &fstest.MapFile{
+					Data: []byte(`(define-library (test good)
+  (export a b)
+  (import (scheme base))
+  (begin (define a 1) (define b 2)))`),
+				},
+			},
+			code:    `(import (test good)) (+ a b)`,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testhelpers.SetupEngineTest(t, tc.fs)
+			_, err := testhelpers.EvalSchemeInEnvMayFail(t, env, tc.code)
+			if !tc.wantErr {
+				qt.Assert(t, err, qt.IsNil)
+				return
+			}
+			qt.Assert(t, err, qt.IsNotNil)
+			// The export gap must surface as ErrUnexportedIdentifier (the name is
+			// declared exported but resolves to no binding) or ErrNoSuchBinding.
+			isExportErr := errors.Is(err, werr.ErrUnexportedIdentifier) || errors.Is(err, werr.ErrNoSuchBinding)
+			qt.Assert(t, isExportErr, qt.IsTrue,
+				qt.Commentf("want ErrUnexportedIdentifier/ErrNoSuchBinding, got %v", err))
+			for _, sub := range tc.mustContain {
+				qt.Assert(t, strings.Contains(err.Error(), sub), qt.IsTrue,
+					qt.Commentf("error %q must contain %q", err.Error(), sub))
+			}
+		})
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -93,6 +93,15 @@ func (p *Parser) SetMaxDepth(n int) {
 	p.maxDepth = n
 }
 
+// SetFoldCase enables or disables R7RS §2.1 fold-case mode at construction time,
+// before any forms are read. This is the programmatic equivalent of a leading
+// #!fold-case directive; it lets a caller (e.g. include-ci) read an entire file
+// case-insensitively without the file itself carrying the directive. An in-file
+// #!fold-case / #!no-fold-case directive still toggles the mode mid-stream.
+func (p *Parser) SetFoldCase(on bool) {
+	p.foldCase = on
+}
+
 func (p *Parser) curr() tokenizer.Token {
 	return p.cur
 }

--- a/pkg/wile/engine_import_composition_test.go
+++ b/pkg/wile/engine_import_composition_test.go
@@ -200,3 +200,45 @@ func TestImportConflictDetection(t *testing.T) {
 		})
 	}
 }
+
+// TestImportRenameOfNonExported pins R7RS §5.6 Task 5C: a rename whose SOURCE name
+// is not exported by the library must error, mirroring the only/except validation,
+// rather than silently no-op the rename. A valid rename of an exported name still
+// works (the new name binds; the old name is no longer available).
+func TestImportRenameOfNonExported(t *testing.T) {
+	testCases := []struct {
+		name    string
+		program string
+		want    string
+		wantErr bool
+	}{
+		{
+			// (rename LIB (nonexistent foo)): source name absent from exports ⇒ error.
+			name:    "rename-of-non-exported-errors",
+			program: `(import (rename (scheme base) (nonexistent foo)))`,
+			wantErr: true,
+		},
+		{
+			// (rename LIB (car kar)): car is exported, kar binds, car shadowed-out.
+			name:    "valid-rename-binds-new-name",
+			program: `(import (rename (scheme base) (car kar))) (kar '(1 2 3))`,
+			want:    "1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx := context.Background()
+			eng := compositionEngine(t)
+			result, err := eng.EvalMultiple(ctx, tc.program)
+			if tc.wantErr {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(errors.Is(err, werr.ErrUnexportedIdentifier), qt.IsTrue)
+				return
+			}
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
Libraries-review Phase 5 (import/export §5.6 enforcement), tasks 5C/5D/5E. 5A/5B already in master. **Deferred** 5F (`(library X)` cond-expand importability — explicit user-decision gate).

| Task | Fix |
|---|---|
| **5C** | `rename` of a non-exported identifier now errors (was a silent no-op). In the `importModRename` branch of `(*importModifier).apply` (`library_bindings.go`), validate every rename SOURCE name is in the current name set → `werr.ErrUnexportedIdentifier`. `(import (rename (scheme base) (nonexistent foo)))` errors; valid renames unchanged. (Worked against the current `[]importModifier` representation — the plan's `p.Renames` was stale.) |
| **5D** | `export` of an undefined/unimported identifier now errors at `define-library` DEFINITION time, not lazily at import. New `validateLibraryExports` in `compile_library_forms.go` (called in `CompileDefineLibrary` after declarations) resolves every export via `findLibraryBinding`, collects ALL missing names, errors once with the full list. |
| **5E** | `include-ci` implemented (was a stub raising `ErrInvalidSyntax`). New `(*Parser).SetFoldCase` in `pkg/parser/parser.go` routes through the existing `#!fold-case` path; `CompileIncludeCi` delegates to the include splice with fold-case on. Works top-level + library-level. |

Tests: `engine_import_composition_test.go` (5C), `library_export_validation_test.go` (5D), `include_ci_test.go` (5E); stale stub-message test updated. Full `go test ./...` + integration (fresh dist) + `make lint` green. Verified the eager export-validation is not over-strict (the whole `pkg/wile` real-stdlib suite passes; a macro-exporting library still loads).

Note: touches `library_bindings.go` (also touched by Phase 1's 5B already-in-master — builds on it cleanly).

🤖 Implemented via worktree-isolated agent; integrated + re-verified.