### PR TITLE
chore: bump workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: go.sum
 
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           # Pinned to v2.11.x — v2.12.1 introduced regressions in
           # //nolint:gocritic suppression handling and ruleguard
@@ -54,7 +54,7 @@ jobs:
       # the step is skipped entirely on PR runs (where no CSVs exist).
       - name: Upload benchmark results
         if: always() && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: benchmark-results-${{ github.sha }}
           path: examples/benchmarks/canonical-results-*.csv
@@ -67,9 +67,9 @@ jobs:
   race:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
           cache-dependency-path: go.sum


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating the Node 20 runtime and currently forces our Node 20 actions onto Node 24, emitting a deprecation warning on every CI run. This bumps each action to a major version that natively targets Node 24.

## Changes

- \`actions/checkout\` v4 → v5
- \`actions/setup-go\` v5 → v6
- \`actions/upload-artifact\` v4 → v5
- \`golangci/golangci-lint-action\` v7 → **v9**

**Why v9 for golangci-lint-action:** v8 still runs on Node 20; only v9.0.0 moved the action runtime to node24. v9 retains golangci-lint v2.x support, so the deliberate \`version: v2.11.1\` binary pin (guarding against the v2.12.1 ruleguard/gocritic regressions) is untouched — the action's Node runtime is independent of the linter binary version it installs.

Covers both \`ci.yml\` and \`release.yml\`.

## Test Plan

- [x] YAML parses
- [ ] CI green on this PR (the only real validation for action-version bumps — they can't be exercised locally), including the golangci-lint gate still enforcing v2.11.1