### PR TITLE
fix(concurrency): enqueue cv waiter before releasing mutex in mutex-unlock!

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,8 +81,15 @@ capabilities Scheme code can reach*, enforced in pure Go.
   extension is not loaded, its primitives do not exist for Scheme code to
   call.
 - **One engine per goroutine.** An `Engine` is not safe for concurrent use
-  by multiple goroutines. SRFI-18 threads *within* an engine are coordinated
-  by the VM.
+  by multiple goroutines. Within an engine, the VM coordinates its own
+  runtime structures (continuation chains, thread scheduling, the phase and
+  syntax registries) and SRFI-18 thread scheduling. It does **not** make
+  concurrent mutation of shared Scheme objects atomic: `vector-set!`,
+  `set-car!`/`set-cdr!`, record and port writes, and `set!` on a captured
+  variable are plain stores. Programs that share mutable state across
+  SRFI-18 threads must synchronize it themselves, with SRFI-18 mutexes or
+  the `atomic` primitives. This matches R7RS and SRFI-18, neither of which
+  promises atomic mutation.
 
 ### Two-layer authorization
 

--- a/extensions/gointerop/sync_cancellation_test.go
+++ b/extensions/gointerop/sync_cancellation_test.go
@@ -53,6 +53,9 @@ func newThreadedEngine(t *testing.T) *wile.Engine {
 		wile.WithExtension(extthreads.Extension),
 	)
 	qt.New(t).Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		_ = engine.Close()
+	})
 	return engine
 }
 

--- a/extensions/gointerop/sync_cancellation_test.go
+++ b/extensions/gointerop/sync_cancellation_test.go
@@ -161,3 +161,78 @@ func TestWithTimeoutInterruptsParkedRWMutex(t *testing.T) {
 
 	qt.Assert(t, result.Internal(), valuestest.SchemeEquals, values.NewSymbol("timed-out"))
 }
+
+// TestTerminateUnparksCVWait is the cv-path analogue of
+// TestTerminateUnparksBlockedSyncPrimitive: a thread parked in an UNTIMED
+// (mutex-unlock! m cv) is reaped by thread-terminate! instead of leaking its
+// goroutine. Before ConditionVariable wait grew a ctx arm, the parked <-ch had no
+// cancellation edge: thread-terminate! cancelled the thread ctx but nothing closed
+// the channel, so thread-join! raised JoinTimeoutException. Reaching the
+// terminated-thread exception proves the goroutine exited on ctx cancellation.
+func TestTerminateUnparksCVWait(t *testing.T) {
+	engine := newThreadedEngine(t)
+
+	code := `
+(define ready (make-atomic #f))
+(define m (make-mutex))
+(define cv (make-condition-variable))
+(define th (make-thread (lambda ()
+  (mutex-lock! m)
+  (atomic-store! ready 'here)
+  (mutex-unlock! m cv))))
+(thread-start! th)
+(let loop ()
+  (if (eq? (atomic-load ready) 'here)
+      #t
+      (begin (thread-yield!) (loop))))
+(thread-terminate! th)
+(thread-join! th 5)
+`
+	expr, err := engine.Parse(context.Background(), "(begin "+code+" )")
+	qt.Assert(t, err, qt.IsNil)
+	_, err = engine.Eval(context.Background(), expr)
+
+	qt.Assert(t, err, qt.IsNotNil)
+	var terminated *values.TerminatedThreadException
+	qt.Assert(t, errors.As(err, &terminated), qt.IsTrue,
+		qt.Commentf("want the SRFI-18 terminated-thread exception; a "+
+			"JoinTimeoutException here means the goroutine leaked parked on the "+
+			"condition variable with no cancellable form. got: %v", err))
+}
+
+// TestUnlockCVDeliversSignalAcrossThreads guards the SRFI-18 condition-wait
+// rendezvous: a consumer that releases the mutex and waits on the cv is woken by a
+// producer that (holding the same mutex) sets the predicate and signals. The
+// consumer uses the standard predicate re-check loop with an UNTIMED wait, so a lost
+// wakeup would hang here (caught by the test timeout). Because the waiter is now
+// enqueued before the mutex is released, the signal the producer sends while blocked
+// acquiring the mutex cannot be lost.
+//
+// The predicate is an atomic box, not a top-level `set!`: top-level bindings are
+// immutable by default, so the mutation has to live in a mutable cell. The mutex
+// still guards the predicate transition — the box is the storage, not the
+// synchronization.
+func TestUnlockCVDeliversSignalAcrossThreads(t *testing.T) {
+	engine := newThreadedEngine(t)
+
+	result := eval(t, engine, `
+(define m (make-mutex))
+(define cv (make-condition-variable))
+(define ready (make-atomic #f))
+(define consumer (make-thread (lambda ()
+  (mutex-lock! m)
+  (let loop ()
+    (if (atomic-load ready)
+        (begin (mutex-unlock! m) 'received)
+        (begin (mutex-unlock! m cv) (mutex-lock! m) (loop)))))))
+(define producer (make-thread (lambda ()
+  (mutex-lock! m)
+  (atomic-store! ready #t)
+  (condition-variable-signal! cv)
+  (mutex-unlock! m))))
+(thread-start! consumer)
+(thread-start! producer)
+(thread-join! consumer)
+`)
+	qt.Assert(t, result.Internal(), valuestest.SchemeEquals, values.NewSymbol("received"))
+}

