### PR TITLE
fix(hygiene): free-template-identifier hygiene on the macro path (D0/D1/D2/D3 + recursive self-ref)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   resolution and the export probe consulted first; imported macros now install into the
   expand frame only (on both the library-internal and top-level import paths). Imported
   macros stay usable.
+- **A free identifier in a macro template now resolves definition-site on the macro path,
+  matching values (R7RS §4.3.2).** A top-level `(define-syntax guard-aux …)` captured
+  `guard`'s private helper — `(guard (e (else 'x)) (raise 'y))` returned the user's
+  transformer instead of `x`. Bootstrap macros/expanders now live in a per-namespace
+  immutable **sealed expand base** (phase 1), so a use-site `define-syntax`,
+  `let-syntax`/`letrec-syntax`, or `import` of a same-named macro **shadows** in the mutable
+  expand child instead of overwriting the pinned binding in place; and macro dispatch consults
+  the template's definition-site pin (after the local `let-syntax` arm, before the use-site
+  arms), so the helper resolves definition-site while a co-introduced keyword still shadows it.
+  This is the private-helper / definition-site guarantee documented for values in
+  `docs/reference/r7rs-differences.md` (Chez two-environment model), now extended to macros;
+  public-macro redefinition is unchanged by intent.
+- **Redefining a core special form now shadows cleanly instead of bricking it.**
+  `(define-syntax let-syntax …)` overwrote the installed primitive-expander slot in place, so
+  every subsequent `(let-syntax …)` failed to compile (`let-syntax` has no fallback). The
+  special-form expanders now install in the sealed expand base, so a user redefine becomes a
+  shadow in the mutable expand child and the user's transformer runs; the original form stays
+  intact for code that does not redefine it.
 - **Release note correction (1.18.0).** The 1.18.0 entry "`channel-select` is
   deterministic when a closed send races a ready receive" described `channel-select`
   as a Scheme primitive. There has never been one; the fix it describes was to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,9 +59,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   expand child instead of overwriting the pinned binding in place; and macro dispatch consults
   the template's definition-site pin (after the local `let-syntax` arm, before the use-site
   arms), so the helper resolves definition-site while a co-introduced keyword still shadows it.
-  This is the private-helper / definition-site guarantee documented for values in
-  `docs/reference/r7rs-differences.md` (Chez two-environment model), now extended to macros;
-  public-macro redefinition is unchanged by intent.
+  The guarantee also covers a helper's **own recursion**: a recursive macro's self-reference
+  (a multi-clause `guard`, a `define-record-type` with fields) is pinned to its own binding, so
+  a use-site redefinition cannot capture the recursion either. This is the private-helper /
+  definition-site guarantee documented for values in `docs/reference/r7rs-differences.md` (Chez
+  two-environment model), now extended to macros; public-macro redefinition is unchanged by
+  intent (a directly-typed reference carries no pin).
 - **Redefining a core special form now shadows cleanly instead of bricking it.**
   `(define-syntax let-syntax …)` overwrote the installed primitive-expander slot in place, so
   every subsequent `(let-syntax …)` failed to compile (`let-syntax` has no fallback). The

--- a/TODO.md
+++ b/TODO.md
@@ -424,6 +424,20 @@ re-confirm each repro before designing a fix.**
     RED (`PWNED` / `let-syntax` "no compiler") and quarantined, #2 confirmed already-GREEN (`c`).
     Arm-trace spike: #1 mis-resolves at **arm 2 (NextPhase)** with a nil pin — pin goes after
     arm 1, before arm 2 (R1-faithful).
+    - **Reorder (execution finding, 2026-07-22):** D3 → phase-0 `sealedBase` regressed the
+      general `Dialect.Forms().Remove()` contract (removed-form expander leaks to runtime value
+      resolution; 3 dialect tests). Resolves design §9 gate #4: phase-0 value frame is NOT
+      collision-free for compile-time handlers. Fix = route D3 into the phase-1 `sealedExpandBase`
+      (design's own contingency); D1 sequenced first, D3 folds into it. Plans updated.
+    - **Phase 1′ DONE (D1 + retargeted D3):** carved per-namespace `sealedExpandBase` (phase-1
+      sealed frame, parent = `sealedBase`); `AtPhase` receiver-branch + `SealedExpandBaseTarget()`
+      route bootstrap macros AND special-form expanders into it; `phaseParent` reparents phase-1
+      only (library frames stay flat islands); enumeration `collect()` added (search + BoundNames).
+      **#3 GREEN** (special forms shadow, not corrupt); 3 dialect removed-form tests GREEN; census
+      retargeted to `sealedExpandBase` (still 47); march-hare + hermetic + climbing-tower GREEN;
+      `,apropos cond` still surfaces bootstrap macros. Gates: lint + build + covercheck (all 41 ≥80%)
+      + `-race` all GREEN. #1 still RED-but-skipped (needs D0+D2). Next: Phase 2′ (D0 reorder + D2
+      pin consult).
 
 - [x] **CHANGELOG now documents scope-keyed global storage** [Docs, S, Done 2026-07-21]: added a
   `[Unreleased] → Changed` entry covering the `8afeb66a…4f73936d` arc and its user-visible

--- a/TODO.md
+++ b/TODO.md
@@ -450,6 +450,20 @@ re-confirm each repro before designing a fix.**
       ratchet: an unpinned expand-bound sibling reference is now a **defect** (was UNCHECKED);
       passes (0 defects). Gates: lint + build + covercheck (all 41 ≥80%) + `-race` GREEN.
       Remaining: Phase 3′ (adversarial import tests + docs + CHANGELOG).
+    - **Phase 4′ DONE (crosscheck remediation + recursive-helper completion, option A):** 5-lens
+      `/crosscheck` verified the topology + D2 sound; found two real gaps the single-clause #1
+      repro masked. (1) The nil-pin census was **vacuous** — its discriminator used the composite
+      `FreeIdKey` (`scope-fingerprint|name`) so `GetGlobalIndex(NewSymbol(name))` always missed;
+      added `match.FreeIdName` and recover the bare name. (2) A recursive helper's **self**-
+      reference (`guard-aux`→`guard-aux`, `define-record-type-impl`→itself; multi-clause guard /
+      record-with-fields) was still capturable — reorder can't pin a self-reference. Fixed with
+      `pinTemplateSelfReferences` (`compile_syntax_rules.go`): after `define-syntax` creates the
+      binding, back-patch every nil-pinned template free-id whose name is the macro's own to that
+      binding (R7RS §4.3.2; preserves create-after-compile so a failed compile leaves no binding).
+      Fixed the whole class uniformly (`and`/`or`/`cond`/`case`/`do`/`define-values`/…). Census now
+      **genuinely load-bearing**: mutation-verified it flags 21 recursive self-refs without the
+      back-patch, 0 with (44→23 nil-pins). Plus convergent hardening (dropped silent-degrade
+      guards + construction-invariant test, `gi.Env` guard, `phaseParent`→method, doc fixes).
 
 - [x] **CHANGELOG now documents scope-keyed global storage** [Docs, S, Done 2026-07-21]: added a
   `[Unreleased] → Changed` entry covering the `8afeb66a…4f73936d` arc and its user-visible

--- a/TODO.md
+++ b/TODO.md
@@ -416,6 +416,14 @@ re-confirm each repro before designing a fix.**
   area (see `memory/` immutable-top-level and hygiene notes; the runtime-phase seal already exists,
   extending it to expand is significant). Redefining an internal bootstrap helper is also an
   uncommon footgun. Needs a maintainer architectural decision rather than a unilateral change.
+  - **In progress 2026-07-22** on `feat/free-template-id-hygiene` per
+    `plans/2026-07-22-free-template-id-hygiene-{design,impl}.local.md` (D3 special-form seal +
+    D1 sealed expand base + D0 helper reorder + D2 macro-dispatch pin consult). Phase-0
+    baselines recorded: nil-pin census = **47 total** (0 runtime-bound; expect **44** after the
+    D0 reorder of the 3 helper edges); march-hare (`TestR7RSConformance`) green; #1/#3 confirmed
+    RED (`PWNED` / `let-syntax` "no compiler") and quarantined, #2 confirmed already-GREEN (`c`).
+    Arm-trace spike: #1 mis-resolves at **arm 2 (NextPhase)** with a nil pin — pin goes after
+    arm 1, before arm 2 (R1-faithful).
 
 - [x] **CHANGELOG now documents scope-keyed global storage** [Docs, S, Done 2026-07-21]: added a
   `[Unreleased] → Changed` entry covering the `8afeb66a…4f73936d` arc and its user-visible

--- a/TODO.md
+++ b/TODO.md
@@ -438,6 +438,17 @@ re-confirm each repro before designing a fix.**
       `,apropos cond` still surfaces bootstrap macros. Gates: lint + build + covercheck (all 41 ≥80%)
       + `-race` all GREEN. #1 still RED-but-skipped (needs D0+D2). Next: Phase 2′ (D0 reorder + D2
       pin consult).
+    - **Phase 2′ DONE (D0 + D2, closes #1):** D0 reordered the sibling helpers (`guard-aux` above
+      `guard`; `define-record-type-impl` above its two delegators) so their pins are non-nil at
+      macro-def time — census dropped **47 → 44** exactly (3 helper edges). D2 threaded the
+      `SyntaxSymbol` into `lookupMacroBinding` and consults the pin AFTER arm 1 (local let-syntax)
+      and BEFORE arm 2 (NextPhase)/arm 3 (library) — mirroring the value-path `tryResolvedBinding`
+      R1 ordering. **#1 GREEN** (`guard`+top-level `guard-aux` → `x`, not `PWNED`); #2 + R1-analog
+      stay GREEN (pin did NOT jump ahead of arm 1); march-hare/ER/§6 cases (generated-macro nil-pin
+      fallthrough, use-site local no-capture, pinned-vs-bare) all GREEN. Census tightened into a
+      ratchet: an unpinned expand-bound sibling reference is now a **defect** (was UNCHECKED);
+      passes (0 defects). Gates: lint + build + covercheck (all 41 ≥80%) + `-race` GREEN.
+      Remaining: Phase 3′ (adversarial import tests + docs + CHANGELOG).
 
 - [x] **CHANGELOG now documents scope-keyed global storage** [Docs, S, Done 2026-07-21]: added a
   `[Unreleased] → Changed` entry covering the `8afeb66a…4f73936d` arc and its user-visible

--- a/TODO.md
+++ b/TODO.md
@@ -401,8 +401,9 @@ re-confirm each repro before designing a fix.**
   different frames, a cross-*kind* same-name clash across two imported libraries (macro `foo`
   vs variable `foo`) is no longer conflict-detected per R7RS §5.6; same-kind clashes still are.
 
