### PR TITLE
fix(dialects,values,expander,repl): four correctness nits from the 2026-07-17 review

### DIFF
--- a/pkg/machine/compilation/expander_time_continuation.go
+++ b/pkg/machine/compilation/expander_time_continuation.go
@@ -238,7 +238,7 @@ func (p *ExpanderTimeContinuation) ExpandExpression(expr syntax.SyntaxValue) (sy
 	case *syntax.SyntaxPair:
 		car := stx.SyntaxCar()
 		cdr := stx.SyntaxCdr()
-		result, err = p.ExpandSyntaxOrProcedureCall(car, cdr)
+		result, err = p.ExpandSyntaxOrProcedureCall(car, cdr, stx.SourceContext())
 		if err != nil {
 			return nil, wrapSourcedError(expr.SourceContext(), werr.WrapForeignErrorf(err, "expand: failed to expand list expression"))
 		}
@@ -260,7 +260,7 @@ func (p *ExpanderTimeContinuation) ExpandSymbol(expr *syntax.SyntaxSymbol) (synt
 // ExpandSyntaxOrProcedureCall handles a list expression. The car may be a
 // symbol (possibly a macro), a nested pair (computed procedure), or a
 // self-evaluating value (like in quoted data or malformed expressions).
-func (p *ExpanderTimeContinuation) ExpandSyntaxOrProcedureCall(car syntax.SyntaxValue, cdr syntax.SyntaxValue) (syntax.SyntaxValue, error) {
+func (p *ExpanderTimeContinuation) ExpandSyntaxOrProcedureCall(car syntax.SyntaxValue, cdr syntax.SyntaxValue, parentCtx *syntax.SourceContext) (syntax.SyntaxValue, error) {
 	switch v := car.(type) {
 	case *syntax.SyntaxPair:
 		// Car is a pair - expand it (computed procedure), then expand arguments
@@ -284,8 +284,15 @@ func (p *ExpanderTimeContinuation) ExpandSyntaxOrProcedureCall(car syntax.Syntax
 		}
 		return syntax.NewSyntaxCons(car, rest1, car.SourceContext()), nil
 	default:
-		// Unknown car type - return expression unchanged
-		return syntax.NewSyntaxCons(car, cdr, car.SourceContext()), nil
+		// Unknown car type (e.g. the empty-list operator in `(())`) - the
+		// empty-list singleton carries no source context, so fall back to the
+		// enclosing form's context rather than emitting a location-less node
+		// that codegen would then mislocate to the parent form.
+		ctx := car.SourceContext()
+		if ctx == nil {
+			ctx = parentCtx
+		}
+		return syntax.NewSyntaxCons(car, cdr, ctx), nil
 	}
 }
 

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -420,6 +420,17 @@ func (p *lineReader) ReadLine() (string, error) {
 	buf := make([]byte, 1)
 	for {
 		n, err := p.f.Read(buf)
+		// Process the returned byte before the error: io.Reader permits a reader
+		// to return n > 0 together with io.EOF, and handling err first would drop
+		// that final byte and truncate the last line.
+		if n > 0 {
+			if buf[0] == '\n' {
+				line := p.r.String()
+				p.r.Reset()
+				return line, nil
+			}
+			p.r.WriteByte(buf[0])
+		}
 		if err != nil {
 			// A final line with no trailing newline is still a line: flush what
 			// is buffered before propagating EOF, or the last form is silently
@@ -431,14 +442,5 @@ func (p *lineReader) ReadLine() (string, error) {
 			}
 			return "", err
 		}
-		if n == 0 {
-			continue
-		}
-		if buf[0] == '\n' {
-			line := p.r.String()
-			p.r.Reset()
-			return line, nil
-		}
-		p.r.WriteByte(buf[0])
 	}
 }

--- a/pkg/repl/repl.go
+++ b/pkg/repl/repl.go
@@ -421,6 +421,14 @@ func (p *lineReader) ReadLine() (string, error) {
 	for {
 		n, err := p.f.Read(buf)
 		if err != nil {
+			// A final line with no trailing newline is still a line: flush what
+			// is buffered before propagating EOF, or the last form is silently
+			// swallowed. The next call sees an empty buffer and returns EOF.
+			if errors.Is(err, io.EOF) && p.r.Len() > 0 {
+				line := p.r.String()
+				p.r.Reset()
+				return line, nil
+			}
 			return "", err
 		}
 		if n == 0 {

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -17,6 +17,8 @@ package repl
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -96,4 +98,40 @@ func TestRunSimple_WithInput_NoTrailingNewline(t *testing.T) {
 	// to 42 rather than being swallowed on EOF.
 	c.Assert(strings.Contains(out.String(), "42"), qt.IsTrue,
 		qt.Commentf("out=%q", out.String()))
+}
+
+// eofWithDataReader delivers its bytes one at a time and returns the FINAL byte
+// together with io.EOF in the same Read — the io.Reader contract case (n > 0 with
+// err == io.EOF) that strings.Reader never exercises.
+type eofWithDataReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *eofWithDataReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	p[0] = r.data[r.pos]
+	r.pos++
+	if r.pos == len(r.data) {
+		return 1, io.EOF
+	}
+	return 1, nil
+}
+
+// TestLineReader_FinalByteWithEOF pins the io.Reader contract: a Read returning
+// the last byte together with io.EOF must not drop that byte. Before the fix,
+// ReadLine handled err before consuming n, so it returned "a" for input "ab".
+func TestLineReader_FinalByteWithEOF(t *testing.T) {
+	c := qt.New(t)
+	lr := newLineReader(&eofWithDataReader{data: []byte("ab")})
+
+	line, err := lr.ReadLine()
+	c.Assert(err, qt.IsNil)
+	c.Assert(line, qt.Equals, "ab")
+
+	// The next read is a clean EOF with nothing buffered.
+	_, err = lr.ReadLine()
+	c.Assert(errors.Is(err, io.EOF), qt.IsTrue)
 }

--- a/pkg/repl/repl_test.go
+++ b/pkg/repl/repl_test.go
@@ -73,3 +73,27 @@ func TestRunSimple_ErrorRecovery(t *testing.T) {
 	// The error renders one stack trace, not two (double-render regression).
 	c.Assert(strings.Count(full, "Stack trace:"), qt.Equals, 1, qt.Commentf("out=%q", full))
 }
+
+// TestRunSimple_WithInput_NoTrailingNewline verifies the simple loop evaluates
+// the final form when the input lacks a trailing newline. ReadLine must flush
+// its buffered partial line on EOF instead of discarding it.
+func TestRunSimple_WithInput_NoTrailingNewline(t *testing.T) {
+	c := qt.New(t)
+	eng, err := wile.NewEngine(context.Background(), wile.WithMutableTopLevel())
+	c.Assert(err, qt.IsNil)
+
+	var out bytes.Buffer
+	r := New(eng,
+		WithInput(strings.NewReader("(define x 21)\n(* x 2)")),
+		WithOutput(&out),
+		WithErrorOutput(&out),
+	)
+
+	err = r.RunSimple(context.Background())
+	c.Assert(err, qt.IsNil)
+
+	// The final form "(* x 2)" has no trailing newline; it must still evaluate
+	// to 42 rather than being swallowed on EOF.
+	c.Assert(strings.Contains(out.String(), "42"), qt.IsTrue,
+		qt.Commentf("out=%q", out.String()))
+}

--- a/pkg/values/scheme_writer.go
+++ b/pkg/values/scheme_writer.go
@@ -16,6 +16,7 @@ package values
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/aalpar/wile/pkg/werr"
@@ -88,6 +89,13 @@ type SchemeWriter struct {
 	needsLabelVector map[*Vector]bool
 	// needsLabelBox tracks which boxes need labels.
 	needsLabelBox map[*Box]bool
+	// seenHashtables maps hashtable pointers to their assigned label numbers.
+	// A Hashtable value slot is mutable, so a cycle can pass through it exactly
+	// as it can through a pair car, vector element, or box; it needs the same
+	// pointer-identity tracking to both label sharing and terminate on cycles.
+	seenHashtables map[*Hashtable]int
+	// needsLabelHashtable tracks which hashtables need labels.
+	needsLabelHashtable map[*Hashtable]bool
 	// displayMode indicates whether to use display format (no quotes on strings).
 	displayMode bool
 	// writeMode controls whether to label all shared or only circular references.
@@ -104,15 +112,17 @@ type SchemeWriter struct {
 // Default mode is WriteModeWrite (labels only circular references).
 func NewSchemeWriter() *SchemeWriter {
 	q := &SchemeWriter{
-		seenPairs:        make(map[*Pair]int),
-		seenVectors:      make(map[*Vector]int),
-		seenBoxes:        make(map[*Box]int),
-		needsLabelPair:   make(map[*Pair]bool),
-		needsLabelVector: make(map[*Vector]bool),
-		needsLabelBox:    make(map[*Box]bool),
-		nextLabel:        0,
-		writeMode:        WriteModeWrite,
-		maxDepth:         DefaultMaxWriteDepth,
+		seenPairs:           make(map[*Pair]int),
+		seenVectors:         make(map[*Vector]int),
+		seenBoxes:           make(map[*Box]int),
+		needsLabelPair:      make(map[*Pair]bool),
+		needsLabelVector:    make(map[*Vector]bool),
+		needsLabelBox:       make(map[*Box]bool),
+		seenHashtables:      make(map[*Hashtable]int),
+		needsLabelHashtable: make(map[*Hashtable]bool),
+		nextLabel:           0,
+		writeMode:           WriteModeWrite,
+		maxDepth:            DefaultMaxWriteDepth,
 	}
 	return q
 }
@@ -145,6 +155,8 @@ func (p *SchemeWriter) WriteString(v Value) (string, error) {
 	p.needsLabelPair = make(map[*Pair]bool)
 	p.needsLabelVector = make(map[*Vector]bool)
 	p.needsLabelBox = make(map[*Box]bool)
+	p.seenHashtables = make(map[*Hashtable]int)
+	p.needsLabelHashtable = make(map[*Hashtable]bool)
 
 	// First pass: identify which objects are referenced multiple times. This
 	// is also the depth-enforcing pass — it is the first traversal to descend
@@ -165,6 +177,7 @@ func (p *SchemeWriter) WriteString(v Value) (string, error) {
 	p.seenPairs = make(map[*Pair]int)
 	p.seenVectors = make(map[*Vector]int)
 	p.seenBoxes = make(map[*Box]int)
+	p.seenHashtables = make(map[*Hashtable]int)
 
 	// Second pass: generate output with labels
 	q := &strings.Builder{}
@@ -247,6 +260,25 @@ func (p *SchemeWriter) findShared(v Value, depth int) {
 		}
 		p.seenBoxes[val] = -1
 		p.findShared(val.Value, depth+1)
+
+	case *Hashtable:
+		if val == nil {
+			return
+		}
+		_, found := p.seenHashtables[val]
+		if found {
+			p.needsLabelHashtable[val] = true
+			return
+		}
+		p.seenHashtables[val] = -1
+		// Only values recurse: no container type is Hashable, so a key is always
+		// a leaf and cannot carry sharing or a cycle (TestNoContainerIsHashable).
+		for _, e := range val.snapshot() {
+			p.findShared(e.value, depth+1)
+			if p.err != nil {
+				return
+			}
+		}
 	}
 }
 
@@ -263,6 +295,9 @@ func (p *SchemeWriter) filterToCircular(v Value) {
 	visitedPairs := make(map[*Pair]bool)
 	visitedVectors := make(map[*Vector]bool)
 	visitedBoxes := make(map[*Box]bool)
+	circularHashtables := make(map[*Hashtable]bool)
+	onStackHashtables := make(map[*Hashtable]bool)
+	visitedHashtables := make(map[*Hashtable]bool)
 
 	var walk func(v Value)
 	walk = func(v Value) {
@@ -335,6 +370,24 @@ func (p *SchemeWriter) filterToCircular(v Value) {
 			onStackBoxes[val] = true
 			walk(val.Value)
 			delete(onStackBoxes, val)
+
+		case *Hashtable:
+			if val == nil {
+				return
+			}
+			if onStackHashtables[val] {
+				circularHashtables[val] = true
+				return
+			}
+			if visitedHashtables[val] {
+				return
+			}
+			visitedHashtables[val] = true
+			onStackHashtables[val] = true
+			for _, e := range val.snapshot() {
+				walk(e.value)
+			}
+			delete(onStackHashtables, val)
 		}
 	}
 
@@ -343,6 +396,7 @@ func (p *SchemeWriter) filterToCircular(v Value) {
 	p.needsLabelPair = circularPairs
 	p.needsLabelVector = circularVectors
 	p.needsLabelBox = circularBoxes
+	p.needsLabelHashtable = circularHashtables
 }
 
 // write outputs a value, handling cycles with datum labels.
@@ -354,6 +408,8 @@ func (p *SchemeWriter) write(sb *strings.Builder, v Value) {
 		p.writeVector(sb, val)
 	case *Box:
 		p.writeBox(sb, val)
+	case *Hashtable:
+		p.writeHashtable(sb, val)
 	case *String:
 		// In display mode, strings are printed without quotes
 		if p.displayMode {
@@ -531,6 +587,50 @@ func (p *SchemeWriter) writeBox(sb *strings.Builder, bx *Box) {
 
 	sb.WriteString("#&")
 	p.write(sb, bx.Value)
+}
+
+// writeHashtable writes a hashtable with cycle detection, mirroring writeVector.
+// Without this arm the default write branch falls through to
+// Hashtable.SchemeString, whose path-scoped recursion emits "..." on a cycle and
+// never assigns datum labels, so sharing or a cycle routed through a hashtable
+// value would be under-represented (R7RS 6.13.3). Only values recurse: no
+// container type is Hashable, so a key is always a leaf. Entries are sorted by
+// rendered key for deterministic output, matching SchemeString.
+func (p *SchemeWriter) writeHashtable(sb *strings.Builder, h *Hashtable) {
+	if h == nil {
+		sb.WriteString("#hash()")
+		return
+	}
+
+	label, found := p.seenHashtables[h]
+	if found && label >= 0 {
+		fmt.Fprintf(sb, "#%d#", label)
+		return
+	}
+
+	if p.needsLabelHashtable[h] {
+		label := p.nextLabel
+		p.nextLabel++
+		p.seenHashtables[h] = label
+		fmt.Fprintf(sb, "#%d=", label)
+	}
+
+	entries := h.snapshot()
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].key.SchemeString() < entries[j].key.SchemeString()
+	})
+	sb.WriteString("#hash(")
+	for i, e := range entries {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+		sb.WriteString("(")
+		p.write(sb, e.key)
+		sb.WriteString(" . ")
+		p.write(sb, e.value)
+		sb.WriteString(")")
+	}
+	sb.WriteString(")")
 }
 
 // WriteValueToString writes a Scheme value to a string with cycle detection.

--- a/pkg/values/scheme_writer_test.go
+++ b/pkg/values/scheme_writer_test.go
@@ -403,3 +403,25 @@ func TestSchemeWriter_ReusableAcrossCalls(t *testing.T) {
 	qt.Assert(t, err, qt.IsNil)
 	qt.Assert(t, s2, qt.Equals, "#0=(2 . #0#)")
 }
+
+func TestWriteSharedValueToString_SharedThroughHashtable(t *testing.T) {
+	// A pair shared between a top-level list element and a hashtable value must
+	// be labeled once (#0=) and back-referenced (#0#) inside the table.
+	shared := values.List(values.NewInteger(1), values.NewInteger(2))
+	h := values.NewEmptyHashtable()
+	qt.Assert(t, h.Set(values.NewSymbol("k"), shared), qt.IsNil)
+	outer := values.List(shared, h)
+
+	result := mustRender(t, values.WriteSharedValueToString, outer)
+	qt.Assert(t, result, qt.Equals, "(#0=(1 2) #hash((k . #0#)))")
+}
+
+func TestWriteValueToString_CycleThroughHashtable(t *testing.T) {
+	// A self-cyclic hashtable (its own value slot points back at the table) must
+	// render a datum label, not SchemeString's "..." depth guard.
+	h := values.NewEmptyHashtable()
+	qt.Assert(t, h.Set(values.NewSymbol("k"), h), qt.IsNil)
+
+	result := mustRender(t, values.WriteValueToString, h)
+	qt.Assert(t, result, qt.Equals, "#0=#hash((k . #0#))")
+}

--- a/pkg/wile/dialect_nomutation.go
+++ b/pkg/wile/dialect_nomutation.go
@@ -118,6 +118,7 @@ func mutationPrimitives() []string {
 		"hashtable-delete!",
 		"hashtable-clear!",
 		"set-box!",
+		"%parameter-raw-set!",
 		"atomic-store!",
 		"atomic-swap!",
 		"atomic-compare-and-swap!",

--- a/pkg/wile/dialect_nomutation_drift_test.go
+++ b/pkg/wile/dialect_nomutation_drift_test.go
@@ -61,9 +61,6 @@ var nonDestructiveBangs = map[string]string{
 	"set-current-directory!": "process state, not a Scheme value",
 	"namespace-define!":      "reflective definition; define is not mutation, and NoMutation keeps define",
 	"namespace-undefine!":    "reflective definition removal; the mirror of namespace-define!",
-
-	// Internal.
-	"%parameter-raw-set!": "internal parameterize plumbing, not user-reachable as mutation",
 }
 
 // TestNoMutationRemovesEveryDestructivePrimitive is the drift guard REVIEW.md §7
@@ -256,4 +253,28 @@ func TestNoMutationRemovedFormInMacroTemplateIsUnbound(t *testing.T) {
 		qt.Commentf("the unbound identifier must be set! specifically"))
 	qt.Assert(t, err.Error(), qt.Not(qt.Contains), "primitive-expander",
 		qt.Commentf("the internal expand-phase handler must never leak into runtime, got %v", err))
+}
+
+// TestNoMutationRemovesParameterRawSet pins finding 5.1: %parameter-raw-set!
+// destructively writes a parameter's held value (prim_parameters.go:
+// param.SetValue) and is no longer used by the parameterize macro, which stores
+// bindings as continuation marks via %parameter-convert. It is a user-reachable
+// destructive update, the direct analogue of the removed set-box!, so NoMutation
+// must remove it.
+func TestNoMutationRemovesParameterRawSet(t *testing.T) {
+	ctx := context.Background()
+	eng, err := wile.NewEngine(ctx, wile.WithDialect(wile.NoMutation))
+	qt.Assert(t, err, qt.IsNil)
+	defer func() {
+		_ = eng.Close()
+	}()
+
+	// Before the fix this evaluated to 99 — a destructive parameter update
+	// surviving a dialect whose whole claim is that no destructive update survives.
+	_, err = eng.EvalMultiple(ctx,
+		`(let ((p (make-parameter 10))) (%parameter-raw-set! p 99) (p))`)
+	qt.Assert(t, errors.Is(err, werr.ErrNoSuchBinding), qt.IsTrue,
+		qt.Commentf("%%parameter-raw-set! must be unbound under no-mutation, got %v", err))
+	qt.Assert(t, err.Error(), qt.Contains, "%parameter-raw-set!",
+		qt.Commentf("the unbound identifier must be %%parameter-raw-set! specifically"))
 }

--- a/pkg/wile/engine.go
+++ b/pkg/wile/engine.go
@@ -54,8 +54,12 @@ const DefaultMaxCallDepth int = 10000
 // environment. Each goroutine should use its own Engine, or
 // synchronize externally.
 //
-// SRFI-18 threads within a single Engine are safe — the VM handles
-// thread coordination internally.
+// Within an Engine, the VM coordinates its own runtime structures and
+// SRFI-18 thread scheduling. It does NOT make concurrent mutation of shared
+// Scheme objects atomic: vector-set!, set-car!/set-cdr!, record and port
+// writes, and set! on a captured variable are plain stores. Programs that
+// share mutable state across SRFI-18 threads must synchronize it themselves,
+// with SRFI-18 mutexes or the atomic primitives.
 type Engine struct {
 	namespace               *environment.Namespace
 	env                     *environment.EnvironmentFrame

--- a/pkg/wile/location_source_test.go
+++ b/pkg/wile/location_source_test.go
@@ -72,3 +72,33 @@ func TestRuntimeErrorSourceProvenance(t *testing.T) {
 		})
 	}
 }
+
+// TestEmptyListOperatorSourceLocation verifies that a form whose operator is the
+// empty list — (()) — localizes its runtime error to its own line, not the
+// enclosing (begin ...) wrapper. The empty-list singleton carries no source
+// context, so the expander must fall back to the enclosing form's context when
+// rebuilding the call node. Regression test for finding 5.3.
+func TestEmptyListOperatorSourceLocation(t *testing.T) {
+	ctx := context.Background()
+	eng, err := NewEngine(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	// (()) sits on line 3; the two filler forms push it down so a line-1
+	// mislocation is distinguishable from the correct line-3 report.
+	const code = "(+ 1 2)\n(+ 3 4)\n(())"
+	_, err = eng.EvalMultipleWithSource(ctx, code, "prog.scm")
+	if err == nil {
+		t.Fatal("expected runtime error")
+	}
+	var re *RuntimeError
+	if !errors.As(err, &re) {
+		t.Fatalf("expected *RuntimeError, got %T: %v", err, err)
+	}
+	const wantPrefix = "prog.scm:3:"
+	if !strings.HasPrefix(re.Source, wantPrefix) {
+		t.Errorf("RuntimeError.Source = %q, want prefix %q", re.Source, wantPrefix)
+	}
+}


### PR DESCRIPTION
## Summary

Four independent correctness fixes from the 2026-07-17 review (Phase 5), plus a stale-docstring retraction. Each is small and self-contained.

- **dialects (C4/#4):** `%parameter-raw-set!` destructively writes a parameter's held value and is user-reachable at the top level, so it survived `NoMutation` — `(let ((p (make-parameter 10))) (%parameter-raw-set! p 99) (p))` returned `99`. It is no longer used by the `parameterize` macro (which stores bindings as continuation marks), making it the direct analogue of the already-removed `set-box!`. Added to `mutationPrimitives()`; the false drift-guard exemption removed.
- **values (C5/#9):** `write`/`write-shared` skipped hashtable interiors, so structure shared or cyclic *through* a hashtable value was neither labeled nor faithfully represented — it fell through to `SchemeString` (`"..."`, no datum labels). `findShared`/`filterToCircular`/`write` grow hashtable arms plus a `writeHashtable` mirroring `writeVector`. Records are deliberately NOT descended into (they print opaquely, so a `#N=` label would have nowhere to render the back-reference).
- **expander (C7/#15):** a form whose operator is the empty list — `(())` — lost its location (the reader returns the shared empty-list singleton with nil `SourceContext`), so codegen stamped the runtime error on the enclosing form's line. The default arm now falls back to the enclosing pair's context.
- **repl (C8/#13):** `lineReader.ReadLine` emitted a line only on `\n` and discarded the buffer on EOF, so a final form with no trailing newline was silently swallowed. It now flushes the partial line before propagating EOF.
- Also corrects `pkg/wile/engine.go`'s godoc, which repeated the false "SRFI-18 threads within a single Engine are safe" claim already retracted from `SECURITY.md` in the concurrency work (PR #808).

## Test plan

- [x] `go test` green on `pkg/values`, `pkg/repl`, `pkg/machine/compilation`, and the `pkg/wile` NoMutation/location/drift tests
- [x] new coverage: `scheme_writer_test.go` (hashtable interiors), `repl_test.go` (EOF flush), `location_source_test.go` (`(())` location), `dialect_nomutation_drift_test.go` (parameter-raw-set!)
- [x] `make lint` (0 issues) — full gate via CI

Refs: `reviews/2026-07-17/REVIEW.md` C4 (#4), C5 (#9), C7 (#15), C8 (#13), Phase 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
