### PR TITLE
fix(hygiene): bind let-syntax keywords on accumulated scopes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,26 +64,45 @@ Items that block production embedded use or prevent silent state corruption.
 
 ### Ambiguous binding references resolve silently instead of erroring (2026-07-18)
 
-- [ ] **`bestOf` picks arbitrarily on a scope-set weight tie** [Medium, S]: when two candidate
-  bindings have **incomparable, equal-cardinality** scope sets that are both subsets of the
-  reference's scope set, Flatt/Racket raise an *ambiguous binding* error. Wile raises nothing:
-  `pkg/environment/best_of.go:60-68` keeps the **first** candidate on a tie, so the reference
-  resolves silently innermost-first. The macro-introduced-top-level-binder rename pass
-  documented the same arbitrariness independently — ties "resolve arbitrarily to the first
-  collected". That pass was **deleted** in `a60e32e1` once scope-keyed globals made it
-  redundant, so read it at `git show a60e32e1^:pkg/machine/compilation/toplevel_binder_hygiene.go`
-  (lines 249-254). Its deletion does not close this item: `bestOf` is untouched and still
-  first-wins on a tie.
+- [x] **Scope-set weight tie fixed at the cause, not by erroring** [Medium, S, Done 2026-07-21,
+  approach 1a per `plans/2026-07-20-scope-keyed-tier1-remediation.md` Item 1]: the filed fix
+  (raise on every `bestOf` tie) was **rejected** — it regresses ordinary R7RS nested `let-syntax`
+  keyword shadowing, which currently *is* an incomparable equal-cardinality tie:
+  `(let-syntax ((m …outer…)) (let-syntax ((m …inner…)) (m)))` weighs both binders 1 under a
+  weight-2 reference, and keep-first (innermost) is the correct INNER result. Two corrections to
+  the original entry that follows: the fix does **not** belong in `bestOf` (it takes two ints and
+  cannot see scope sets; the local reducer compares across frames while the global one is
+  per-frame first-wins — one edit site, two semantics), and "error on a tie" conflates shadowing
+  with ambiguity.
 
-  **The fix belongs in `bestOf`, not at a call site.** The gap is uniform across local and
-  global resolution; fixing one path alone would make it stricter than the other and create a
-  new inconsistency. Landing it in `bestOf` covers both at once.
+  **1a — fix the cause.** `expander_let_syntax.go` bound each `let-syntax`/`letrec-syntax`
+  keyword on the bare singleton `[]*syntax.Scope{letScope}`, discarding the keyword's accumulated
+  enclosing scopes. It now binds on `slices.Clone(keywordSym.Scopes())` + `letScope` at all three
+  coupled sites (letrec pre-register, compile-loop create, and the re-resolve that must use the
+  identical set or `MaybeCreateLocalBinding` keys a second slot). A nested binder is then a strict
+  scope-set superset of its enclosing binder and wins by maximality (a perfect match), so the tie
+  never forms. Top-level binders are unchanged (empty `Scopes()` ⇒ the set is still `{letScope}`).
 
-  Deliberately scoped **out** of two plans that each touch adjacent code, so it does not get
-  bundled and lost: `plans/2026-07-18-scope-keyed-global-bindings-design.md` (Part III) and
-  `plans/2026-07-18-load-order-independent-binding-resolution-design.md` (Fork C — same
-  conclusion, reached independently). Both are prerequisites in practice, since scope-keyed
-  globals make equal-cardinality ties reachable at top level for the first time.
+  **Census confirms completeness** (throwaway `WILE_TIE_CENSUS` probe on the tie branch, since
+  reverted): before 1a the nested case produced a `weight=1 target=2` tie; after 1a it is gone.
+  Across `r7rs-tests.scm`, `macros-test.scm`, and the ER-macro corpus there are **zero `weight>0`
+  ties** — no genuine ambiguity. Every residual tie is `weight=0` (the empty set; two
+  `{}`-bindings of a name = benign shadowing resolved by frame order). So there is nothing to
+  error on, and 1b (a real `ErrAmbiguousBinding` on a same-frame incomparable tie) stays deferred
+  as the fallback if such a tie is ever constructed (none has been). Guard: nested + triple-nested
+  cases in `TestScopeResolution_LetSyntaxShadowing`.
+
+  **Residual, filed separately:** `resolveNodeByScopes` (`frame_reclaim_build.go`) hand-rolls the
+  same argmax over a Go *map*, so its tie is non-deterministic rather than first-wins. Unreachable
+  in the corpus (no `weight>0` tie feeds it), but it is the one site where a tie would resolve
+  non-deterministically; a determinism follow-up, not gated on this item.
+
+  *Original framing (2026-07-18), retained for provenance:* the macro-introduced-top-level-binder
+  rename pass documented the same arbitrariness independently — ties "resolve arbitrarily to the
+  first collected" — at `git show a60e32e1^:pkg/machine/compilation/toplevel_binder_hygiene.go`
+  (lines 249-254). Scoped out of `plans/2026-07-18-scope-keyed-global-bindings-design.md`
+  (Part III) and `…-load-order-independent-binding-resolution-design.md` (Fork C) so it would not
+  be bundled and lost.
 
 ### Name-keyed identity survives in consumers of scope-keyed bindings (2026-07-19)
 