-- [ ] **No sealed base above phase 0** [Correctness, M, 2026-07-19 — repro VERIFIED 2026-07-21
-  (top-level, not library); fix DEFERRED as architectural]: **the reported library-import vector
+- [x] **No sealed base above phase 0** [Correctness, M, 2026-07-19; **RESOLVED 2026-07-22** on
+  `feat/free-template-id-hygiene`, commits `2f8052bc`/`8f3079b7`/`f70f6aec` — supersedes the
+  "DEFERRED as architectural" call below with the free-template-id-hygiene arc]: **the reported library-import vector
   does NOT reproduce** — importing a library that rebinds `guard-aux` leaves `(guard …)` intact,
   even inside that library's own body. What DOES reproduce is a **top-level**
   `(define-syntax guard-aux …)`: it then compromises `guard` (`(guard (e (#t 'caught)) (raise 'x))`

--- a/docs/environment/system.md
+++ b/docs/environment/system.md
@@ -285,6 +285,51 @@ These invariants must be maintained:
      value lands on a different binding than the one just created.
      `DefineOwnGlobal` exists so that pairing cannot be written by hand
 
+6. **Sealed base (phase 0) and sealed expand base (phase 1) are per-namespace
+   immutable frames, reached only via the parent chain**
+   - Each `Namespace` owns two sealed frames that are **not** `PhaseRegistry`
+     entries: `sealedBase` (phase 0: Go primitives + sealed stdlib procedures +
+     optimizer `Stable` anchors) and `sealedExpandBase` (phase 1: bootstrap
+     macros + special-form primitive expanders). The mutable phase frames parent
+     to them:
+
+     ```
+     phase 0:  runtime          → sealedBase          → nil
+                                  (prims + sealed procs)
+     phase 1:  expand-child      → sealedExpandBase    → sealedBase → nil
+               (user define-syntax   (bootstrap macros,
+                lands here)           special-form expanders)
+     phase 2+: compile           → sealedBase          → nil
+     ```
+
+   - The carve is **phase-1-only**: `createPhaseEnv` reparents only the expand
+     phase to `sealedExpandBase` (via `phaseParent`), and only for a namespace
+     that owns a sealed base (`base == owner.sealedBase`). A flat
+     `NewChildRuntime` library frame has no sealed base and stays a flat island
+     (library isolation). Phases 2+ parent straight to `sealedBase`, preserving
+     hermeticity and the climbing-tower invariant that higher phases never
+     introduce a phase→phase parent edge.
+   - **Why `sealedExpandBase` is distinct from `sealedBase`, not a reuse.** A
+     compile-time handler (a bootstrap macro, `BindingTypeSyntax`, or a
+     special-form expander, `BindingTypePrimitive`) placed on the phase-0 value
+     frame is reachable by **runtime value resolution** (the runtime frame
+     parents to `sealedBase`). That is a phase confusion: a dialect that removes
+     a form (`Dialect.Forms().Remove`) would then leak the form's
+     `#<primitive-expander:…>` into the value world instead of the name being
+     unbound. The phase-1 `sealedExpandBase` is on the expand chain only, so it is
+     invisible to phase-0 value resolution.
+   - **A top-level `(define-syntax foo …)` shadows, it does not overwrite.** It
+     lands in the mutable expand child (`AtPhase(PhaseExpand)` from the mutable
+     runtime), a different frame from the pinned bootstrap `foo` in
+     `sealedExpandBase`. Bootstrap macros compile with `env == sealedBase`, so
+     their `define-syntax` writes route into `sealedExpandBase` via the
+     `AtPhase` receiver branch; expanders register there directly via
+     `SealedExpandBaseTarget()`.
+   - **Enumeration must collect both.** Because neither sealed frame is a
+     `PhaseRegistry` entry, name/doc walks (`BoundNamesAcrossPhases`, `,apropos`)
+     must `collect(SealedBase())` **and** `collect(SealedExpandBase())` explicitly,
+     or primitive / bootstrap-macro names silently vanish from introspection.
+
 ---
 
 ## Load-Path Stack

--- a/docs/reference/r7rs-differences.md
+++ b/docs/reference/r7rs-differences.md
@@ -205,9 +205,13 @@ same-named macro does **not** capture it:
 The helper macros are sealed in a per-namespace immutable **expand base** (phase 1), the
 macro-phase analogue of the sealed base above, and macro dispatch consults the pin after the
 local `let-syntax` arm and before the use-site arms (so a co-introduced keyword still shadows,
-the R1 invariant). Scope: this is a *private-helper / definition-site* guarantee, not "freeze
-every public macro" — a user who redefines a public macro like `cond` still sees their
-redefinition in code they subsequently write that expands through it.
+the R1 invariant). This holds for a helper's **own recursion** as well: a recursive macro's
+template reference to itself (e.g. `guard-aux`'s multi-clause recursion, `define-record-type`
+building one accessor per field) resolves to its own definition-site binding, so a use-site
+redefinition of the private helper cannot capture the recursion. Scope: this is a
+*private-helper / definition-site* guarantee, not "freeze every public macro" — a user who
+redefines a public macro like `cond` still sees their redefinition in code they subsequently
+write that expands through it (a directly-typed reference carries no pin).
 
 **define/set! asymmetry on sealed names.** `(define caar …)` *introduces* a child-frame
 shadow (closures keep the sealed binding); `(set! caar …)` *mutates the existing* binding

--- a/docs/reference/r7rs-differences.md
+++ b/docs/reference/r7rs-differences.md
@@ -188,6 +188,27 @@ This mirrors Chez's sealed-base + interaction-environment split: code already co
 against the base does not observe later interactive redefines. It is an intentional,
 documented deviation from R7RS's single mutable top level.
 
+**Free template identifiers resolve definition-site — on the macro path too.** The same
+definition-site pinning applies to a free identifier in a `syntax-rules` template, for macro
+references as well as value references (R7RS §4.3.2 referential transparency). A bootstrap
+macro whose template references a private helper macro — e.g. `guard` referencing `guard-aux`
+— resolves that helper to its definition-site binding, so a later use-site
+`(define-syntax guard-aux …)`, `let-syntax`/`letrec-syntax` binder, or `import` of a
+same-named macro does **not** capture it:
+
+```scheme
+(define-syntax guard-aux (syntax-rules () ((_ . r) 'PWNED)))
+(guard (e (else 'x)) (raise 'y))   ; => x   (guard's own guard-aux, not the redefinition)
+(guard-aux ignored)                ; => PWNED  (a direct call sees the redefinition)
+```
+
+The helper macros are sealed in a per-namespace immutable **expand base** (phase 1), the
+macro-phase analogue of the sealed base above, and macro dispatch consults the pin after the
+local `let-syntax` arm and before the use-site arms (so a co-introduced keyword still shadows,
+the R1 invariant). Scope: this is a *private-helper / definition-site* guarantee, not "freeze
+every public macro" — a user who redefines a public macro like `cond` still sees their
+redefinition in code they subsequently write that expands through it.
+
 **define/set! asymmetry on sealed names.** `(define caar …)` *introduces* a child-frame
 shadow (closures keep the sealed binding); `(set! caar …)` *mutates the existing* binding
 in place (closures observe it) — and in the compiled program, `set!` of a `Stable` sealed

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -44,7 +44,7 @@ func TestFreeTemplateIdHygiene(t *testing.T) {
 			code: `(define-syntax guard-aux (syntax-rules () ((_ r ...) 'PWNED)))
 			       (guard (e (else 'x)) (raise 'y))`,
 			expected: "x",
-			closedBy: "Phase 3 (D0+D1+D2)",
+			closedBy: "", // closed by Phase 2′ (D0 pin population + D2 pin consultation)
 		},
 		{
 			name: "guard2_letsyntax_local_no_capture",
@@ -109,4 +109,64 @@ func TestFreeTemplateIdHygiene_CoIntroducedLetSyntaxBeatsGlobalPin(t *testing.T)
 	result, err := engine.EvalMultiple(context.Background(), code)
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.SchemeString(), qt.Equals, "LOCAL") // the co-introduced helper, not 'GLOBAL
+}
+
+// TestFreeTemplateIdHygiene_Section6Cases covers the design's §6 soundness cases for the
+// D2 pin consultation beyond #1 (which is in TestFreeTemplateIdHygiene). Each is green after
+// Phase 2′ (D0+D2) and must stay green.
+func TestFreeTemplateIdHygiene_Section6Cases(t *testing.T) {
+	tcs := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			// §6 case 1: a macro that GENERATES an inner macro referencing a define the
+			// outer expansion introduces. The generated reference has no stable def-time
+			// pin (nil), so D2 must fall THROUGH to the current use-site walk to reach the
+			// introduced define. In-process analogue of march-hare/jabberwocky.
+			name: "case1_generated_macro_nil_pin_fallthrough",
+			code: `(define-syntax make-getter
+			         (syntax-rules ()
+			           ((_ name)
+			            (begin
+			              (define secret 42)
+			              (define-syntax name (syntax-rules () ((_) secret)))))))
+			       (make-getter get-secret)
+			       (get-secret)`,
+			expected: "42",
+		},
+		{
+			// §6 case 2 (hygiene direction): a USE-SITE local variable named like a
+			// template free-id (a macro) must NOT capture it. guard's template references
+			// guard-aux; a use-site (let ((guard-aux …))) variable of a different scope does
+			// not shadow it — hasLocalVariableBinding is false, the pin fires, guard works.
+			name: "case2b_use_site_local_var_no_capture",
+			code: `(let ((guard-aux 'i-am-a-variable))
+			         (guard (e (else 'caught)) (raise 'x)))`,
+			expected: "caught",
+		},
+		{
+			// §6 case 4: a pinned template reference and a bare use-site reference of the
+			// same name resolve to DIFFERENT bindings. guard's template ref to guard-aux is
+			// pinned to the sealed bootstrap guard-aux (so guard still works); a direct
+			// (guard-aux …) call reaches the user's top-level redefinition. present/absent
+			// pin IS the def-site/use-site split.
+			name: "case4_pinned_vs_bare_different_bindings",
+			code: `(define-syntax guard-aux (syntax-rules () ((_ . r) 'USER-GUARD-AUX)))
+			       (list (guard (e (else 'guard-works)) (raise 'x))
+			             (guard-aux ignored))`,
+			expected: "(guard-works USER-GUARD-AUX)",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
+			c.Assert(err, qt.IsNil)
+			result, err := engine.EvalMultiple(context.Background(), tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.expected)
+		})
+	}
 }

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Aaron Alpar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/aalpar/wile/pkg/wile"
+)
+
+// TestFreeTemplateIdHygiene exercises R7RS §4.3.2: a free identifier in a macro
+// template resolves to the binding in effect at the macro's DEFINITION site, and a
+// same-named binding introduced at the USE site does not capture it.
+//
+// Each case is a sequence of top-level forms; EvalMultiple runs them in order and
+// returns the last value. A fresh engine per case isolates the #1/#3 mutations (they
+// mutate an installed slot and would cross-contaminate a shared engine).
+func TestFreeTemplateIdHygiene(t *testing.T) {
+	tcs := []struct {
+		name     string
+		code     string
+		expected string
+		closedBy string // the phase that flips this GREEN; "" = green today (guard)
+	}{
+		{
+			name: "exposure1_toplevel_guard_aux_hijack",
+			// #1: a top-level (define-syntax guard-aux ...) must NOT capture guard's
+			// private helper. guard(else) catches the raise and yields 'x.
+			code: `(define-syntax guard-aux (syntax-rules () ((_ r ...) 'PWNED)))
+			       (guard (e (else 'x)) (raise 'y))`,
+			expected: "x",
+			closedBy: "Phase 3 (D0+D1+D2)",
+		},
+		{
+			name: "guard2_letsyntax_local_no_capture",
+			// Filed as #2 but does NOT reproduce on b96f8b53: a use-site
+			// (let-syntax ((guard-aux ...))) carries its own intro scope, which is not a
+			// subset of guard's template free-id def-site scope, so arm 1 already refuses
+			// it (design §1.2). GREEN today; a standing guard that D2 must not regress.
+			code: `(let-syntax ((guard-aux (syntax-rules () ((_ . a) 'hijacked))))
+			         (guard (e (#t 'c)) (raise 'b)))`,
+			expected: "c",
+			closedBy: "", // green guard: already correct, never quarantined
+		},
+		{
+			name: "exposure3_letsyntax_special_form_corruption",
+			// #3: redefining the let-syntax special form must SHADOW cleanly, not brick
+			// it. Before D3 the user define-syntax reuses the installed slot
+			// (CreateGlobalBinding dedups ignoring BindingType) and SetOwnGlobalValue
+			// overwrites the Primitive-typed slot in place, so every subsequent
+			// (let-syntax ...) is rejected by lookup and ERRORS (err != nil). After D3 the
+			// redefine lands in the mutable child as a BindingTypeSyntax shadow and the
+			// user's transformer runs.
+			code: `(define-syntax let-syntax (syntax-rules () ((_ bindings body ...) 'shadowed)))
+			       (let-syntax ((tmp (syntax-rules () ((_) 42)))) (tmp))`,
+			expected: "shadowed",
+			closedBy: "Phase 1 (D3)",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.closedBy != "" {
+				t.Skipf("RED until %s — free-template-id-hygiene (%s)", tc.closedBy, tc.name)
+			}
+			c := qt.New(t)
+			engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
+			c.Assert(err, qt.IsNil)
+			result, err := engine.EvalMultiple(context.Background(), tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.expected)
+		})
+	}
+}
+
+// TestFreeTemplateIdHygiene_CoIntroducedLetSyntaxBeatsGlobalPin is the R1-analog on
+// the macro dispatch path: a co-introduced let-syntax helper must win over a
+// same-named definition-site GLOBAL macro pin. Mirrors the value-path R1 fix
+// (25d832c0). If this ever fails after D2, the pin was inserted BEFORE the local
+// let-syntax arm — the R1 "jumps the queue" mistake. Green today (no pin consulted →
+// co-introduced wins via arm 1); must stay green after D2.
+func TestFreeTemplateIdHygiene_CoIntroducedLetSyntaxBeatsGlobalPin(t *testing.T) {
+	c := qt.New(t)
+	engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
+	c.Assert(err, qt.IsNil)
+	code := `
+	  ;; a def-time GLOBAL macro named helper
+	  (define-syntax helper (syntax-rules () ((_) 'GLOBAL)))
+	  ;; a macro whose template co-introduces its OWN let-syntax helper of the same name
+	  (define-syntax uses-own-helper
+	    (syntax-rules ()
+	      ((_) (let-syntax ((helper (syntax-rules () ((_) 'LOCAL))))
+	             (helper)))))
+	  (uses-own-helper)`
+	result, err := engine.EvalMultiple(context.Background(), code)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.SchemeString(), qt.Equals, "LOCAL") // the co-introduced helper, not 'GLOBAL
+}

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -170,3 +170,58 @@ func TestFreeTemplateIdHygiene_Section6Cases(t *testing.T) {
 		})
 	}
 }
