### PR TITLE
fix(tokenizer,docs): unbounded hex escape digits; record SRFI-13 deviation

### DIFF
--- a/docs/reference/r7rs-differences.md
+++ b/docs/reference/r7rs-differences.md
@@ -228,43 +228,6 @@ as `caar`/`map`) is rejected with `ErrImmutableBinding`. This is ordinary Scheme
 
 ---
 
-## SRFI-13 Binary Comparisons Return Boolean (Not the Mismatch Index)
-
-**Affected Procedures:** `string=`, `string<`, `string>`, `string<=`,
-`string>=`, `string<>` and their six `-ci` variants, from `(srfi 13)`.
-
-**SRFI-13 says:** these return the index of the first mismatch (or, for
-`string=`, the index one past the end of the compared range) on success, and
-`#f` on failure. The index is what makes them useful as both a predicate and a
-positional probe in one call.
-
-**Wile returns:** `#t` / `#f`.
-
-```scheme
-(import (srfi 13))
-(string= "abc" "abc")   ; SRFI-13: 3      Wile: #t
-(string< "abc" "abd")   ; SRFI-13: 2      Wile: #t
-(string= "abc" "abd")   ; SRFI-13: #f     Wile: #f
-```
-
-**Why:** the boolean contract is what these procedures' own docstrings state
-(`Returns: boolean`, `pkg/stdlib/lib/srfi/13/comparison.scm`) and what the
-bundled test suite pins (`integration/testdata/srfi-13-tests-phase5.scm`). The
-deviation is deliberate and tested, not an oversight — but it was previously
-undocumented, which is the defect this entry fixes.
-
-**Portability impact:** code ported from another Scheme that uses the return
-value positionally (e.g. `(let ((i (string< a b))) ...)`) will silently get `#t`
-where it expects an integer. Boolean-only uses (`if`, `cond`, `and`) port
-unchanged.
-
-**Workaround:** use the R7RS variadic forms (`string=?`, `string<?`, …) when a
-predicate is all that is needed. For a mismatch index, compare positions
-explicitly; `%string-compare-impl` in the same file already computes one
-internally, so exposing it is mechanically available if a caller needs it.
-
----
-
 ## Continuation Value-Count (Splicing, Not Arity-Checked)
 
 **Affected Primitives:** `call-with-current-continuation` / `call/cc` escape

--- a/docs/reference/r7rs-differences.md
+++ b/docs/reference/r7rs-differences.md
@@ -228,6 +228,43 @@ as `caar`/`map`) is rejected with `ErrImmutableBinding`. This is ordinary Scheme
 
 ---
 
+## SRFI-13 Binary Comparisons Return Boolean (Not the Mismatch Index)
+
+**Affected Procedures:** `string=`, `string<`, `string>`, `string<=`,
+`string>=`, `string<>` and their six `-ci` variants, from `(srfi 13)`.
+
+**SRFI-13 says:** these return the index of the first mismatch (or, for
+`string=`, the index one past the end of the compared range) on success, and
+`#f` on failure. The index is what makes them useful as both a predicate and a
+positional probe in one call.
+
+**Wile returns:** `#t` / `#f`.
+
+```scheme
+(import (srfi 13))
+(string= "abc" "abc")   ; SRFI-13: 3      Wile: #t
+(string< "abc" "abd")   ; SRFI-13: 2      Wile: #t
+(string= "abc" "abd")   ; SRFI-13: #f     Wile: #f
+```
+
+**Why:** the boolean contract is what these procedures' own docstrings state
+(`Returns: boolean`, `pkg/stdlib/lib/srfi/13/comparison.scm`) and what the
+bundled test suite pins (`integration/testdata/srfi-13-tests-phase5.scm`). The
+deviation is deliberate and tested, not an oversight — but it was previously
+undocumented, which is the defect this entry fixes.
+
+**Portability impact:** code ported from another Scheme that uses the return
+value positionally (e.g. `(let ((i (string< a b))) ...)`) will silently get `#t`
+where it expects an integer. Boolean-only uses (`if`, `cond`, `and`) port
+unchanged.
+
+**Workaround:** use the R7RS variadic forms (`string=?`, `string<?`, …) when a
+predicate is all that is needed. For a mismatch index, compare positions
+explicitly; `%string-compare-impl` in the same file already computes one
+internally, so exposing it is mechanically available if a caller needs it.
+
+---
+
 ## Continuation Value-Count (Splicing, Not Arity-Checked)
 
 **Affected Primitives:** `call-with-current-continuation` / `call/cc` escape