--- a/extensions/threads/prim_threads.go
+++ b/extensions/threads/prim_threads.go
@@ -446,7 +446,7 @@ func PrimMutexUnlock(mc machine.CallContext) error {
 		owner.UntrackMutex(mutex)
 	}
 
-	result := mutex.Unlock(cv, timeout)
+	result := mutex.UnlockContext(mc.Context(), cv, timeout)
 	mc.SetValue(values.BoolToBoolean(result))
 	return nil
 }

--- a/pkg/values/condition_variable.go
+++ b/pkg/values/condition_variable.go
@@ -15,6 +15,7 @@
 package values
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -94,21 +95,41 @@ func (p *ConditionVariable) Broadcast() {
 	p.waitChs = nil
 }
 
-// Wait waits on the condition variable.
-// Returns true if signaled, false if timeout.
+// Wait waits on the condition variable until signaled or (if timeout is non-nil)
+// the timeout elapses. Returns true if signaled, false if timed out.
 //
-// Each waiter registers a per-waiter channel. Signal/Broadcast close
-// the channel to wake the waiter. Timeouts remove the channel from
-// the queue without disturbing other waiters.
+// The *Mutex argument is unused: atomic unlock-and-wait is owned by
+// Mutex.UnlockContext, which enqueues the waiter (registerWaiter) before releasing
+// the mutex. Wait itself registers and blocks in one step, which is correct only for
+// a caller that holds no mutex.
 func (p *ConditionVariable) Wait(_ *Mutex, timeout *time.Duration) bool {
+	return p.blockOnWaiter(context.Background(), p.registerWaiter(), timeout)
+}
+
+// registerWaiter appends a fresh notification channel to the wait set and returns
+// it. Separating registration from blocking lets Mutex.UnlockContext enqueue the
+// waiter BEFORE releasing the mutex, closing the SRFI-18 lost-wakeup window in which
+// a signal could land on an empty wait set.
+func (p *ConditionVariable) registerWaiter() chan struct{} {
 	ch := make(chan struct{})
 	p.mu.Lock()
 	p.waitChs = append(p.waitChs, ch)
 	p.mu.Unlock()
+	return ch
+}
 
+// blockOnWaiter parks until ch is closed by Signal/Broadcast, the timeout elapses,
+// or ctx is cancelled. Returns true iff woken by a signal. On timeout or
+// cancellation it deregisters ch; a removeWaiter miss means Signal/Broadcast already
+// claimed ch at the boundary, so that case still reports signaled.
+func (p *ConditionVariable) blockOnWaiter(ctx context.Context, ch chan struct{}, timeout *time.Duration) bool {
 	if timeout == nil {
-		<-ch
-		return true
+		select {
+		case <-ch:
+			return true
+		case <-ctx.Done():
+			return !p.removeWaiter(ch)
+		}
 	}
 
 	timer := time.NewTimer(*timeout)
@@ -117,22 +138,25 @@ func (p *ConditionVariable) Wait(_ *Mutex, timeout *time.Duration) bool {
 	select {
 	case <-ch:
 		return true
+	case <-ctx.Done():
+		return !p.removeWaiter(ch)
 	case <-timer.C:
-		// Try to remove our channel. If Signal/Broadcast already
-		// closed and removed it, the removal fails and we report
-		// signaled — the signal arrived at the timeout boundary.
-		p.mu.Lock()
-		removed := false
-		for i, c := range p.waitChs {
-			if c == ch {
-				p.waitChs = append(p.waitChs[:i], p.waitChs[i+1:]...)
-				removed = true
-				break
-			}
-		}
-		p.mu.Unlock()
-		return !removed
+		return !p.removeWaiter(ch)
 	}
+}
+
+// removeWaiter removes ch from the wait set, reporting whether it was present. A
+// false return means Signal/Broadcast already closed and removed ch.
+func (p *ConditionVariable) removeWaiter(ch chan struct{}) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, c := range p.waitChs {
+		if c == ch {
+			p.waitChs = append(p.waitChs[:i], p.waitChs[i+1:]...)
+			return true
+		}
+	}
+	return false
 }
 
 // WaiterCount returns the number of threads waiting on this condition variable.