+
+// TestFreeTemplateIdHygiene_Adversarial exercises additional use-site capture vectors that
+// must NOT hijack a bootstrap macro's private helper. They are standing guards that the D1/D2
+// changes must not regress. Clauses use (#t …) rather than (else …): the else auxiliary-syntax
+// literal does not resolve inside a let-syntax scope (a pre-existing limitation, present on
+// master b96f8b53 and unrelated to this arc — the #2 guard uses the same workaround), so an
+// (else …) clause here would fail for a reason orthogonal to guard-aux capture. The
+// library-import vector never reproduced (TODO "No sealed base above phase 0") and needs a
+// library registry the in-process EvalMultiple harness does not wire up; it is left uncovered.
+func TestFreeTemplateIdHygiene_Adversarial(t *testing.T) {
+	tcs := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			// A use-site nested let-syntax binding guard-aux must not capture (a variant of
+			// the #2 guard: the binder's intro scope is not a subset of guard's def-site scope).
+			name: "nested_let_syntax_no_capture",
+			code: `(let ()
+			         (let-syntax ((guard-aux (syntax-rules () ((_ . r) 'HIJACK))))
+			           (guard (e (#t 'safe)) (raise 'x))))`,
+			expected: "safe",
+		},
+		{
+			// Same via letrec-syntax.
+			name: "letrec_syntax_no_capture",
+			code: `(letrec-syntax ((guard-aux (syntax-rules () ((_ . r) 'HIJACK))))
+			         (guard (e (#t 'safe)) (raise 'x)))`,
+			expected: "safe",
+		},
+		{
+			// A macro-generating macro that introduces a helper of a colliding name in its
+			// output. guard used in the generated body still resolves guard-aux def-site.
+			name: "macro_generating_macro_colliding_helper",
+			code: `(define-syntax with-evil-guard-aux
+			         (syntax-rules ()
+			           ((_ body)
+			            (let-syntax ((guard-aux (syntax-rules () ((_ . r) 'HIJACK))))
+			              body))))
+			       (with-evil-guard-aux (guard (e (#t 'safe)) (raise 'x)))`,
+			expected: "safe",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
+			c.Assert(err, qt.IsNil)
+			result, err := engine.EvalMultiple(context.Background(), tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.expected)
+		})
+	}
+}

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -171,6 +171,50 @@ func TestFreeTemplateIdHygiene_Section6Cases(t *testing.T) {
 	}
 }
 