--- a/pkg/internal/tokenizer/tokenizer_literals.go
+++ b/pkg/internal/tokenizer/tokenizer_literals.go
@@ -64,7 +64,7 @@ func (p *Tokenizer) readHexEscapeToken() {
 	if p.err != nil {
 		return
 	}
-	x, n := p.readUnsignedBaseNInteger(16, 8)
+	x, n := p.readUnsignedBaseNInteger(16, 0)
 	if p.err != nil {
 		return
 	}
@@ -198,7 +198,7 @@ func (p *Tokenizer) readCharacterMnemonicOrCharacterEscapeOrCharacterHexEscape()
 		// R7RS: \x<hex scalar value>; where hex scalar value is any Unicode code point
 		// (0 to 0x10FFFF) except surrogates (0xD800-0xDFFF)
 		p.state = TokenizerStateCharHexEscape
-		x, n := p.readUnsignedBaseNInteger(16, 32) //nolint:errcheck
+		x, n := p.readUnsignedBaseNInteger(16, 0) //nolint:errcheck
 		if n == 0 {
 			p.err = NewTokenizerErrorWithWrap(p.err, MessageInvalidCharacterHexEscape)
 			return utf8.RuneError

--- a/pkg/internal/tokenizer/tokenizer_string_test.go
+++ b/pkg/internal/tokenizer/tokenizer_string_test.go
@@ -696,3 +696,32 @@ func TestLargeTokenScansInLinearTime(t *testing.T) {
 	c.Check(len(toks[0].Value()), qt.Equals, n)
 	c.Check(time.Now().Before(deadline), qt.IsTrue, qt.Commentf("scanning a %d-byte symbol took longer than the linear-time budget", n))
 }
+
+// TestStringHexEscapeUnboundedDigits pins R7RS §7.1.1
+// <hex scalar value> ::= <digit 16>+ (no digit-count bound). A string hex
+// escape with gratuitous leading zeros past the historical 8-digit cap denotes
+// the same code point and must be accepted; validateCodePoint owns the range
+// check. The character path is asserted for parity.
+func TestStringHexEscapeUnboundedDigits(t *testing.T) {
+	tcs := []struct {
+		name  string
+		input string
+		typ   TokenizerState
+		value string
+	}{
+		{name: "string 9 digits", input: `"\x000000041;"`, typ: TokenizerStateString, value: "A"},
+		{name: "string 16 digits", input: `"\x0000000000000041;"`, typ: TokenizerStateString, value: "A"},
+		{name: "char 9 digits", input: `#\x000000041`, typ: TokenizerStateCharHexEscape, value: "A"},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			tok := NewTokenizer(strings.NewReader(tc.input), false)
+			defer tok.Close()
+			token, err := tok.Next()
+			c.Assert(err, qt.IsNil)
+			c.Assert(token.Type(), qt.Equals, tc.typ)
+			c.Assert(token.Value(), qt.Equals, tc.value)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two small conformance items from the 2026-07-17 review (Phase 6).

- **tokenizer (P1/#1):** the string `\x…;` path capped the hex scalar at 8 digits while the character path capped at 32 — inconsistent with each other, and both narrower than R7RS 7.1.1, whose `<hex scalar value> ::= <digit 16>+` has no digit-count bound. `"\x000000041;"` is a valid spelling of `"A"` and was rejected. Both paths now read unbounded digits; `validateCodePoint` already owns the real constraint (`> 0x10FFFF` and surrogates still rejected — unchanged tests prove it).
- **docs (P2/#10):** SRFI-13's binary comparison family is specified to return the first-mismatch index, not a boolean. Wile returns `#t`/`#f`, matching the procedures' own "Returns: boolean" docstrings and pinned by `srfi-13-tests-phase5.scm` — a deliberate, tested deviation that was simply missing from `r7rs-differences.md`. Recorded there with the portability impact (positional uses of the return value silently see `#t`) and the workaround. Returning the actual index is a separate contract-breaking change and is NOT done here (`%string-compare-impl` already computes one if ever wanted).

## Test plan

- [x] `go test` green on `pkg/internal/tokenizer`; new `tokenizer_string_test.go` cases for unbounded hex digits, with the `> 0x10FFFF` / surrogate rejections unchanged
- [x] `make lint` (0 issues) — full gate via CI

Refs: `reviews/2026-07-17/REVIEW.md` P1 (#1), P2 (#10), Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
