### PR TITLE
chore(ci): move the three node20 actions onto node24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: github.event_name == 'push'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/coverage.out
@@ -54,7 +54,7 @@ jobs:
       # the step is skipped entirely on PR runs (where no CSVs exist).
       - name: Upload benchmark results
         if: always() && github.event_name == 'push'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results-${{ github.sha }}
           path: examples/benchmarks/canonical-results-*.csv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: CD
         run: make cd
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
GitHub is past Node 20's EOL and force-substitutes node24 for any action declaring `runs.using: node20`. Three were flagged on the v1.19.0 run. The substitution is temporary — when withdrawn, `using: node20` is a hard error at step start, before any Go runs.

| Action | Bump | Why this version |
|---|---|---|
| `actions/upload-artifact` | v5 → **v6** | v6 is the node24 release, no input changes. v7 exists but rewrites to ESM and adds an `archive` input this repo does not use. |
| `goreleaser/goreleaser-action` | v6 → **v7** | Only node24 major. `version` / `args` unchanged; `~> v2` is still the input default, so the call site is identical. |
| `actions/github-script` | — | Not referenced in this repo. Pinned inside `codecov/codecov-action@v5`'s composite (`action.yml:233`) at v7.0.1 = node20. Cleared by **codecov/codecov-action v5 → v6**, which pins github-script v8.0.0 = node24. |

`actions/checkout@v5`, `actions/setup-go@v6` and `golangci/golangci-lint-action@v9` already declare node24 and are untouched.

## Validation caveat

This PR's CI run proves the YAML parses and nothing else. Both changed `ci.yml` steps are gated on `if: github.event_name == 'push'`, so they are **skipped on PR runs**; `release.yml` runs only on a tag push. The bumps are actually exercised by:

- the next push to `master` (Codecov upload + benchmark artifact upload)
- the next release cut (goreleaser)

`upload-artifact@v6` requires Actions Runner ≥ 2.327.1 — fine on GitHub-hosted runners, would matter for self-hosted.