+// TestFreeTemplateIdHygiene_RecursiveHelperSelfReference covers the recursive private-helper
+// case: a bootstrap helper macro (guard-aux, define-record-type-impl) references ITSELF in its
+// template. That self-reference is collected before the macro's own binding exists, so it was
+// nil-pinned and captured by a use-site redefinition — the reported #1 bug generalized to the
+// recursion-firing path (multi-clause guard, a record with fields), which D0's reorder alone
+// cannot pin (a macro cannot be defined before itself). Closed by pinning a template's
+// self-reference to the macro's own definition-site binding after it is created
+// (compile_define_syntax.go). #1's single-else / zero-field cases do not fire the recursion.
+func TestFreeTemplateIdHygiene_RecursiveHelperSelfReference(t *testing.T) {
+	tcs := []struct {
+		name     string
+		code     string
+		expected string
+	}{
+		{
+			// Multi-clause guard forces guard-aux to recurse via its own name. A use-site
+			// (define-syntax guard-aux …) must not capture that recursion.
+			name: "multiclause_guard_guard_aux_recursion_no_capture",
+			code: `(define-syntax guard-aux (syntax-rules () ((_ . r) 'PWNED)))
+			       (guard (e (#f 'first) (#t 'second)) (raise 'z))`,
+			expected: "second",
+		},
+		{
+			// A record with fields forces define-record-type-impl to recurse (one step per
+			// field). A use-site redefinition of the private impl helper must not capture it.
+			name: "record_with_fields_impl_recursion_no_capture",
+			code: `(define-syntax define-record-type-impl (syntax-rules () ((_ x ...) 'PWNED)))
+			       (define-record-type point (make-point x y) point? (x px) (y py))
+			       (px (make-point 3 4))`,
+			expected: "3",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
+			c.Assert(err, qt.IsNil)
+			result, err := engine.EvalMultiple(context.Background(), tc.code)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.SchemeString(), qt.Equals, tc.expected)
+		})
+	}
+}
+
 // TestFreeTemplateIdHygiene_Adversarial exercises additional use-site capture vectors that
 // must NOT hijack a bootstrap macro's private helper. They are standing guards that the D1/D2
 // changes must not regress. Clauses use (#t …) rather than (else …): the else auxiliary-syntax

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -35,7 +35,6 @@ func TestFreeTemplateIdHygiene(t *testing.T) {
 		name     string
 		code     string
 		expected string
-		closedBy string // the phase that flips this GREEN; "" = green today (guard)
 	}{
 		{
 			name: "exposure1_toplevel_guard_aux_hijack",
@@ -44,18 +43,16 @@ func TestFreeTemplateIdHygiene(t *testing.T) {
 			code: `(define-syntax guard-aux (syntax-rules () ((_ r ...) 'PWNED)))
 			       (guard (e (else 'x)) (raise 'y))`,
 			expected: "x",
-			closedBy: "", // closed by Phase 2′ (D0 pin population + D2 pin consultation)
 		},
 		{
 			name: "guard2_letsyntax_local_no_capture",
 			// Filed as #2 but does NOT reproduce on b96f8b53: a use-site
 			// (let-syntax ((guard-aux ...))) carries its own intro scope, which is not a
 			// subset of guard's template free-id def-site scope, so arm 1 already refuses
-			// it (design §1.2). GREEN today; a standing guard that D2 must not regress.
+			// it (design §1.2). A standing guard that D2 must not regress.
 			code: `(let-syntax ((guard-aux (syntax-rules () ((_ . a) 'hijacked))))
 			         (guard (e (#t 'c)) (raise 'b)))`,
 			expected: "c",
-			closedBy: "", // green guard: already correct, never quarantined
 		},
 		{
 			name: "exposure3_letsyntax_special_form_corruption",
@@ -69,14 +66,10 @@ func TestFreeTemplateIdHygiene(t *testing.T) {
 			code: `(define-syntax let-syntax (syntax-rules () ((_ bindings body ...) 'shadowed)))
 			       (let-syntax ((tmp (syntax-rules () ((_) 42)))) (tmp))`,
 			expected: "shadowed",
-			closedBy: "", // closed by Phase 1′ (D1+D3): special-form expanders now in the sealed expand base
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.closedBy != "" {
-				t.Skipf("RED until %s — free-template-id-hygiene (%s)", tc.closedBy, tc.name)
-			}
 			c := qt.New(t)
 			engine, err := wile.NewEngine(context.Background(), wile.WithProfile(wile.KitchenSink))
 			c.Assert(err, qt.IsNil)

--- a/integration/free_template_id_hygiene_test.go
+++ b/integration/free_template_id_hygiene_test.go
@@ -69,7 +69,7 @@ func TestFreeTemplateIdHygiene(t *testing.T) {
 			code: `(define-syntax let-syntax (syntax-rules () ((_ bindings body ...) 'shadowed)))
 			       (let-syntax ((tmp (syntax-rules () ((_) 42)))) (tmp))`,
 			expected: "shadowed",
-			closedBy: "Phase 1 (D3)",
+			closedBy: "", // closed by Phase 1′ (D1+D3): special-form expanders now in the sealed expand base
 		},
 	}
 	for _, tc := range tcs {

--- a/pkg/environment/environment_frame.go
+++ b/pkg/environment/environment_frame.go
@@ -246,6 +246,13 @@ func (p *EnvironmentFrame) TopLevel() *EnvironmentFrame {
 // Phase 0 is runtime, phase 1 is expansion (for-syntax), phase 2 is compile-time, etc.
 // Negative phases (e.g., -1 for for-template) are also supported.
 //
+// Phase 1 is RECEIVER-DEPENDENT: for the sealed-base receiver it resolves to the
+// namespace's sealedExpandBase (the sealed sibling that holds bootstrap macros/expanders);
+// for every other receiver, and for every other phase, it resolves through the shared
+// PhaseRegistry. This is what routes a bootstrap-macro define-syntax (compiled with env ==
+// sealedBase) into the immutable frame while user code (env == the mutable runtime) lands in
+// the mutable expand child.
+//
 // This is the primary method for cross-phase access with O(1) lookup time.
 // The environment must have been created via NewNamespace().
 func (p *EnvironmentFrame) AtPhase(phase Phase) *EnvironmentFrame {
@@ -254,8 +261,11 @@ func (p *EnvironmentFrame) AtPhase(phase Phase) *EnvironmentFrame {
 	// AtPhase(PhaseExpand). Route those — and only those, receiver == the sealed base — into
 	// the sealed expand base, so a bootstrap macro is immutable while a user define-syntax
 	// (compiled with env == the mutable runtime, guard false) shadows in the mutable expand
-	// child. Symmetric with SealedBaseTarget's ns.runtime == p keying.
-	if phase == PhaseExpand && p.namespace != nil && p.namespace.sealedBase == p && p.namespace.sealedExpandBase != nil {
+	// child. Symmetric with SealedBaseTarget's ns.runtime == p keying. sealedExpandBase is
+	// non-nil whenever sealedBase is (both built together in wireRuntimeFrames), so this does
+	// not guard it — a broken construction invariant should fail loud downstream, not silently
+	// route bootstrap macros into the mutable child.
+	if phase == PhaseExpand && p.namespace != nil && p.namespace.sealedBase == p {
 		return p.namespace.sealedExpandBase
 	}
 	topLevel := p.TopLevel()
@@ -1029,11 +1039,15 @@ func (p *EnvironmentFrame) SealedBaseTarget() *EnvironmentFrame {
 // (NewChildRuntime, which has no sealed expand base) it is the frame's own expand phase,
 // preserving the pre-carve target (env.Expand()). Parallels SealedBaseTarget (phase 0) for the
 // expand phase. It is direct (no AtPhase dependency), so the expander registration and the
-// bootstrap-macro AtPhase redirect are independent mechanisms into the same frame. See
+// bootstrap-macro AtPhase redirect are independent mechanisms into the same frame. Mirrors
+// SealedBaseTarget's ns.runtime == p keying (and, like it, trusts the construction invariant:
+// sealedExpandBase is non-nil whenever runtime is, both built together in wireRuntimeFrames —
+// a broken invariant fails loud at the bootstrap install site, it does not silently degrade
+// the namespace-owning path to the mutable frame). See
 // plans/2026-07-22-free-template-id-hygiene-impl.local.md (D1+D3).
 func (p *EnvironmentFrame) SealedExpandBaseTarget() *EnvironmentFrame {
 	ns := p.namespace
-	if ns != nil && ns.runtime == p && ns.sealedExpandBase != nil {
+	if ns != nil && ns.runtime == p {
 		return ns.sealedExpandBase
 	}
 	return p.Expand()

--- a/pkg/environment/environment_frame.go
+++ b/pkg/environment/environment_frame.go
@@ -249,6 +249,15 @@ func (p *EnvironmentFrame) TopLevel() *EnvironmentFrame {
 // This is the primary method for cross-phase access with O(1) lookup time.
 // The environment must have been created via NewNamespace().
 func (p *EnvironmentFrame) AtPhase(phase Phase) *EnvironmentFrame {
+	// Bootstrap macros compile with env == sealedBase (LoadBootstrapCore routes their load
+	// through runtimeTarget); their define-syntax writes go to p.env.NextPhase() ==
+	// AtPhase(PhaseExpand). Route those — and only those, receiver == the sealed base — into
+	// the sealed expand base, so a bootstrap macro is immutable while a user define-syntax
+	// (compiled with env == the mutable runtime, guard false) shadows in the mutable expand
+	// child. Symmetric with SealedBaseTarget's ns.runtime == p keying.
+	if phase == PhaseExpand && p.namespace != nil && p.namespace.sealedBase == p && p.namespace.sealedExpandBase != nil {
+		return p.namespace.sealedExpandBase
+	}
 	topLevel := p.TopLevel()
 	if topLevel.phases == nil {
 		panic(werr.WrapForeignErrorf(
@@ -1011,4 +1020,21 @@ func (p *EnvironmentFrame) SealedBaseTarget() *EnvironmentFrame {
 		return ns.sealedBase
 	}
 	return p
+}
+
+// SealedExpandBaseTarget returns the frame that should receive sealed (immutable) EXPAND-phase
+// bindings — the special-form primitive expanders — when a registry is applied with this frame
+// as its target. For a namespace-owning runtime frame (this frame == its namespace's Runtime())
+// that is the namespace's sealed EXPAND base (phase 1); for a flat library frame
+// (NewChildRuntime, which has no sealed expand base) it is the frame's own expand phase,
+// preserving the pre-carve target (env.Expand()). Parallels SealedBaseTarget (phase 0) for the
+// expand phase. It is direct (no AtPhase dependency), so the expander registration and the
+// bootstrap-macro AtPhase redirect are independent mechanisms into the same frame. See
+// plans/2026-07-22-free-template-id-hygiene-impl.local.md (D1+D3).
+func (p *EnvironmentFrame) SealedExpandBaseTarget() *EnvironmentFrame {
+	ns := p.namespace
+	if ns != nil && ns.runtime == p && ns.sealedExpandBase != nil {
+		return ns.sealedExpandBase
+	}
+	return p.Expand()
 }

--- a/pkg/environment/environment_frame_test.go
+++ b/pkg/environment/environment_frame_test.go
@@ -322,8 +322,11 @@ func TestEnvironmentFrame_PhaseHierarchy(t *testing.T) {
 	qt.Assert(t, compile.GlobalEnvironment(), qt.Not(qt.Equals), expand.GlobalEnvironment())
 
 	// Phase environments parent to the frozen sealed base (hermetic), skipping the
-	// mutable runtime frame: a phase-1/2 lookup cannot see phase-0 user defines.
-	qt.Assert(t, expand.Parent(), qt.Equals, topLevel.Namespace().SealedBase())
+	// mutable runtime frame: a phase-1/2 lookup cannot see phase-0 user defines. Phase 1
+	// (expand) parents one level further, to the sealed EXPAND base (D1), which parents to
+	// the phase-0 sealed base; phase 2 (compile) parents straight to the sealed base.
+	qt.Assert(t, expand.Parent(), qt.Equals, topLevel.Namespace().SealedExpandBase())
+	qt.Assert(t, expand.Parent().Parent(), qt.Equals, topLevel.Namespace().SealedBase())
 	qt.Assert(t, compile.Parent(), qt.Equals, topLevel.Namespace().SealedBase())
 
 	// After the sealed-base carve, TopLevel() returns the structural root — the

--- a/pkg/environment/namespace.go
+++ b/pkg/environment/namespace.go
@@ -212,6 +212,19 @@ type Namespace struct {
 	// a report namespace copies the parent's into its own (see NewSchemeReportNamespace).
 	sealedBase *EnvironmentFrame
 
+	// sealedExpandBase is the per-NAMESPACE immutable EXPAND frame (phase 1): bootstrap
+	// macros + special-form primitive expanders, parent = sealedBase. It is the lexical
+	// parent of the mutable expand child (envs[PhaseExpand]); it is NOT a PhaseRegistry
+	// entry, reached only via the parent chain, mirroring sealedBase at phase 0. It makes a
+	// top-level (define-syntax foo …) shadow in the mutable child rather than overwrite the
+	// pinned bootstrap macro/expander in place, AND keeps compile-time handlers off the
+	// phase-0 value frame (a handler there is reachable by runtime value resolution and leaks
+	// a dialect-removed form's #<primitive-expander:…> into the value world). Fresh (empty)
+	// per namespace; a report namespace gets a fresh one too, matching that
+	// scheme-report-environment carries no bootstrap macros. See
+	// plans/2026-07-22-free-template-id-hygiene-impl.local.md (D1+D3).
+	sealedExpandBase *EnvironmentFrame
+
 	// envMap is an optional virtual environment variable map.
 	// When non-nil, envvars primitives read from this map instead of
 	// the process environment (os.Getenv/os.Environ), bypassing the
@@ -300,6 +313,16 @@ func (p *Namespace) SealedBase() *EnvironmentFrame {
 	return p.sealedBase
 }
 
+// SealedExpandBase returns this Namespace's immutable sealed EXPAND-phase frame (phase 1):
+// bootstrap macros and special-form primitive expanders, lexical parent of the mutable expand
+// child. PER-NAMESPACE (like SealedBase), reached only via the parent chain, never a
+// PhaseRegistry entry. Enumeration sites (,apropos, REPL completion) must collect it explicitly
+// or bootstrap-macro names/docs vanish from introspection. See
+// plans/2026-07-22-free-template-id-hygiene-impl.local.md (D1).
+func (p *Namespace) SealedExpandBase() *EnvironmentFrame {
+	return p.sealedExpandBase
+}
+
 // BoundSymbolNames returns a freshly-consed list of every symbol bound in the
 // namespace's runtime, spanning BOTH the mutable runtime global (user defines) and
 // the sealed base (primitives + sealed stdlib procedures). It is the shared body of
@@ -366,6 +389,7 @@ func (p *Namespace) BoundNamesAcrossPhases() []string {
 		collect(p.phases.Get(phase))
 	}
 	collect(p.sealedBase)
+	collect(p.sealedExpandBase) // phase-1 sealed frame: bootstrap macros/expanders, not a phase entry
 	sort.Strings(names)
 	return names
 }
@@ -1074,6 +1098,19 @@ func wireRuntimeFrames(ns *Namespace, sealedGlobal, mutableGlobal *GlobalEnviron
 		phaseLevel: PhaseRuntime,
 		namespace:  ns,
 	}
+	// sealedExpandBase is the phase-1 sibling of sealedBase: the immutable home of bootstrap
+	// macros and special-form primitive expanders. Parent = sealedBase; a fresh, empty global
+	// (bootstrap fills it for a live engine, or it stays empty for a report namespace, which
+	// carries no bootstrap macros). Built unconditionally here — the single wireRuntimeFrames
+	// funnel — so every namespace-builder (NewNamespace, NewChildNamespace/profile,
+	// NewSchemeReportNamespace) gets it; the WithStableBasePrimitives opt-in-skip is the
+	// cautionary precedent for NOT gating this behind an option.
+	ns.sealedExpandBase = &EnvironmentFrame{
+		parent:     ns.sealedBase,
+		global:     newGlobalEnvironmentFrameForNamespace(ns),
+		phaseLevel: PhaseExpand,
+		namespace:  ns,
+	}
 	ns.runtime = &EnvironmentFrame{
 		parent:     ns.sealedBase,
 		global:     mutableGlobal,
@@ -1083,6 +1120,7 @@ func wireRuntimeFrames(ns *Namespace, sealedGlobal, mutableGlobal *GlobalEnviron
 	ns.phases = newPhaseRegistryForNamespace(ns) // envs[PhaseRuntime] = ns.runtime
 	ns.runtime.phases = ns.phases
 	ns.sealedBase.phases = ns.phases
+	ns.sealedExpandBase.phases = ns.phases
 }
 
 // newPhaseRegistryForChild creates a PhaseRegistry for a child environment

--- a/pkg/environment/phase_registry.go
+++ b/pkg/environment/phase_registry.go
@@ -143,7 +143,7 @@ func (p *PhaseRegistry) createPhaseEnv(phase Phase) *EnvironmentFrame {
 		// define-syntax shadows in this mutable child.
 		// See plans/2026-07-10-hermetic-phases-core-impl.local.md and
 		// plans/2026-07-22-free-template-id-hygiene-impl.local.md.
-		parent:     phaseParent(p, phase),
+		parent:     p.phaseParent(phase),
 		global:     global,
 		phaseLevel: phase,
 		phases:     p,
@@ -159,10 +159,11 @@ func (p *PhaseRegistry) createPhaseEnv(phase Phase) *EnvironmentFrame {
 // phase->phase parent edge. The reparent applies ONLY to a namespace that OWNS a sealed base
 // (base == p.owner.sealedBase): a flat NewChildRuntime library frame's SealedBaseTarget() is the
 // frame itself and it has no sealed expand base, so it stays a flat island (guarding library
-// isolation).
-func phaseParent(p *PhaseRegistry, phase Phase) *EnvironmentFrame {
+// isolation). base == p.owner.sealedBase already implies sealedExpandBase is non-nil (both built
+// together in wireRuntimeFrames), so it is not guarded here.
+func (p *PhaseRegistry) phaseParent(phase Phase) *EnvironmentFrame {
 	base := p.envs[PhaseRuntime].SealedBaseTarget()
-	if phase == PhaseExpand && p.owner != nil && p.owner.sealedExpandBase != nil && base == p.owner.sealedBase {
+	if phase == PhaseExpand && p.owner != nil && base == p.owner.sealedBase {
 		return p.owner.sealedExpandBase
 	}
 	return base

--- a/pkg/environment/phase_registry.go
+++ b/pkg/environment/phase_registry.go
@@ -138,14 +138,34 @@ func (p *PhaseRegistry) createPhaseEnv(phase Phase) *EnvironmentFrame {
 		// returns the frozen sealedBase — skipping user defines + phase-0 imports,
 		// which is the hermeticity cut. For a flat NewChildRuntime library frame
 		// it returns the frame itself, leaving library visibility unchanged.
-		// See plans/2026-07-10-hermetic-phases-core-impl.local.md.
-		parent:     p.envs[PhaseRuntime].SealedBaseTarget(),
+		// Phase 1 (expand) reparents one level further to the sealed EXPAND base
+		// (phaseParent) so bootstrap macros/expanders are immutable while a user
+		// define-syntax shadows in this mutable child.
+		// See plans/2026-07-10-hermetic-phases-core-impl.local.md and
+		// plans/2026-07-22-free-template-id-hygiene-impl.local.md.
+		parent:     phaseParent(p, phase),
 		global:     global,
 		phaseLevel: phase,
 		phases:     p,
 		namespace:  p.owner,
 	}
 	return q
+}
+
+// phaseParent selects a phase frame's lexical parent. Phase 1 (expand) parents to the sealed
+// EXPAND base so bootstrap macros/expanders are immutable while a user define-syntax shadows in
+// the mutable child; every other phase parents straight to the phase-0 sealed-base target,
+// preserving hermeticity and the climbing-tower invariant that higher phases never introduce a
+// phase->phase parent edge. The reparent applies ONLY to a namespace that OWNS a sealed base
+// (base == p.owner.sealedBase): a flat NewChildRuntime library frame's SealedBaseTarget() is the
+// frame itself and it has no sealed expand base, so it stays a flat island (guarding library
+// isolation).
+func phaseParent(p *PhaseRegistry, phase Phase) *EnvironmentFrame {
+	base := p.envs[PhaseRuntime].SealedBaseTarget()
+	if phase == PhaseExpand && p.owner != nil && p.owner.sealedExpandBase != nil && base == p.owner.sealedBase {
+		return p.owner.sealedExpandBase
+	}
+	return base
 }
 
 // Phases returns all currently instantiated phase levels.

--- a/pkg/environment/phase_registry_test.go
+++ b/pkg/environment/phase_registry_test.go
@@ -95,19 +95,25 @@ func TestPhaseRegistry_Phases(t *testing.T) {
 func TestPhaseRegistry_PhaseEnvParentsToSealedBase(t *testing.T) {
 	topLevel := NewNamespaceFrame() // ns.runtime
 	sealedBase := topLevel.Namespace().SealedBase()
+	sealedExpandBase := topLevel.Namespace().SealedExpandBase()
 
 	phase1 := topLevel.phases.GetOrCreate(PhaseExpand)
 	phase2 := topLevel.phases.GetOrCreate(PhaseCompile)
 
-	// Phase frames parent to the frozen sealed base (hermetic), NOT the mutable
-	// runtime frame.
-	qt.Assert(t, phase1.Parent(), qt.Equals, sealedBase)
-	qt.Assert(t, phase2.Parent(), qt.Equals, sealedBase)
+	// Phase 1 (expand) parents to the sealed EXPAND base (D1), which in turn parents to
+	// the phase-0 sealed base — the new middle frame. Bootstrap macros/expanders live in
+	// sealedExpandBase, immutable, while a user define-syntax shadows in this mutable
+	// child. Every other phase parents straight to the phase-0 sealed base (hermetic),
+	// NOT the mutable runtime frame — confirming the carve is phase-1-only.
+	qt.Assert(t, phase1.Parent(), qt.Equals, sealedExpandBase)     // was: sealedBase
+	qt.Assert(t, sealedExpandBase.Parent(), qt.Equals, sealedBase) // NEW middle frame
+	qt.Assert(t, phase2.Parent(), qt.Equals, sealedBase)           // unchanged (phase-1-only radius)
 	qt.Assert(t, phase1.Parent(), qt.Not(qt.Equals), topLevel)
 
 	// Climbing-tower hermeticity: higher phases created on demand (the climb adds
 	// HIGHER siblings) must ALSO parent to the frozen sealed base, never to a lower
-	// phase frame — the climb must never reintroduce a phase->phase parent edge.
+	// phase frame — the climb must never reintroduce a phase->phase parent edge. Only
+	// phase 1 carves; phases 2/3/5 stay on the phase-0 sealed base.
 	phase3 := topLevel.phases.GetOrCreate(3)
 	phase5 := topLevel.phases.GetOrCreate(5)
 	qt.Assert(t, phase3.Parent(), qt.Equals, sealedBase)

--- a/pkg/environment/sealed_base_frame_test.go
+++ b/pkg/environment/sealed_base_frame_test.go
@@ -166,6 +166,32 @@ func TestSealedExpandBase_SpecialFormExpanderLivesInSealedExpandBase(t *testing.
 	qt.Assert(t, inSealedBase, qt.IsNil)      // NOT on the phase-0 value frame (no runtime-value leak)
 }
 
+// TestSealedExpandBaseConstructionInvariant asserts every namespace-building entry point
+// wires a non-nil sealedExpandBase parented to the sealed base at phase 1. The routing
+// accessors (SealedExpandBaseTarget, AtPhase's phase-1 branch, phaseParent) trust this
+// invariant rather than nil-guarding, so a builder that forgets it must fail HERE — loudly —
+// not silently degrade the expand-phase seal to the mutable frame (the WithStableBasePrimitives
+// profile-child divergence is the cautionary precedent for an unenforced construction step).
+func TestSealedExpandBaseConstructionInvariant(t *testing.T) {
+	root := environment.NewNamespace()
+	builders := []struct {
+		name string
+		ns   *environment.Namespace
+	}{
+		{"NewNamespace", root},
+		{"NewChildNamespace", root.NewChildNamespace()},
+		{"NewSchemeReportNamespace", root.NewSchemeReportNamespace()},
+	}
+	for _, b := range builders {
+		t.Run(b.name, func(t *testing.T) {
+			seb := b.ns.SealedExpandBase()
+			qt.Assert(t, seb, qt.IsNotNil)
+			qt.Assert(t, seb.Parent(), qt.Equals, b.ns.SealedBase())
+			qt.Assert(t, seb.PhaseLevel(), qt.Equals, environment.PhaseExpand)
+		})
+	}
+}
+
 // TestBoundNamesAcrossPhases verifies the all-phases name walk that backs
 // Engine.BoundNames and REPL completion: it must span the sealed base (so
 // primitives like car and bootstrap procedures like caar appear, not just the

--- a/pkg/environment/sealed_base_frame_test.go
+++ b/pkg/environment/sealed_base_frame_test.go
@@ -130,6 +130,42 @@ func TestSealedBase_BootstrapProcedureInSealedBase(t *testing.T) {
 	qt.Assert(t, inSealed, qt.IsNotNil) // owned by the sealed base
 }
 
+// TestSealedExpandBase_BootstrapMacroLivesInSealedExpandBase verifies a Scheme-defined
+// bootstrap macro (cond) lands in the sealed EXPAND base (phase 1), not the mutable expand
+// child — the phase-1 analogue of TestSealedBase_BootstrapProcedureInSealedBase (D1). A
+// later top-level (define-syntax cond …) is thus a shadow in the mutable child, not an
+// in-place overwrite of the pinned bootstrap macro (closes the #1 stability leg).
+func TestSealedExpandBase_BootstrapMacroLivesInSealedExpandBase(t *testing.T) {
+	ns := testhelpers.NewBootstrappedNamespace(t)
+	condSym := values.NewSymbol("cond")
+
+	// Own-frame probe (no parent walk): the mutable expand child vs. the sealed expand base.
+	inMutableExpand := ns.Runtime().Expand().GlobalEnvironment().GetGlobalIndex(condSym)
+	inSealedExpand := ns.SealedExpandBase().GlobalEnvironment().GetGlobalIndex(condSym)
+
+	qt.Assert(t, inMutableExpand, qt.IsNil)   // shadowable (absent from the mutable expand child's own frame)
+	qt.Assert(t, inSealedExpand, qt.IsNotNil) // owned by the sealed expand base
+}
+
+// TestSealedExpandBase_SpecialFormExpanderLivesInSealedExpandBase verifies a special-form
+// primitive expander (let-syntax) lands in the sealed EXPAND base after the D3 retarget, not
+// the mutable expand child. This is what makes a user (define-syntax let-syntax …) a clean
+// shadow instead of an in-place corruption of the installed expander (closes #3), while
+// keeping the expander — a compile-time handler — off the phase-0 value frame (so it cannot
+// leak into runtime value resolution).
+func TestSealedExpandBase_SpecialFormExpanderLivesInSealedExpandBase(t *testing.T) {
+	ns := testhelpers.NewBootstrappedNamespace(t)
+	letSyntaxSym := values.NewSymbol("let-syntax")
+
+	inMutableExpand := ns.Runtime().Expand().GlobalEnvironment().GetGlobalIndex(letSyntaxSym)
+	inSealedExpand := ns.SealedExpandBase().GlobalEnvironment().GetGlobalIndex(letSyntaxSym)
+	inSealedBase := ns.SealedBase().GlobalEnvironment().GetGlobalIndex(letSyntaxSym)
+
+	qt.Assert(t, inMutableExpand, qt.IsNil)   // shadowable (absent from the mutable expand child)
+	qt.Assert(t, inSealedExpand, qt.IsNotNil) // owned by the sealed expand base (phase 1)
+	qt.Assert(t, inSealedBase, qt.IsNil)      // NOT on the phase-0 value frame (no runtime-value leak)
+}
+
 // TestBoundNamesAcrossPhases verifies the all-phases name walk that backs
 // Engine.BoundNames and REPL completion: it must span the sealed base (so
 // primitives like car and bootstrap procedures like caar appear, not just the

--- a/pkg/internal/bootstrap/bootstrap_core.go
+++ b/pkg/internal/bootstrap/bootstrap_core.go
@@ -76,7 +76,14 @@ func LoadBootstrapCore(ctx context.Context, env *environment.EnvironmentFrame, r
 	}
 
 	bootstrapResolver := compilation.NewEmbedFileResolver(core.BootstrapFS)
-	err = loadBootstrapMacros(ctx, env, reg.MacroSources(), bootstrapResolver)
+	// Bootstrap macros load against runtimeTarget (= the sealed base for a namespace-owning
+	// env, the flat frame itself for a library env), symmetric with loadBootstrapProcedures
+	// below. Compiling a define-syntax with env == sealedBase makes its NextPhase() write
+	// land in sealedExpandBase (via the AtPhase receiver branch), so a bootstrap macro is
+	// immutable and a later user (define-syntax foo …) shadows in the mutable expand child
+	// instead of overwriting it in place. For a library env runtimeTarget == env, so this is
+	// unchanged there.
+	err = loadBootstrapMacros(ctx, runtimeTarget, reg.MacroSources(), bootstrapResolver)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "LoadBootstrapCore: load bootstrap macros")
 	}
@@ -86,7 +93,7 @@ func LoadBootstrapCore(ctx context.Context, env *environment.EnvironmentFrame, r
 		return nil, werr.WrapForeignErrorf(err, "LoadBootstrapCore: load bootstrap procedures")
 	}
 
-	err = loadBootstrapMacros(ctx, env, []string{core.LateBootstrapMacroSource}, bootstrapResolver)
+	err = loadBootstrapMacros(ctx, runtimeTarget, []string{core.LateBootstrapMacroSource}, bootstrapResolver)
 	if err != nil {
 		return nil, werr.WrapForeignErrorf(err, "LoadBootstrapCore: load late bootstrap macros")
 	}

--- a/pkg/internal/match/syntax_expand.go
+++ b/pkg/internal/match/syntax_expand.go
@@ -29,6 +29,7 @@ package match
 import (
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/aalpar/wile/pkg/syntax"
 	"github.com/aalpar/wile/pkg/values"
@@ -97,6 +98,18 @@ type ExpandOptions struct {
 // (name, scopes) pair.
 func FreeIdKey(name string, scopes []*syntax.Scope) string {
 	return syntax.ScopeFingerprint(scopes) + "|" + name
+}
+
+// FreeIdName recovers the bare identifier from a FreeIdKey — the inverse of FreeIdKey.
+// The fingerprint contains only [0-9,], so the first '|' unambiguously ends it (a name may
+// itself contain '|'). Callers that indexed a freeIds map get the composite key, not the bare
+// name; use this to compare against a symbol's own name (e.g. a template's self-reference).
+func FreeIdName(key string) string {
+	_, name, found := strings.Cut(key, "|")
+	if !found {
+		return key
+	}
+	return name
 }
 
 // resolveSourceContext returns the source context for a newly-constructed

--- a/pkg/machine/compilation/compile_define_syntax.go
+++ b/pkg/machine/compilation/compile_define_syntax.go
@@ -108,6 +108,13 @@ func (p *CompileTimeContinuation) CompileDefineSyntax(ctctx CompileTimeCallConte
 		return p.wrapCompilationError(werr.WrapForeignErrorf(err, "define-syntax: failed to store transformer for %s", keyword.Key))
 	}
 
+	// The transformer was compiled before the binding above existed, so a template
+	// reference to the macro's OWN name (a recursive macro) was snapshotted with a nil pin.
+	// Now that the binding exists, pin those self-references to it so the recursion resolves
+	// definition-site (R7RS §4.3.2) and a use-site redefinition of a private helper cannot
+	// capture it. See pinTemplateSelfReferences.
+	pinTemplateSelfReferences(closure, keyword.Key, globalIndex)
+
 	// define-syntax is compile-time only, emit no runtime operations
 	return nil
 }

--- a/pkg/machine/compilation/compile_syntax_rules.go
+++ b/pkg/machine/compilation/compile_syntax_rules.go
@@ -294,6 +294,48 @@ func compileClauseWithEllipsisAndLiterals(
 	}, nil
 }
 
+// pinTemplateSelfReferences fills the definition-site pin for a syntax-rules template's free
+// references to the macro BEING DEFINED. collectFreeIdentifiersWithEllipsis runs while compiling
+// the transformer, which is BEFORE CompileDefineSyntax creates the macro's own binding, so a
+// recursive self-reference (guard-aux -> guard-aux, define-record-type-impl -> itself) is
+// snapshotted with a nil Global. R7RS §4.3.2 requires that free self-reference to resolve to the
+// macro's OWN definition-site binding; without the pin it degrades to use-site resolution and a
+// user redefinition of the (private) helper captures the recursion — the reported hijack
+// generalized to any recursion-firing use (a multi-clause guard, a record with fields). Once the
+// binding exists, back-patch every nil-pinned free identifier whose name is the macro's own name
+// to that binding. This preserves the create-after-compile order (a failed transformer compile
+// still leaves no binding). No-op for a non-syntax-rules transformer (ER-macro/lambda carry no
+// ClausesWrapper) and for a nil pin.
+func pinTemplateSelfReferences(closure values.Value, macroName string, gi *environment.GlobalIndex) {
+	if gi == nil {
+		return
+	}
+	cls, ok := closure.(*machine.MachineClosure)
+	if !ok {
+		return
+	}
+	tpl := cls.Template()
+	if tpl == nil {
+		return
+	}
+	for _, lit := range tpl.Literals() {
+		w, ok := lit.(*ClausesWrapper)
+		if !ok {
+			continue
+		}
+		for _, clause := range w.Clauses {
+			for key, res := range clause.FreeIds {
+				if res == nil || res.Global != nil {
+					continue
+				}
+				if match.FreeIdName(key) == macroName {
+					res.Global = gi
+				}
+			}
+		}
+	}
+}
+
 // collectFreeIdentifiersWithEllipsis walks the template and collects all
 // identifiers that are NOT pattern variables, using a custom ellipsis
 // identifier. These "free identifiers" refer to bindings outside the macro and

--- a/pkg/machine/compilation/compile_syntax_rules.go
+++ b/pkg/machine/compilation/compile_syntax_rules.go
@@ -325,7 +325,14 @@ func pinTemplateSelfReferences(closure values.Value, macroName string, gi *envir
 		}
 		for _, clause := range w.Clauses {
 			for key, res := range clause.FreeIds {
-				if res == nil || res.Global != nil {
+				// Back-patch only a GENUINELY-unbound self-reference. Skip an already-resolved
+				// global (Global != nil) and — importantly — a reference that resolved to a
+				// LOCAL binding (HasLocalBinding: an enclosing local variable shadowing the
+				// macro's name; overriding it with the macro's global would break that local
+				// resolution). A nil-Global entry that merely carries a LibScope is a library
+				// macro's own self-reference and IS pinned (it should resolve to the library's
+				// own binding, which is what gi points at).
+				if res == nil || res.Global != nil || res.HasLocalBinding {
 					continue
 				}
 				if match.FreeIdName(key) == macroName {

--- a/pkg/machine/compilation/compile_syntax_rules.go
+++ b/pkg/machine/compilation/compile_syntax_rules.go
@@ -310,37 +310,47 @@ func pinTemplateSelfReferences(closure values.Value, macroName string, gi *envir
 	if gi == nil {
 		return
 	}
-	cls, ok := closure.(*machine.MachineClosure)
-	if !ok {
-		return
-	}
-	tpl := cls.Template()
-	if tpl == nil {
-		return
-	}
-	for _, lit := range tpl.Literals() {
-		w, ok := lit.(*ClausesWrapper)
-		if !ok {
-			continue
-		}
-		for _, clause := range w.Clauses {
-			for key, res := range clause.FreeIds {
-				// Back-patch only a GENUINELY-unbound self-reference. Skip an already-resolved
-				// global (Global != nil) and — importantly — a reference that resolved to a
-				// LOCAL binding (HasLocalBinding: an enclosing local variable shadowing the
-				// macro's name; overriding it with the macro's global would break that local
-				// resolution). A nil-Global entry that merely carries a LibScope is a library
-				// macro's own self-reference and IS pinned (it should resolve to the library's
-				// own binding, which is what gi points at).
-				if res == nil || res.Global != nil || res.HasLocalBinding {
-					continue
-				}
-				if match.FreeIdName(key) == macroName {
-					res.Global = gi
-				}
+	for _, clause := range ClausesFromClosure(closure) {
+		for k, res := range clause.FreeIds {
+			// Back-patch only a GENUINELY-unbound self-reference. Skip an already-resolved
+			// global (Global != nil) and — importantly — a reference that resolved to a
+			// LOCAL binding (HasLocalBinding: an enclosing local variable shadowing the
+			// macro's name; overriding it with the macro's global would break that local
+			// resolution). A nil-Global entry that merely carries a LibScope is a library
+			// macro's own self-reference and IS pinned (it should resolve to the library's
+			// own binding, which is what gi points at).
+			if res == nil || res.Global != nil || res.HasLocalBinding {
+				continue
+			}
+			if match.FreeIdName(k) == macroName {
+				res.Global = gi
 			}
 		}
 	}
+}
+
+// ClausesFromClosure recovers the syntax-rules clause set from a compiled transformer
+// closure — the *ClausesWrapper stored as the closure's template literal by
+// createTransformerClosure. Returns nil for a non-syntax-rules transformer (an ER-macro or
+// lambda body carries no ClausesWrapper). A syntax-rules closure carries exactly one wrapper,
+// so the first match is the whole set. Shared by pinTemplateSelfReferences and the bootstrap
+// nil-pin census, so both read clauses through one extractor rather than parallel copies.
+func ClausesFromClosure(closure values.Value) []*SyntaxRulesClause {
+	cls, ok := closure.(*machine.MachineClosure)
+	if !ok {
+		return nil
+	}
+	tpl := cls.Template()
+	if tpl == nil {
+		return nil
+	}
+	for _, lit := range tpl.Literals() {
+		w, ok := lit.(*ClausesWrapper)
+		if ok {
+			return w.Clauses
+		}
+	}
+	return nil
 }
 
 // collectFreeIdentifiersWithEllipsis walks the template and collects all

--- a/pkg/machine/compilation/expander_time_continuation.go
+++ b/pkg/machine/compilation/expander_time_continuation.go
@@ -320,38 +320,70 @@ func (p *ExpanderTimeContinuation) ExpandPrimitiveForm(primName string, sym *syn
 	return syntax.NewSyntaxCons(sym, expr, sym.SourceContext()), nil
 }
 
-// lookupMacroBinding resolves sym0 to a macro (syntax) binding, or nil.
+// lookupMacroBinding resolves the reference sym to a macro (syntax) binding, or nil.
 //
-// Three places to look, in order: the local env (let-syntax / letrec-syntax), the
-// expand phase one step up from the expanding frame (the symmetric counterpart of
-// define-syntax storage — expanding phase-N code reads macros at phase N+1, so a
-// macro defined inside a transformer body resolves at its climbed phase; at
-// phaseLevel 0, NextPhase() == Expand()), and finally the library env named by any
-// scope the symbol carries, which is how a library macro reaches an UNEXPORTED
-// helper macro of its own library.
+// Four probes, in order: (arm 1) the local env (let-syntax / letrec-syntax), scope-precise;
+// (D2) the definition-site pin sym carries as a free template identifier — consulted between
+// arms 1 and 2 so a co-introduced keyword still shadows it but a use-site define-syntax
+// cannot capture it; (arm 2) the expand phase one step up from the expanding frame (the
+// symmetric counterpart of define-syntax storage — expanding phase-N code reads macros at
+// phase N+1, so a macro defined inside a transformer body resolves at its climbed phase; at
+// phaseLevel 0, NextPhase() == Expand()); and (arm 3) the library env named by any scope the
+// symbol carries, which is how a library macro reaches an UNEXPORTED helper macro of its own
+// library.
 //
-// It exists because ExpandOnce had only the first two. A macro reachable solely
-// through the library-scope arm was therefore reported by (expand-once …) as "not a
-// macro" — a real macro call that the expander itself expands perfectly well. Two
-// copies of a three-step lookup is how one of them ends up two steps long.
-func (p *ExpanderTimeContinuation) lookupMacroBinding(sym0 *values.Symbol, symbolScopes []*syntax.Scope) *environment.Binding {
-	// Resolve under the reference's own scope set, not nil. GetBinding documents
-	// nil as MATCH ANY, which takes the first live slot of the name and so lets a
-	// bare user reference reach a keyword introduced inside a macro expansion.
-	// This is only sound once binders are scope-keyed at creation: a wildcard read
-	// and a wildcard write were cancelling, so fixing either alone relocates the
-	// asymmetry rather than closing it.
+// It takes the full SyntaxSymbol (not the bare *values.Symbol) so it can read the pin; the
+// callers keep their own sym.Unwrap() for the hasLocalVariableBinding / LookupPrimitiveExpander
+// checks. It exists because ExpandOnce once had only arms 1 and 2. A macro reachable solely
+// through the library-scope arm was therefore reported by (expand-once …) as "not a macro" — a
+// real macro call that the expander itself expands perfectly well.
+func (p *ExpanderTimeContinuation) lookupMacroBinding(sym *syntax.SyntaxSymbol, symbolScopes []*syntax.Scope) *environment.Binding {
+	sym0, ok := sym.Unwrap().(*values.Symbol)
+	if !ok {
+		return nil
+	}
+
+	// ARM 1: current-phase local+global, scope-precise. Resolve under the reference's
+	// own scope set, not nil. GetBinding documents nil as MATCH ANY, which takes the
+	// first live slot of the name and so lets a bare user reference reach a keyword
+	// introduced inside a macro expansion. This is only sound once binders are
+	// scope-keyed at creation: a wildcard read and a wildcard write were cancelling, so
+	// fixing either alone relocates the asymmetry rather than closing it. A co-introduced
+	// let-syntax keyword (shares the intro scope) is caught HERE and MUST win over the pin
+	// (the R1 invariant); a use-site let-syntax binder of a different scope is refused here.
 	bnd := p.env.GetBinding(sym0, symbolScopes)
 	if bnd != nil && bnd.BindingType() == environment.BindingTypeSyntax {
 		return bnd
 	}
 
+	// D2: definition-site pin. A free template identifier carrying a GlobalIndex resolves
+	// to its DEFINITION-site macro binding here — AFTER arm 1 (so a co-introduced
+	// let-syntax keyword, which shares the intro scope, still shadows it: the R1 ordering,
+	// mirrored from compile_time_continuation.go's post-GetLocalIndex tryResolvedBinding)
+	// and BEFORE the use-site NextPhase/library arms (so a top-level or use-site
+	// define-syntax cannot capture it). A directly typed reference carries no pin and falls
+	// straight through — the present/absent-pin split IS the def-site/use-site split. The
+	// pin is a specific (frame, slot) via GetOwnGlobalBinding (no parent walk), strictly
+	// more specific than the scope walk, so it cannot reintroduce a wildcard match; and the
+	// BindingTypeSyntax filter excludes compile-time handlers (primitive expanders / syntax
+	// compilers are BindingTypePrimitive), so a pin resolving to one falls through.
+	gi, ok := sym.ResolvedBinding.(*environment.GlobalIndex)
+	if ok && gi != nil {
+		pinned := gi.Env.GetOwnGlobalBinding(gi)
+		if pinned != nil && pinned.BindingType() == environment.BindingTypeSyntax {
+			return pinned
+		}
+	}
+
+	// ARM 2: NextPhase (define-syntax storage). A top-level user (define-syntax …) lands
+	// here; without the pin above, this is where the #1 capture happened.
 	expandEnv := p.env.NextPhase()
 	bnd = expandEnv.GetBinding(sym0, symbolScopes)
 	if bnd != nil && bnd.BindingType() == environment.BindingTypeSyntax {
 		return bnd
 	}
 
+	// ARM 3: library-scope (unexported helper macro of the symbol's own library).
 	if p.env.Namespace() == nil {
 		return nil
 	}
@@ -399,7 +431,7 @@ func (p *ExpanderTimeContinuation) ExpandSyntaxExpression(sym *syntax.SyntaxSymb
 	hasLocalBinding := p.hasLocalVariableBinding(sym0, sym.Scopes())
 
 	if !hasLocalBinding {
-		bnd := p.lookupMacroBinding(sym0, sym.Scopes())
+		bnd := p.lookupMacroBinding(sym, sym.Scopes())
 		if bnd != nil {
 			return p.expandMacroInvocation(sym, expr, bnd)
 		}
@@ -583,7 +615,7 @@ func (p *ExpanderTimeContinuation) ExpandOnce(expr syntax.SyntaxValue) (syntax.S
 	// two-step version, missing the library arm, so (expand-once …) reported a macro
 	// reachable only through a library scope as not-a-macro, even though expansion
 	// itself handled it fine.
-	bnd := p.lookupMacroBinding(sym0, sym.Scopes())
+	bnd := p.lookupMacroBinding(sym, sym.Scopes())
 	if bnd == nil {
 		// Not a macro - no expansion
 		return expr, false, nil

--- a/pkg/machine/compilation/expander_time_continuation.go
+++ b/pkg/machine/compilation/expander_time_continuation.go
@@ -368,7 +368,11 @@ func (p *ExpanderTimeContinuation) lookupMacroBinding(sym *syntax.SyntaxSymbol, 
 	// BindingTypeSyntax filter excludes compile-time handlers (primitive expanders / syntax
 	// compilers are BindingTypePrimitive), so a pin resolving to one falls through.
 	gi, ok := sym.ResolvedBinding.(*environment.GlobalIndex)
-	if ok && gi != nil {
+	if ok && gi != nil && gi.Env != nil {
+		// gi.Env != nil guards the immediate deref below: a *GlobalIndex can be a
+		// DEFERRED index (Env == nil, e.g. NewDeferredGlobalIndex). Every pin attached to
+		// SyntaxSymbol.ResolvedBinding today is resolved (Env set), but that is a non-local
+		// invariant the type does not enforce, so guard the field we dereference.
 		pinned := gi.Env.GetOwnGlobalBinding(gi)
 		if pinned != nil && pinned.BindingType() == environment.BindingTypeSyntax {
 			return pinned

--- a/pkg/machine/compilation/primitive_expanders_registry.go
+++ b/pkg/machine/compilation/primitive_expanders_registry.go
@@ -75,9 +75,10 @@ var primitiveExpanderEntries = []PhaseEntry[PrimitiveExpanderFunc]{
 	{"import", (*ExpanderTimeContinuation).expandImportForm},
 }
 
-// RegisterPrimitiveExpanders binds all primitive expanders in the expand-time
-// environment (env.Expand()). These are looked up by ExpandPrimitiveForm()
-// when the expander encounters a special form.
+// RegisterPrimitiveExpanders binds all primitive expanders in the sealed EXPAND base
+// (env.SealedExpandBaseTarget() — the phase-1 sealed frame; the flat frame's own expand
+// child for a library env). These are looked up by ExpandPrimitiveForm() when the expander
+// encounters a special form.
 //
 // Each primitive has different expansion behavior:
 //   - quote, define-syntax, define-library, quasiquote: return unchanged (no expansion)

--- a/pkg/machine/compilation/primitive_expanders_registry.go
+++ b/pkg/machine/compilation/primitive_expanders_registry.go
@@ -88,7 +88,21 @@ var primitiveExpanderEntries = []PhaseEntry[PrimitiveExpanderFunc]{
 //   - lambda, case-lambda: expand body expressions
 //   - syntax-case, cond-expand: return unchanged (compile-time forms)
 func RegisterPrimitiveExpanders(env *environment.EnvironmentFrame) error {
-	return RegisterPhaseBindings(env, env.Expand, primitiveExpanderEntries,
+	// Install special-form expanders in the phase-1 SEALED EXPAND base (via
+	// SealedExpandBaseTarget), not the mutable expand child. A user (define-syntax let-syntax
+	// …) then creates a distinct binding in the mutable child (a shadow), instead of reusing
+	// and overwriting this slot in place — CreateGlobalBinding dedups by scopeSetsEqual
+	// ignoring BindingType, and SetOwnGlobalValue overwrites the Primitive-typed slot's value,
+	// which every lookup then rejects (let-syntax, having no Tier-1 fallback, dies). Lookup
+	// still finds these via LookupPrimitiveExpander -> env.Expand() walking the parent chain,
+	// which after the phaseParent reparent reaches sealedExpandBase. It must NOT be the phase-0
+	// SealedBaseTarget(): a compile-time handler there is reachable by RUNTIME value resolution
+	// and leaks a dialect-removed form's #<primitive-expander:…> into the value world. For a
+	// flat library frame SealedExpandBaseTarget() falls back to env.Expand(), unchanged.
+	taproot := func() *environment.EnvironmentFrame {
+		return env.SealedExpandBaseTarget()
+	}
+	return RegisterPhaseBindings(env, taproot, primitiveExpanderEntries,
 		func(name string, fn PrimitiveExpanderFunc) values.Value {
 			return NewPrimitiveExpander(name, fn)
 		})

--- a/pkg/registry/core/bootstrap_macros.scm
+++ b/pkg/registry/core/bootstrap_macros.scm
@@ -156,16 +156,12 @@
 ;; template variable. Opaque records are hidden from record? and
 ;; record-type but their type-specific predicates and accessors work
 ;; normally.
-(define-syntax define-record-type
-  (syntax-rules ()
-    ((define-record-type type (constructor constructor-tag ...) predicate field-spec ...)
-     (define-record-type-impl make-record-type type (constructor constructor-tag ...) predicate () () field-spec ...))))
-
-(define-syntax define-opaque-record-type
-  (syntax-rules ()
-    ((define-opaque-record-type type (constructor constructor-tag ...) predicate field-spec ...)
-     (define-record-type-impl make-opaque-record-type type (constructor constructor-tag ...) predicate () () field-spec ...))))
-
+;; define-record-type-impl is defined BEFORE its two delegators (D0, 2026-07-22)
+;; so that their templates, which freely reference define-record-type-impl, pin
+;; that reference to its definition-site binding at macro-definition time — a
+;; use-site (define-syntax define-record-type-impl …) then cannot capture it (D2,
+;; R7RS 4.3.2). It references only define/begin + record primitives (registered
+;; before bootstrap macros), so it compiles standalone here.
 (define-syntax define-record-type-impl
   (syntax-rules ()
     ((define-record-type-impl maker type (constructor constructor-tag ...) predicate (field-name ...) (defn ...))
@@ -184,6 +180,16 @@
        (field-name ... field-tag)
        (defn ... (begin (define accessor (record-accessor type 'field-tag)) (define modifier (record-modifier type 'field-tag))))
        rest ...))))
+
+(define-syntax define-record-type
+  (syntax-rules ()
+    ((define-record-type type (constructor constructor-tag ...) predicate field-spec ...)
+     (define-record-type-impl make-record-type type (constructor constructor-tag ...) predicate () () field-spec ...))))
+
+(define-syntax define-opaque-record-type
+  (syntax-rules ()
+    ((define-opaque-record-type type (constructor constructor-tag ...) predicate field-spec ...)
+     (define-record-type-impl make-opaque-record-type type (constructor constructor-tag ...) predicate () () field-spec ...))))
 
 ;; Multiple values binding forms
 ;;

--- a/pkg/registry/core/bootstrap_macros_late.scm
+++ b/pkg/registry/core/bootstrap_macros_late.scm
@@ -12,6 +12,29 @@
 
 ;; Exception handling (R7RS §4.2.7 guard macro)
 ;;
+;; guard-aux is defined BEFORE guard (D0, 2026-07-22) so that guard's template,
+;; which freely references guard-aux, pins that reference to guard-aux's
+;; definition-site binding at macro-definition time (SyntaxSymbol.ResolvedBinding
+;; non-nil). With the pin populated and consulted on the macro path (D2), a
+;; use-site (define-syntax guard-aux …) can no longer capture guard's private
+;; helper (R7RS 4.3.2). guard-aux references only itself + begin/let/if, so it
+;; compiles standalone here.
+(define-syntax guard-aux
+  (syntax-rules (else =>)
+    ((guard-aux re-raise var (else result ...))
+     (begin result ...))
+    ((guard-aux re-raise var (test => proc) clause ...)
+     (let ((t test))
+       (if t
+           (proc t)
+           (guard-aux re-raise var clause ...))))
+    ((guard-aux re-raise var (test result ...) clause ...)
+     (if test
+         (begin result ...)
+         (guard-aux re-raise var clause ...)))
+    ((guard-aux re-raise var)
+     (re-raise))))
+
 ;; Uses the double call/cc pattern from R7RS §7.3 so that when no clause
 ;; matches, the exception is re-raised in the dynamic extent of the
 ;; original raise (where the previous exception handler is current).
@@ -47,19 +70,3 @@
            (lambda ()
              (let ((results (call-with-values (lambda () e1 e2 ...) list)))
                (lambda () (apply values results)))))))))))
-
-(define-syntax guard-aux
-  (syntax-rules (else =>)
-    ((guard-aux re-raise var (else result ...))
-     (begin result ...))
-    ((guard-aux re-raise var (test => proc) clause ...)
-     (let ((t test))
-       (if t
-           (proc t)
-           (guard-aux re-raise var clause ...))))
-    ((guard-aux re-raise var (test result ...) clause ...)
-     (if test
-         (begin result ...)
-         (guard-aux re-raise var clause ...)))
-    ((guard-aux re-raise var)
-     (re-raise))))

--- a/pkg/registry/search.go
+++ b/pkg/registry/search.go
@@ -268,6 +268,10 @@ func searchEnvironmentBindings(env *environment.EnvironmentFrame, lowerPattern s
 	// phase walk above never reaches it. Collect it so ,apropos still surfaces
 	// binding-level docs on sealed entries, mirroring Namespace.BoundSymbolNames.
 	collect(ns.SealedBase())
+	// Likewise the sealed EXPAND base (phase 1): bootstrap macros and special-form
+	// expanders live here post-carve, also off the phase walk (reached only via the
+	// parent chain), so collect it or their names/docs vanish from ,apropos.
+	collect(ns.SealedExpandBase())
 
 	return q
 }

--- a/pkg/wile/bootstrap_nilpin_test.go
+++ b/pkg/wile/bootstrap_nilpin_test.go
@@ -40,45 +40,40 @@ type nilPin struct {
 	compileBound bool
 }
 
-// TestBootstrapMacrosPinLateBoundReferents is a ratchet against review finding C6.
+// TestBootstrapMacrosPinLateBoundReferents is a load-order ratchet for bootstrap macro
+// free-identifier references, across BOTH the runtime and expand phases.
 //
 // `unless`'s template referenced `not`, a bootstrap PROCEDURE that loaded after the
 // macros. At macro-definition time the referent was unbound, so the free-id snapshot
-// took a nil pin, resolution degraded to use-site, and a user (define not ...)
-// captured the macro's own identifier (R7RS 4.3.2). Nothing else enforces "which
-// bootstrap file does this macro belong in", and the failure is silent, so this test
-// enumerates every syntax-rules macro in the expand frame, walks each clause's
-// FreeIds, and fails on any Global == nil && !HasLocalBinding whose name is
-// nevertheless bound in the runtime phase after bootstrap.
+// took a nil pin (SyntaxRulesClause.FreeIds[name].Global == nil), resolution degraded to
+// use-site, and a user (define not ...) captured the macro's own identifier (R7RS 4.3.2).
+// The analogous expand-phase case was `guard` -> `guard-aux`: a top-level
+// (define-syntax guard-aux …) captured guard's private helper.
 //
-// The expand/compile phases do NOT fail the test, but NOT because they are safe.
-// The original rationale here claimed a sibling-macro reference (and -> and,
-// guard -> guard-aux) "resolves in operator position during expansion, where a
-// runtime define cannot reach it". That is FALSE, and measurably so:
+// Both are now closed, so this test can certify both phases (updated 2026-07-22, the
+// free-template-id-hygiene arc — plans/2026-07-22-free-template-id-hygiene-impl.local.md):
 //
-//	(guard (e (else 'caught)) (raise 'x))                          => caught
-//	(define-syntax guard-aux (syntax-rules () ((_ r ...) 'PWNED)))
-//	(guard (e (else 'caught)) (raise 'x))                          => PWNED
+//   - D1 carved a sealed EXPAND base (Namespace.SealedExpandBase, phase 1): bootstrap
+//     macros/expanders live there, immutable, so a top-level define-syntax shadows in the
+//     mutable expand child instead of overwriting the pinned binding in place.
+//   - D2 taught macro dispatch (lookupMacroBinding) to consult the pin, after the local
+//     let-syntax arm and before the NextPhase/library arms.
+//   - D0 reordered the sibling helpers (guard-aux, define-record-type-impl) above their
+//     referencers so their pins are non-nil at macro-definition time.
 //
-// A top-level define-syntax reaches the expand frame and overwrites the binding
-// IN PLACE (same *Binding, new value), so `guard`'s reference to its private helper
-// is captured by ordinary user code. No library or import is required.
+// So a pin into a bootstrap macro/expander IS now load-bearing. The census walks every
+// syntax-rules macro in the SEALED EXPAND base, walks each clause's FreeIds, and FAILS on
+// any Global == nil && !HasLocalBinding whose name is bound in the runtime phase (a late
+// bootstrap procedure) OR in the expand phase (an unpinned sibling macro/expander — a real
+// capture exposure). A neither-bound nil-pin is genuinely inert (a special form the
+// expander handles, a template-introduced binder, or a syntax-rules literal like else/=>).
 //
-// Pinning does not prevent this. A pin is a *Binding pointer, so an in-place value
-// overwrite defeats it; verified by reordering guard-aux above guard, which does
-// pin the reference (census drops to 46) and changes nothing about the capture.
-// Runtime-phase referents like `not` survive only because they live in the SEALED
-// BASE while a top-level define writes to the mutable runtime child, a different
-// frame. There is no sealed base for the expand phase, so bootstrap macro bindings
-// are mutable in place and pins into them are not load-bearing.
+// Fixing a flagged entry: reorder the referent's definition above the referencing macro
+// (sibling macro/expander) or into an earlier bootstrap file (runtime procedure). A
+// precisely-justified exclusion (e.g. an auxiliary-syntax literal, or a referent bound only
+// under a fuller profile) must be narrow and commented, not a broad skip.
 //
-// The census therefore certifies bootstrap LOAD ORDER for runtime-phase referents
-// and nothing more. It is not evidence that expand-phase referents are safe; the
-// known-capturable name today is guard-aux. Do not widen this test to assert
-// expand-phase safety without first carving an immutable base for the expand phase
-// (or renaming the helper beyond user reach).
-//
-// Run with -v to see the full census, including the unbound entries.
+// Run with -v to see the full census, including the inert entries.
 func TestBootstrapMacrosPinLateBoundReferents(t *testing.T) {
 	ctx := context.Background()
 	eng, err := wile.NewEngine(ctx, wile.WithProfile(wile.KitchenSink))
@@ -112,27 +107,28 @@ func TestBootstrapMacrosPinLateBoundReferents(t *testing.T) {
 	defects := make([]nilPin, 0, len(pins))
 	unchecked := make([]nilPin, 0, len(pins))
 	for _, p := range pins {
-		if p.runtimeBound {
+		if p.runtimeBound || p.expandBound {
 			defects = append(defects, p)
 			continue
 		}
 		unchecked = append(unchecked, p)
 	}
 
-	t.Logf("nil-pin census: %d total, %d runtime-bound (DEFECT), %d not runtime-bound (UNCHECKED, not proven safe)",
+	t.Logf("nil-pin census: %d total, %d runtime/expand-bound (DEFECT), %d neither (inert: special form / binder / literal)",
 		len(pins), len(defects), len(unchecked))
 
 	for _, p := range defects {
-		t.Errorf("macro %q pins free identifier %q as unbound, but %q IS bound in the runtime "+
-			"phase after bootstrap (expand=%v compile=%v). The macro is defined before its "+
-			"referent loads, so the reference degrades to use-site resolution and a user "+
-			"(define %s ...) captures it. Move the macro after the definition (see "+
-			"bootstrap_macros_late.scm) or move the definition earlier.",
-			p.macro, p.freeID, p.freeID, p.expandBound, p.compileBound, p.freeID)
+		t.Errorf("macro %q pins free identifier %q as unbound, but %q IS bound after bootstrap "+
+			"(runtime=%v expand=%v compile=%v). The macro is defined before its referent loads, "+
+			"so the reference degrades to use-site resolution and a user (define %s ...) or "+
+			"(define-syntax %s ...) captures it. Move the referent's definition earlier (for a "+
+			"runtime procedure see bootstrap_macros_late.scm; for a sibling macro/expander "+
+			"reorder it above this macro, as guard-aux was above guard).",
+			p.macro, p.freeID, p.freeID, p.runtimeBound, p.expandBound, p.compileBound, p.freeID, p.freeID)
 	}
 
-	t.Logf("--- not runtime-bound: inert (special form / binder / literal) OR an expand-phase " +
-		"sibling reference this test does not check (e.g. guard-aux, which IS capturable) ---")
+	t.Logf("--- neither runtime- nor expand-bound: genuinely inert (special form handled by the " +
+		"expander, template-introduced binder, or syntax-rules literal like else/=>) ---")
 	byName := map[string][]string{}
 	for _, p := range unchecked {
 		byName[p.freeID] = append(byName[p.freeID], p.macro)

--- a/pkg/wile/bootstrap_nilpin_test.go
+++ b/pkg/wile/bootstrap_nilpin_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/aalpar/wile/pkg/environment"
 	"github.com/aalpar/wile/pkg/internal/match"
-	"github.com/aalpar/wile/pkg/machine"
 	"github.com/aalpar/wile/pkg/machine/compilation"
 	"github.com/aalpar/wile/pkg/values"
 	"github.com/aalpar/wile/pkg/wile"
@@ -173,7 +172,7 @@ func collectNilPins(t *testing.T, env, expandEnv *environment.EnvironmentFrame) 
 		if bnd == nil || bnd.BindingType() != environment.BindingTypeSyntax {
 			continue
 		}
-		clauses := clausesOf(bnd.Value())
+		clauses := compilation.ClausesFromClosure(bnd.Value())
 		if clauses == nil {
 			continue
 		}
@@ -206,25 +205,4 @@ func collectNilPins(t *testing.T, env, expandEnv *environment.EnvironmentFrame) 
 		t.Fatalf("no syntax-rules macros found — the walk is broken, not the bootstrap")
 	}
 	return q
-}
-
-// clausesOf digs the *compilation.ClausesWrapper out of a transformer closure's literal
-// pool. Returns nil for a syntax binding that is not a syntax-rules macro (a primitive
-// expander or a syntax-case transformer), which the caller skips.
-func clausesOf(v values.Value) []*compilation.SyntaxRulesClause {
-	cl, ok := v.(*machine.MachineClosure)
-	if !ok {
-		return nil
-	}
-	tpl := cl.Template()
-	if tpl == nil {
-		return nil
-	}
-	for _, lit := range tpl.Literals() {
-		w, ok := lit.(*compilation.ClausesWrapper)
-		if ok {
-			return w.Clauses
-		}
-	}
-	return nil
 }

--- a/pkg/wile/bootstrap_nilpin_test.go
+++ b/pkg/wile/bootstrap_nilpin_test.go
@@ -90,7 +90,10 @@ func TestBootstrapMacrosPinLateBoundReferents(t *testing.T) {
 	}()
 
 	env := eng.Environment()
-	expandEnv := env.Expand()
+	// D1 (2026-07-22): bootstrap macros now live in the sealed EXPAND base (phase 1),
+	// not the mutable expand child (env.Expand()), which holds only user define-syntax.
+	// Walk the sealed expand base so the census still sees the bootstrap macros.
+	expandEnv := env.Namespace().SealedExpandBase()
 
 	pins := collectNilPins(t, env, expandEnv)
 

--- a/pkg/wile/bootstrap_nilpin_test.go
+++ b/pkg/wile/bootstrap_nilpin_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aalpar/wile/pkg/environment"
+	"github.com/aalpar/wile/pkg/internal/match"
 	"github.com/aalpar/wile/pkg/machine"
 	"github.com/aalpar/wile/pkg/machine/compilation"
 	"github.com/aalpar/wile/pkg/values"
@@ -59,14 +60,20 @@ type nilPin struct {
 //   - D2 taught macro dispatch (lookupMacroBinding) to consult the pin, after the local
 //     let-syntax arm and before the NextPhase/library arms.
 //   - D0 reordered the sibling helpers (guard-aux, define-record-type-impl) above their
-//     referencers so their pins are non-nil at macro-definition time.
+//     referencers so a DIRECT reference's pin is non-nil at macro-definition time.
+//   - pinTemplateSelfReferences back-patches a template's reference to the macro's OWN name
+//     (a recursive macro's self-reference — guard-aux -> guard-aux, and -> and) to the
+//     just-created binding, which reorder alone cannot pin (a macro precedes itself nowhere).
 //
 // So a pin into a bootstrap macro/expander IS now load-bearing. The census walks every
-// syntax-rules macro in the SEALED EXPAND base, walks each clause's FreeIds, and FAILS on
-// any Global == nil && !HasLocalBinding whose name is bound in the runtime phase (a late
-// bootstrap procedure) OR in the expand phase (an unpinned sibling macro/expander — a real
-// capture exposure). A neither-bound nil-pin is genuinely inert (a special form the
-// expander handles, a template-introduced binder, or a syntax-rules literal like else/=>).
+// syntax-rules macro in the SEALED EXPAND base, walks each clause's FreeIds (keyed by
+// FreeIdKey = scope-fingerprint|name — recover the bare name with match.FreeIdName before the
+// discriminator lookups, or every lookup misses and the partition is vacuous), and FAILS on
+// any Global == nil && !HasLocalBinding whose bare name is bound in the runtime phase (a late
+// bootstrap procedure) OR in the expand phase (an unpinned sibling macro/expander or recursive
+// self-reference — a real capture exposure). A neither-bound nil-pin is genuinely inert (a
+// special form the expander handles, a template-introduced binder, or a syntax-rules literal
+// like else/=>).
 //
 // Fixing a flagged entry: reorder the referent's definition above the referencing macro
 // (sibling macro/expander) or into an earlier bootstrap file (runtime procedure). A
@@ -172,13 +179,17 @@ func collectNilPins(t *testing.T, env, expandEnv *environment.EnvironmentFrame) 
 		}
 		macroCount++
 		for _, cl := range clauses {
-			for name, res := range cl.FreeIds {
+			for fkey, res := range cl.FreeIds {
 				if res == nil {
 					continue
 				}
 				if res.Global != nil || res.HasLocalBinding {
 					continue
 				}
+				// FreeIds is keyed by FreeIdKey (scope-fingerprint|name); the discriminator
+				// lookups take a bare symbol, so recover the bare name — otherwise every
+				// GetGlobalIndex(NewSymbol("|name")) misses and the partition is vacuous.
+				name := match.FreeIdName(fkey)
 				q = append(q, nilPin{
 					macro:        key.Key,
 					freeID:       name,


### PR DESCRIPTION
## Summary

Makes a free identifier in a macro's `syntax-rules` template resolve to the binding in effect at the macro's **definition** site on the **macro** resolution path — R7RS §4.3.2 referential transparency — matching the pinning the **value** path already did. Closes the two live exposures from `TODO.md` "No sealed base above phase 0":

- **#1** — a top-level `(define-syntax guard-aux …)` hijacked `guard`'s private helper (`(guard (e (else 'x)) (raise 'y))` → `PWNED`).
- **#3** — redefining a special form (`(define-syntax let-syntax …)`) overwrote the installed primitive-expander slot in place and permanently bricked it.

Exposure **#2** (local `let-syntax`) already resolved correctly by scope-keying; it's a standing green guard.

## Approach — four legs

- **D1** — carve a per-namespace immutable **`sealedExpandBase`** (phase 1), the macro-phase analogue of the phase-0 sealed base. Bootstrap macros + special-form expanders live there; a use-site `define-syntax` shadows in the mutable expand child instead of overwriting the pinned binding in place. Phase-1-only carve; flat library frames stay flat islands.
- **D3** — route the special-form expanders into `sealedExpandBase` (**not** the phase-0 `sealedBase`, which is reachable by runtime value resolution — see decision 1 below).
- **D0** — reorder the sibling helpers so a direct reference's pin is non-nil at macro-definition time (census 47→44).
- **D2** — `lookupMacroBinding` consults the definition-site pin, **after** the local `let-syntax` arm (so a co-introduced keyword still shadows — the R1 invariant) and **before** the use-site NextPhase/library arms.

## Two decisions made mid-execution

1. **D3 targets `sealedExpandBase`, not the phase-0 `sealedBase`.** The naive D3 (route through `sealedBase`) regressed the general `Dialect.Forms().Remove()` contract: a compile-time handler on the phase-0 value frame is reachable by runtime value resolution, so a dialect-removed form leaked `#<primitive-expander:set!>` into the value world (3 dialect tests). This resolved the design's open §9 gate #4 (the phase-0 value frame is not collision-free for compile-time handlers). The phase-1 frame is invisible to phase-0 value resolution.

2. **Recursive self-references are pinned via a back-patch.** A recursive helper that references **itself** (`guard-aux`→`guard-aux`, `define-record-type-impl`→itself, and every recursive macro) had that self-reference collected before its own binding existed → nil pin → still capturable on any recursion-firing use (a multi-clause `guard`, a record with fields). D0's reorder cannot pin a self-reference. `pinTemplateSelfReferences` back-patches it after the binding is created (preserving create-after-compile, so a failed compile leaves no binding). Fixes the class uniformly; the correct R7RS behavior for recursive macros.

## Review

5-lens `/crosscheck` (opus) verified the topology + D2 mechanism **sound, no correctness bug**. The test + code lenses caught two gaps the single-clause #1 repro masked: the nil-pin census was **vacuous** (it keyed discriminator lookups on the composite `FreeIdKey`, so no defect could ever fire), and recursive self-references were still capturable (decision 2). Both fixed. The census is now **mutation-verified load-bearing**: without the back-patch it flags 21 recursive self-refs; with it, 0. Convergent hardening also applied (dropped silent-degrade nil-guards + a construction-invariant test, `gi.Env` deref guard, `phaseParent`→method, doc drift).

## Test plan

- [x] `TestFreeTemplateIdHygiene` — #1 (`x`, not `PWNED`), #2 guard (`c`), #3 (`shadowed`)
- [x] `TestFreeTemplateIdHygiene_CoIntroducedLetSyntaxBeatsGlobalPin` — R1-analog: pin does not jump ahead of arm 1
- [x] `TestFreeTemplateIdHygiene_Section6Cases` — generated-macro nil-pin fallthrough, use-site local no-capture, pinned-vs-bare
- [x] `TestFreeTemplateIdHygiene_RecursiveHelperSelfReference` — multi-clause guard (`second`), record-with-fields (`3`)
- [x] `TestFreeTemplateIdHygiene_Adversarial` — nested `let-syntax`/`letrec-syntax`/macro-generating no-capture
- [x] `TestSealedExpandBase_*` + `TestSealedExpandBaseConstructionInvariant` — frame topology, immutability, per-builder wiring
- [x] `TestBootstrapMacrosPinLateBoundReferents` — repaired + mutation-verified load-bearing (0 defects, 23 inert)
- [x] `march-hare`/`jabberwocky` (§6 case 1) nil-pin fallthrough intact; dialect removed-form contract green
- [x] `make ci` (lint + build-all + covercheck + docs/examples) + `go test -race ./...` (45 pkgs, 0 races) green

## Docs
`docs/reference/r7rs-differences.md` (macro-path def-site pinning + recursion), `docs/environment/system.md` (sealed-base/sealed-expand-base topology invariant), `CHANGELOG.md`, `TODO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
