### PR TITLE
fix(examples,ci): repair broken shipped examples and execute them in make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ examples:
 #   make ci
 #   make ci SKIP_LINT=1
 .PHONY: ci
-ci: $(if $(SKIP_LINT),,lint) build-all test covercheck readme-check check-readme-links check-docs-orphans examples verify-mod
+ci: $(if $(SKIP_LINT),,lint) build-all test covercheck readme-check check-readme-links check-docs-orphans examples test-examples verify-mod
 	@echo "CI passed"
 
 # ── CD: release-specific validation ─────────────────────────────────
@@ -246,7 +246,8 @@ bench:
 # Measures time and memory usage. Useful for detecting performance regressions.
 #   make bench-schelog
 SCHELOG_DIR=examples/logic/schelog
-SCHELOG_LIBS=-f $(SCHELOG_DIR)/schelog.scm \
+SCHELOG_LIBS=-i \
+             -f $(SCHELOG_DIR)/schelog.scm \
              -f $(SCHELOG_DIR)/toys.scm \
              -f $(SCHELOG_DIR)/puzzle.scm \
              -f $(SCHELOG_DIR)/mapcol.scm \
@@ -255,11 +256,11 @@ SCHELOG_LIBS=-f $(SCHELOG_DIR)/schelog.scm \
 .PHONY: bench-schelog
 bench-schelog: build
 	@if command -v gtime >/dev/null 2>&1; then \
-		gtime -v $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm 2>&1; \
+		gtime -v $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm < /dev/null 2>&1; \
 	elif [ -x /usr/bin/time ]; then \
-		/usr/bin/time -l $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm 2>&1; \
+		/usr/bin/time -l $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm < /dev/null 2>&1; \
 	else \
-		time $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm; \
+		time $(DIST_DIR)/$(HOST_OS)/$(HOST_ARCH)/$(MY_BIN) -q $(SCHELOG_LIBS) -f $(SCHELOG_DIR)/benchmark.scm < /dev/null; \
 	fi
 
 # Run the miniKanren benchmark suite (logic programming via R7RS libraries).

--- a/examples/.ci-exclude
+++ b/examples/.ci-exclude
@@ -3,7 +3,6 @@
 
 # Intentionally demonstrate error conditions and exit non-zero.
 basics/error-source-tracking.scm
-control/exceptions.scm
 
 # Flaky: parallel-map spawns many threads; intermittent timeout on CI runners.
 concurrency/parallel-map.scm

--- a/examples/benchmarks/run-extended.sh
+++ b/examples/benchmarks/run-extended.sh
@@ -163,8 +163,8 @@ for run in $(seq 1 "$RUNS"); do
         case "$bench" in
             schelog-zebra)
                 OUTPUT=$(SCHEME_INCLUDE_PATH="$PROJECT_ROOT" \
-                    timeout "$TIMEOUT" "$SCHEME" -q \
-                    --file "$SCRIPT_DIR/schelog-zebra-bench.scm" 2>&1) || true
+                    timeout "$TIMEOUT" "$SCHEME" -q -i \
+                    --file "$SCRIPT_DIR/schelog-zebra-bench.scm" < /dev/null 2>&1)
                 TIME=$(echo "$OUTPUT" | grep "^Total time:" | awk '{print $3}' | tr -d 's')
                 ;;
             kanren-zebra)

--- a/examples/benchmarks/schelog-zebra-bench.scm
+++ b/examples/benchmarks/schelog-zebra-bench.scm
@@ -1,7 +1,13 @@
 ;;; schelog-zebra-bench.scm - Timed Schelog zebra puzzle benchmark
 ;;;
 ;;; Outputs "Total time: Xs" for compatibility with run-extended.sh.
-;;; Usage: SCHEME_INCLUDE_PATH=. ./dist/wile --file examples/benchmarks/schelog-zebra-bench.scm
+;;; Usage: SCHEME_INCLUDE_PATH=. ./dist/wile -q -i \
+;;;            --file examples/benchmarks/schelog-zebra-bench.scm < /dev/null
+;;;
+;;; -i (mutable top level) is REQUIRED: schelog is unmodified upstream source
+;;; that set!s its own top-level globals and redefines %append, both of which
+;;; the immutable-top-level default rejects. `< /dev/null` feeds EOF so the
+;;; REPL that -i leaves running exits 0 instead of waiting on stdin.
 
 (include "examples/logic/schelog/schelog.scm")
 (include "examples/logic/schelog/puzzle.scm")

--- a/examples/control/exceptions.scm
+++ b/examples/control/exceptions.scm
@@ -22,10 +22,6 @@
      (else (search (+ s-pos 1)))))
   (search 0))
 