--- a/pkg/values/mutex.go
+++ b/pkg/values/mutex.go
@@ -254,24 +254,46 @@ func (p *Mutex) LockContext(ctx context.Context, timeout *time.Duration, owner *
 	return true, nil
 }
 
-// Unlock releases the mutex
-// If cv is provided, atomically unlock and wait on condition variable
+// Unlock releases the mutex without ctx cancellation, delegating to UnlockContext
+// with a background ctx — for callers with no ctx to thread (tests, internal
+// helpers). VM primitives use UnlockContext so a thread parked on the condition
+// variable is reaped by thread-terminate!.
 func (p *Mutex) Unlock(cv *ConditionVariable, timeout *time.Duration) bool {
-	p.mu.Lock()
+	return p.UnlockContext(context.Background(), cv, timeout)
+}
 
-	// Release the mutex
-	p.state = MutexUnlocked
-	p.owner = nil
-	p.cond.Signal()
-
+// UnlockContext releases the mutex. If cv is non-nil it performs the SRFI-18 atomic
+// unlock-and-wait: the waiter is enqueued on cv BEFORE the mutex is released, so an
+// idiomatic signaller (which holds this mutex while changing the predicate) cannot
+// signal an empty wait set and lose the wakeup. ctx cancellation unparks the cv wait
+// so thread-terminate! reaps a thread blocked here.
+//
+// cv.mu and this mutex's internal lock are never held simultaneously, so no
+// lock-order inversion arises. A non-idiomatic signaller that signals WITHOUT
+// holding the mutex can still race ahead of registerWaiter; SRFI-18 requires the
+// mutex be held, and closing that window would nest cv.mu inside p.mu and
+// re-introduce a lock-order edge.
+func (p *Mutex) UnlockContext(ctx context.Context, cv *ConditionVariable, timeout *time.Duration) bool {
 	if cv == nil {
+		p.mu.Lock()
+		p.state = MutexUnlocked
+		p.owner = nil
+		p.cond.Signal()
 		p.mu.Unlock()
 		return true
 	}
 
-	// Atomically release mutex and wait on condition variable
+	// Enqueue on the cv while the mutex is still MutexLocked, then release: this pins
+	// the waiter into the wait set before any signaller can acquire the mutex.
+	ch := cv.registerWaiter()
+
+	p.mu.Lock()
+	p.state = MutexUnlocked
+	p.owner = nil
+	p.cond.Signal()
 	p.mu.Unlock()
-	return cv.Wait(p, timeout)
+
+	return cv.blockOnWaiter(ctx, ch, timeout)
 }
 
 // MarkAbandoned marks the mutex as abandoned (called when owner thread terminates).