--- a/pkg/machine/compilation/expander_let_syntax.go
+++ b/pkg/machine/compilation/expander_let_syntax.go
@@ -23,6 +23,8 @@ package compilation
 // Extracted from expander_time_continuation.go.
 
 import (
+	"slices"
+
 	"github.com/aalpar/wile/pkg/environment"
 	"github.com/aalpar/wile/pkg/syntax"
 	"github.com/aalpar/wile/pkg/values"
@@ -133,8 +135,14 @@ func (p *ExpanderTimeContinuation) expandLetSyntaxImpl(sym *syntax.SyntaxSymbol,
 				return nil, wrapSourcedError(bindingStx.SourceContext(), werr.WrapForeignErrorf(werr.ErrNotASymbol, "%s: keyword must be a symbol", formName))
 			}
 			keyword := keywordSym.Unwrap().(*values.Symbol)
-			// Create binding with letScope so free identifier resolution works
-			_, _ = childExpandEnv.MaybeCreateLocalBinding(keyword, environment.BindingTypeSyntax, []*syntax.Scope{letScope}, keywordSym.SourceContext())
+			// Bind on the keyword's accumulated scope set plus letScope, not the
+			// bare singleton. A nested same-named binder then carries a strict
+			// superset of its enclosing binder's scopes and wins resolution by
+			// maximality, instead of tying it on cardinality and falling back to
+			// collection order. Clone first: Scopes() hands back the symbol's live
+			// backing slice, so appending into it would corrupt its hygiene state.
+			keywordScopes := append(slices.Clone(keywordSym.Scopes()), letScope)
+			_, _ = childExpandEnv.MaybeCreateLocalBinding(keyword, environment.BindingTypeSyntax, keywordScopes, keywordSym.SourceContext())
 
 			cdr := current.SyntaxCdr()
 			nextPair, ok := cdr.(*syntax.SyntaxPair)
@@ -177,9 +185,10 @@ func (p *ExpanderTimeContinuation) expandLetSyntaxImpl(sym *syntax.SyntaxSymbol,
 		// itself. That region is expressed two ways at once, and both are needed:
 		// the keywords are pre-registered in childExpandEnv above, so compile the
 		// spec against that frame rather than the outer one, and the spec carries
-		// letScope, so a template identifier naming a sibling is a superset of the
-		// binder keyed on that scope. Compiling against p.env with an unscoped spec
-		// left free-identifier resolution unable to see the very bindings the
+		// letScope, which the sibling binder also carries atop the keyword's
+		// accumulated scopes, so a sibling reference is a superset of that binder
+		// and resolves to it. Compiling against p.env with an unscoped spec left
+		// free-identifier resolution unable to see the very bindings the
 		// pre-registration existed to expose.
 		//
 		// let-syntax keeps the outer environment and the unscoped spec: its
@@ -196,13 +205,18 @@ func (p *ExpanderTimeContinuation) expandLetSyntaxImpl(sym *syntax.SyntaxSymbol,
 			return nil, wrapSourcedError(transformerExpr.SourceContext(), werr.WrapForeignErrorf(err, "%s: could not compile transformer for %s", formName, keyword.Key))
 		}
 
-		// Store in child expand environment with letScope for free identifier resolution
-		localIndex, created := childExpandEnv.MaybeCreateLocalBinding(keyword, environment.BindingTypeSyntax, []*syntax.Scope{letScope}, keywordSym.SourceContext())
+		// Store on the keyword's accumulated scope set plus letScope (see the
+		// pre-registration above for why the bare singleton is wrong). The
+		// pre-register and this re-resolve must use the identical set, or
+		// MaybeCreateLocalBinding keys a second slot and the transformer lands in
+		// the wrong binding.
+		keywordScopes := append(slices.Clone(keywordSym.Scopes()), letScope)
+		localIndex, created := childExpandEnv.MaybeCreateLocalBinding(keyword, environment.BindingTypeSyntax, keywordScopes, keywordSym.SourceContext())
 		if !created {
-			// letrec-syntax pre-registered this keyword above, under letScope.
-			// Re-resolve under the same set, not nil: nil is MATCH ANY, which takes
-			// the first live slot of the name rather than the one just addressed.
-			localIndex = childExpandEnv.GetLocalIndex(keyword, []*syntax.Scope{letScope})
+			// letrec-syntax pre-registered this keyword above, under the same set.
+			// Re-resolve under that set, not nil: nil is MATCH ANY, which takes the
+			// first live slot of the name rather than the one just addressed.
+			localIndex = childExpandEnv.GetLocalIndex(keyword, keywordScopes)
 		}
 		if localIndex == nil {
 			return nil, wrapSourcedError(keywordSym.SourceContext(), werr.WrapForeignErrorf(

--- a/pkg/machine/scope_resolution_test.go
+++ b/pkg/machine/scope_resolution_test.go
@@ -554,6 +554,27 @@ func TestScopeResolution_LetSyntaxShadowing(t *testing.T) {
 			         (my-val))`,
 			want: values.NewInteger(42),
 		},
+		{
+			// Nested let-syntax rebinding the same keyword: the inner binder wins
+			// in its body. Both binders are visible to the reference, and the
+			// inner binder's scope set is a strict superset of the outer's, so it
+			// resolves by maximality (see expander_let_syntax.go — keywords bind on
+			// the accumulated scope set, not a bare singleton). This is the case
+			// where the two binders would otherwise tie on scope-set cardinality.
+			name: "nested let-syntax resolves innermost keyword",
+			code: `(let-syntax ((m (syntax-rules () ((m) 10))))
+			         (let-syntax ((m (syntax-rules () ((m) 20))))
+			           (m)))`,
+			want: values.NewInteger(20),
+		},
+		{
+			name: "triple-nested let-syntax resolves innermost keyword",
+			code: `(let-syntax ((m (syntax-rules () ((m) 1))))
+			         (let-syntax ((m (syntax-rules () ((m) 2))))
+			           (let-syntax ((m (syntax-rules () ((m) 3))))
+			             (m))))`,
+			want: values.NewInteger(3),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
## What

`let-syntax`/`letrec-syntax` bound each keyword on the bare singleton `[]*syntax.Scope{letScope}`, discarding the keyword's accumulated enclosing scopes. A nested same-named binder then tied its enclosing binder on scope-set cardinality (both weight 1 under a weight-2 reference), and resolution fell back to collection order (innermost, by luck of the innermost-first walk). The result was correct but for the wrong reason: a genuine ambiguity is indistinguishable from this legitimate shadowing.

This binds instead on `slices.Clone(keywordSym.Scopes())` + `letScope` at all three coupled sites (letrec pre-register, compile-loop create, and the re-resolve that must use the identical set or `MaybeCreateLocalBinding` keys a second slot). The nested binder is now a strict scope-set superset and wins by maximality, so the tie never forms. Top-level binders are unchanged (empty `Scopes()` leaves the set at `{letScope}`).

## Why this shape (approach 1a)

Approach **1a** of the ambiguous-binding-tie item (TODO Tier 1 / `plans/2026-07-20-scope-keyed-tier1-remediation.md` Item 1). The originally-filed fix, raise an *ambiguous binding* error on every `bestOf` tie, was rejected because it **regresses ordinary R7RS nested `let-syntax` keyword shadowing**, which currently *is* an incomparable equal-cardinality tie. Fixing the cause (the singleton scope set) removes the shadowing ties without erroring.

## Census (completeness)

A throwaway `WILE_TIE_CENSUS` probe on the `bestOf` tie branch, run over `r7rs-tests.scm`, `macros-test.scm`, and the ER-macro corpus:

- **Before:** the nested case produced a `weight=1 target=2` tie.
- **After:** that tie is gone; **zero `weight>0` ties** anywhere in the corpus. Every residual tie is `weight=0` (the empty set, i.e. two `{}`-bindings of a name = benign shadowing by frame order).

So no genuine ambiguity remains to error on; 1b (a real `ErrAmbiguousBinding` on a same-frame incomparable tie) stays deferred as the fallback if such a tie is ever constructed (none has been).

## Test plan

- [x] `TestScopeResolution_LetSyntaxShadowing` — added nested + triple-nested guards (that path was previously untested)
- [x] `go test ./pkg/machine/... ./pkg/environment/... ./pkg/wile/... ./integration/...` green
- [x] `make lint` (0 issues) + `make covercheck` (all 41 packages ≥80%)
- [x] Tie census confirms zero `weight>0` ties post-change

## Not in scope

`resolveNodeByScopes` (`frame_reclaim_build.go`) hand-rolls the same argmax over a Go map, so its tie is non-deterministic rather than first-wins. Unreachable in the corpus (no `weight>0` tie feeds it); filed as a separate determinism follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