-;; Helper for make-error
-(define (make-error msg)
-  (error msg))
-
 ;; Example 1: Basic guard
 (display "Example 1: Catching exceptions with guard\n")
 (display "  ")
@@ -92,7 +88,7 @@
         (k #f))
       (lambda ()
         (display "Body executing...\n  ")
-        (raise (make-error "Test error"))
+        (error "Test error")
         (display "This won't print\n")))))
 (newline)
 

--- a/examples/control/exceptions.scm
+++ b/examples/control/exceptions.scm
@@ -13,6 +13,19 @@
 (display "=== Exception Handling in Wile ===\n")
 (newline)
 
+;; Helper for string-contains (not in R7RS-small)
+(define (string-contains str substr)
+  (define (search s-pos)
+    (cond
+     ((> (+ s-pos (string-length substr)) (string-length str)) #f)
+     ((string=? (substring str s-pos (+ s-pos (string-length substr))) substr) #t)
+     (else (search (+ s-pos 1)))))
+  (search 0))
+
+;; Helper for make-error
+(define (make-error msg)
+  (error msg))
+
 ;; Example 1: Basic guard
 (display "Example 1: Catching exceptions with guard\n")
 (display "  ")
@@ -68,16 +81,19 @@
 ;; Example 4: with-exception-handler
 (display "Example 4: with-exception-handler (handler doesn't return)\n")
 (display "  ")
-(with-exception-handler
-  (lambda (err)
-    (display "Handler called: ")
-    (display (error-object-message err))
-    (newline)
-    (display "  Handler exiting via continuation\n"))
-  (lambda ()
-    (display "Body executing...\n  ")
-    (raise (make-error "Test error"))
-    (display "This won't print\n")))
+(call-with-current-continuation
+  (lambda (k)
+    (with-exception-handler
+      (lambda (err)
+        (display "Handler called: ")
+        (display (error-object-message err))
+        (newline)
+        (display "  Handler exiting via continuation\n")
+        (k #f))
+      (lambda ()
+        (display "Body executing...\n  ")
+        (raise (make-error "Test error"))
+        (display "This won't print\n")))))
 (newline)
 
 ;; Example 5: Error object inspection
@@ -101,11 +117,11 @@
 (define (validate-age age)
   (cond
    ((not (number? age))
-    (error 'type-error "Age must be a number" age))
+    (error "Age must be a number" 'type-error age))
    ((< age 0)
-    (error 'value-error "Age cannot be negative" age))
+    (error "Age cannot be negative" 'value-error age))
    ((> age 150)
-    (error 'value-error "Age unrealistic" age))
+    (error "Age unrealistic" 'value-error age))
    (else age)))
 
 (define (test-validate age)
@@ -176,12 +192,12 @@
 (display "Example 8: Using exceptions for control flow (break pattern)\n")
 (define (find-first pred lst)
   (guard (found
-          ((equal? 'found (car (error-object-irritants found)))
-           (cadr (error-object-irritants found))))
+          ((equal? "found" (error-object-message found))
+           (car (error-object-irritants found))))
     (for-each
      (lambda (x)
        (when (pred x)
-         (error 'found 'found x)))
+         (error "found" x)))
      lst)
     #f))
 
@@ -233,19 +249,6 @@
          (newline)))
   (safe-sqrt -4))
 (newline)
-
-;; Helper for string-contains (not in R7RS-small)
-(define (string-contains str substr)
-  (define (search s-pos)
-    (cond
-     ((> (+ s-pos (string-length substr)) (string-length str)) #f)
-     ((string=? (substring str s-pos (+ s-pos (string-length substr))) substr) #t)
-     (else (search (+ s-pos 1)))))
-  (search 0))
-
-;; Helper for make-error
-(define (make-error msg)
-  (error msg))
 
 ;; Summary
 (display "=== Summary ===\n")

--- a/tools/sh/run-examples.sh
+++ b/tools/sh/run-examples.sh
@@ -24,14 +24,19 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXAMPLES_DIR="$REPO_ROOT/examples"
 EXCLUDE_FILE="$EXAMPLES_DIR/.ci-exclude"
 
-# Detect timeout command (GNU timeout or macOS gtimeout via coreutils)
-if command -v timeout >/dev/null 2>&1; then
-    TIMEOUT_CMD=(timeout --kill-after=5)
-elif command -v gtimeout >/dev/null 2>&1; then
-    TIMEOUT_CMD=(gtimeout --kill-after=5)
-else
-    TIMEOUT_CMD=()
-fi
+# Detect a timeout command that actually supports --kill-after. Presence is not
+# enough: BSD/MacPorts ship a `timeout` that rejects the flag, and picking it by
+# name alone makes EVERY example fail with a usage error. Probe each candidate
+# and take the first that works; gtimeout (coreutils) is tried first because on
+# macOS it is the GNU one. No candidate means run without a timeout.
+TIMEOUT_CMD=()
+for candidate in gtimeout timeout; do
+    if command -v "$candidate" >/dev/null 2>&1 &&
+       "$candidate" --kill-after=5 1 true >/dev/null 2>&1; then
+        TIMEOUT_CMD=("$candidate" --kill-after=5)
+        break
+    fi
+done
 
 # Load exclusion list (paths relative to examples/, comments and blanks skipped)
 declare -A excluded

--- a/tools/sh/run-examples.sh
+++ b/tools/sh/run-examples.sh
@@ -28,12 +28,14 @@ EXCLUDE_FILE="$EXAMPLES_DIR/.ci-exclude"
 # enough: BSD/MacPorts ship a `timeout` that rejects the flag, and picking it by
 # name alone makes EVERY example fail with a usage error. Probe each candidate
 # and take the first that works; gtimeout (coreutils) is tried first because on
-# macOS it is the GNU one. No candidate means run without a timeout.
+# macOS it is the GNU one. No candidate means run without a timeout. The
+# duration ($TIMEOUT) is folded into the array so that an empty TIMEOUT_CMD
+# expands to nothing — otherwise the bare duration would be run as a command.
 TIMEOUT_CMD=()
 for candidate in gtimeout timeout; do
     if command -v "$candidate" >/dev/null 2>&1 &&
        "$candidate" --kill-after=5 1 true >/dev/null 2>&1; then
-        TIMEOUT_CMD=("$candidate" --kill-after=5)
+        TIMEOUT_CMD=("$candidate" --kill-after=5 "$TIMEOUT")
         break
     fi
 done
@@ -62,7 +64,7 @@ while IFS= read -r -d '' scm; do
         continue
     fi
 
-    if "${TIMEOUT_CMD[@]}" "$TIMEOUT" "$SCHEME" --quiet -f "$scm" >/dev/null 2>&1; then
+    if "${TIMEOUT_CMD[@]}" "$SCHEME" --quiet -f "$scm" >/dev/null 2>&1; then
         passed=$((passed + 1))
     else
         failed=$((failed + 1))


### PR DESCRIPTION
## Summary

Repairs shipped-broken examples and — the root cause — makes `make ci` actually **execute** the `.scm` example tree, which only ran at release (`make cd`) before, which is why both breakages shipped unnoticed.

- **`examples/control/exceptions.scm` (C9/#11)** had four independent defects, not the one the review named:
  1. both helpers (`string-contains`, `make-error`) were defined at the *bottom* but used from Example 2 — file execution is `(begin …)`-wrapped with `letrec*` ordering, so a define used before initialization is `#!void`. Relocated above first use.
  2. Example 4's handler returned from a non-continuable `raise`. Wrapped in `call/cc`, escaping via `(k #f)` — which the example's own prose ("handler doesn't return") describes.
  3. Example 6 passed a symbol as `error`'s message (Wile requires a string). Symbol demoted to an irritant.
  4. Example 8 same string-message rule; the guard now keys off the message and reads the value from the irritants.

  All 10 examples now run to `=== Summary ===` at exit 0, so the false `control/exceptions.scm` entry is removed from `examples/.ci-exclude` (its "intentionally demonstrates error conditions" rationale was never true).
- **schelog (C10/#12):** both the documented direct-run command and `make bench-schelog` failed under the immutable-top-level default (schelog `set!`s its own top-level globals and redefines `%append`). Sources are unmodified upstream conformance fixtures, so both paths now pass `-i` with `< /dev/null` to feed the trailing REPL an EOF; `run-extended.sh` drops the `|| true` that swallowed the failure.
- **ci:** `make ci` Go-built the embedding examples but never ran the `.scm` tree — added `test-examples` as a CI stage.
- **`run-examples.sh`** probed for the *presence* of `timeout`, but BSD/MacPorts ship one that rejects `--kill-after`; it now probes that the flag actually works and prefers `gtimeout`.

## Test plan

- [x] `make test-examples` → **Examples: 56 passed, 2 skipped, 0 failed**
- [x] `control/exceptions.scm` runs to its summary at exit 0

Refs: `reviews/2026-07-17/REVIEW.md` C9 (#11), C10 (#12), N5, Phase 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