--- a/pkg/values/mutex_test.go
+++ b/pkg/values/mutex_test.go
@@ -338,9 +338,11 @@ func TestUnlockCVNoLostWakeup(t *testing.T) {
 		cv.Signal()
 		m.Unlock(nil, nil)
 
+		timer := time.NewTimer(5 * time.Second)
 		select {
 		case <-done:
-		case <-time.After(5 * time.Second):
+			timer.Stop()
+		case <-timer.C:
 			t.Fatalf("iteration %d: consumer never woke — the signal was lost "+
 				"because the waiter was not enqueued before the mutex was released", i)
 		}

--- a/pkg/values/mutex_test.go
+++ b/pkg/values/mutex_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -300,4 +301,48 @@ func TestMutex_SchemeString(t *testing.T) {
 
 	var nilM *values.Mutex
 	qt.Assert(t, nilM.SchemeString(), qt.Equals, "#<mutex:void>")
+}
+
+// TestUnlockCVNoLostWakeup drives the SRFI-18 unlock-and-wait rendezvous directly at
+// the Go level, which is where the lost-wakeup window is narrow enough to hit
+// reliably. Each iteration races a consumer (lock, predicate false, unlock-and-wait)
+// against a producer (lock, set predicate, signal, unlock). The producer holds the
+// mutex while signalling, so under enqueue-before-release the signal can never land
+// on an empty wait set.
+//
+// Before the fix, Unlock released the mutex and only then called cv.Wait: a producer
+// that acquired the mutex in that gap signalled nothing and the consumer parked
+// forever. The per-iteration deadline turns that hang into a failure instead of a
+// suite timeout.
+func TestUnlockCVNoLostWakeup(t *testing.T) {
+	const iterations = 20000
+
+	for i := range iterations {
+		m := values.NewMutex("m")
+		cv := values.NewConditionVariable("cv")
+		var ready atomic.Bool
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+			m.Lock(nil, nil)
+			for !ready.Load() {
+				m.Unlock(cv, nil)
+				m.Lock(nil, nil)
+			}
+			m.Unlock(nil, nil)
+		}()
+
+		m.Lock(nil, nil)
+		ready.Store(true)
+		cv.Signal()
+		m.Unlock(nil, nil)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: consumer never woke — the signal was lost "+
+				"because the waiter was not enqueued before the mutex was released", i)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a SRFI-18 **lost-wakeup** race in `(mutex-unlock! mutex cv timeout)`, plus a coupled goroutine-leak / cancellation gap discovered alongside it.

SRFI-18 requires the waiting thread be added to the condition variable **before** the mutex is released, so an idiomatic signaller (which holds the mutex while mutating the predicate) always sees a non-empty wait set. `Mutex.Unlock` released the mutex first and only then called `cv.Wait`, so a signaller that acquired the mutex in that gap signalled an empty wait set and the wakeup was lost.

## Fix

- Split `ConditionVariable.Wait` into `registerWaiter` / `blockOnWaiter` / `removeWaiter`, so `Mutex.UnlockContext` can **enqueue the waiter while still holding the mutex**, then release. This pins the waiter into the wait set before any signaller can acquire the mutex.
- `blockOnWaiter` grows a `ctx.Done()` arm, closing the coupled goroutine leak: a thread parked in `(mutex-unlock! m cv)` previously had no cancellation edge, so `thread-terminate!` could not reap it and `thread-join!` raised `JoinTimeoutException`. The VM primitive now threads `mc.Context()` through `UnlockContext`.
- `Mutex.Unlock` is retained as a background-ctx delegate for callers with no ctx to thread (tests, internal helpers).

**Lock ordering:** `cv.mu` and the mutex's internal lock are never held simultaneously, so no lock-order inversion is introduced. A non-idiomatic signaller that signals *without* holding the mutex can still race `registerWaiter`; SRFI-18 requires the mutex be held, and closing that window would nest `cv.mu` inside `p.mu` and re-introduce a lock-order edge.

Also retracts the `SECURITY.md` claim that SRFI-18 threads within an engine are "coordinated by the VM": the VM coordinates its own structures; it does not make `vector-set!`, `set-car!`, port writes, or captured-variable `set!` atomic. The real boundary is documented instead.

## Test plan

- [x] `TestUnlockCVNoLostWakeup` drives the rendezvous at the Go level, where the window is reachable: hangs at ~iteration 6.7k before the fix, runs 20000 clean after. (The Scheme-level equivalent does not reproduce — VM dispatch overhead widens the gap enough to mask the race.)
- [x] `sync_cancellation_test.go` covers the `thread-terminate!` reaping of a cv-parked thread.
- [x] `go test -race` green on `pkg/values`, `extensions/threads`, `extensions/gointerop`
- [x] `make lint` (0 issues) + `make covercheck` (41/41 ≥ 80%)

Refs: `reviews/2026-07-17/REVIEW.md` C1 (#8), Phase 1.1/1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
